### PR TITLE
Remove cancelled flag from NetworkResponse

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/http/NetworkResponse.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/NetworkResponse.h
@@ -39,13 +39,6 @@ class CORE_API NetworkResponse final {
   bool IsCancelled() const;
 
   /**
-   * @brief Set cancelled field.
-   * @param[in] cancelled True if associated request was cancelled.
-   * @return reference to *this.
-   */
-  NetworkResponse& WithCancelled(bool cancelled);
-
-  /**
    * @brief Get HTTP response code.
    * @return HTTP response code.
    */
@@ -94,8 +87,6 @@ class CORE_API NetworkResponse final {
   int status_{0};
   /// Human-readable error message in case of failed associated request.
   std::string error_;
-  /// True if associated request was cancelled.
-  bool cancelled_{false};
 };
 
 }  // namespace http

--- a/olp-cpp-sdk-core/src/http/NetworkResponse.cpp
+++ b/olp-cpp-sdk-core/src/http/NetworkResponse.cpp
@@ -18,20 +18,18 @@
  */
 
 #include "olp/core/http/NetworkResponse.h"
+#include "olp/core/http/NetworkTypes.h"
 
 namespace olp {
 namespace http {
 
-bool NetworkResponse::IsCancelled() const { return cancelled_; }
+bool NetworkResponse::IsCancelled() const {
+  return status_ == static_cast<int>(ErrorCode::CANCELLED_ERROR);
+}
 
 int NetworkResponse::GetStatus() const { return status_; }
 
 const std::string& NetworkResponse::GetError() const { return error_; }
-
-NetworkResponse& NetworkResponse::WithCancelled(bool cancelled) {
-  cancelled_ = cancelled;
-  return *this;
-}
 
 NetworkResponse& NetworkResponse::WithStatus(int status) {
   status_ = status;

--- a/olp-cpp-sdk-core/src/http/android/NetworkAndroid.cpp
+++ b/olp-cpp-sdk-core/src/http/android/NetworkAndroid.cpp
@@ -738,8 +738,7 @@ void NetworkAndroid::SelfRun() {
         callback(NetworkResponse()
                      .WithRequestId(response_data.id)
                      .WithStatus(response_data.status)
-                     .WithError(response_data.error)
-                     .WithCancelled(cancelled));
+                     .WithError(response_data.error));
       }
     }
   }

--- a/olp-cpp-sdk-core/src/http/ios/OLPNetworkIOS.mm
+++ b/olp-cpp-sdk-core/src/http/ios/OLPNetworkIOS.mm
@@ -292,8 +292,7 @@ olp::http::SendOutcome OLPNetworkIOS::Send(
         callback(olp::http::NetworkResponse()
                      .WithRequestId(strong_task.requestId)
                      .WithStatus(status)
-                     .WithError(error_str)
-                     .WithCancelled(cancelled));
+                     .WithError(error_str));
       }
 
     };

--- a/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.cpp
+++ b/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.cpp
@@ -905,7 +905,6 @@ void NetworkWinHttp::CompletionThread() {
         }
         // must call outside lock to prevent deadlock
         callback(NetworkResponse()
-                     .WithCancelled(result->cancelled)
                      .WithError(str)
                      .WithRequestId(result->request_id)
                      .WithStatus(status));

--- a/olp-cpp-sdk-dataservice-read/tests/CatalogClientTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/CatalogClientTest.cpp
@@ -704,7 +704,6 @@ generateNetworkMocks(std::shared_ptr<std::promise<void>> pre_signal,
       auto cancel_code = static_cast<int>(ErrorCode::CANCELLED_ERROR);
       (*callback_placeholder)(NetworkResponse()
                                   .WithError("Cancelled")
-                                  .WithCancelled(true)
                                   .WithStatus(cancel_code));
     }
   };

--- a/olp-cpp-sdk-dataservice-write/tests/TestCommons.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/TestCommons.cpp
@@ -87,7 +87,6 @@ generateNetworkMocks(std::shared_ptr<std::promise<void>> pre_signal,
       auto cancel_code = static_cast<int>(ErrorCode::CANCELLED_ERROR);
       (*callback_placeholder)(NetworkResponse()
                                   .WithError("Cancelled")
-                                  .WithCancelled(true)
                                   .WithStatus(cancel_code));
     }
   };


### PR DESCRIPTION
Cancellation flag is duplicated by status code.
Method is not used by SDK.

Resolves: OLPEDGE-780

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>