### PR TITLE
Fixed CMake and build errors when configuring tests for iOS / Android

### DIFF
--- a/cmake/android/tester/app/jni/com_here_android_olp_TesterActivity.cpp
+++ b/cmake/android/tester/app/jni/com_here_android_olp_TesterActivity.cpp
@@ -34,7 +34,6 @@
 #include <string>
 #include <olp/core/context/Context.h>
 #include <olp/core/porting/make_unique.h>
-#include <testutils/CustomParameters.hpp>
 
 #define LOGE(...) ((void)__android_log_print(ANDROID_LOG_ERROR, "native-activity", __VA_ARGS__))
 #define LOGI(...) ((void)__android_log_print(ANDROID_LOG_INFO, "native-activity", __VA_ARGS__))
@@ -150,8 +149,6 @@ Java_com_here_android_olp_TesterActivity_runTests(JNIEnv* env, jobject obj, jstr
     int argc = args.size() - 1;
 
     testing::InitGoogleTest(&argc, argv);
-
-    CustomParameters::getInstance( ).init( argc, argv );
 
     logcatSetup();
     int result = RUN_ALL_TESTS();

--- a/cmake/ios/tester/CMakeLists.txt.in
+++ b/cmake/ios/tester/CMakeLists.txt.in
@@ -52,6 +52,7 @@ target_link_libraries(${PROJECT_NAME}
     "-Wl,-force_load"
     ${SVC_TEST_LIB}
     "-Wl,-noall_load"
+    gtest
 )
 
 target_include_directories(${PROJECT_NAME}

--- a/cmake/ios/tester/MyViewController.mm
+++ b/cmake/ios/tester/MyViewController.mm
@@ -19,7 +19,6 @@
 
 #import "MyViewController.h"
 #include "gtest/gtest.h"
-#include "testutils/CustomParameters.hpp"
 #import <vector>
 #import <mach/mach.h>
 
@@ -168,7 +167,6 @@
 
 
         testing::InitGoogleTest(&new_argc, new_argv.data());
-        CustomParameters::getInstance( ).init(new_argc, new_argv.data());
 
         int result = RUN_ALL_TESTS();
         if (!_run_with_global_queue)

--- a/olp-cpp-sdk-authentication/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-authentication/tests/CMakeLists.txt
@@ -49,7 +49,7 @@ if (ANDROID OR IOS)
         ${OLP_AUTHENTICATION_TEST_SOURCES}
     )
 
-    target_link_libraries(olp-cpp-sdk-authentication-tests
+    target_link_libraries(olp-cpp-sdk-authentication-tests-lib
     PRIVATE
         custom-params
         gmock

--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -54,7 +54,7 @@ if (ANDROID OR IOS)
 
     # Some tests include private headers of core. This should be fixed in tests,
     # only then here.
-    target_include_directories(olp-cpp-sdk-core-tests
+    target_include_directories(olp-cpp-sdk-core-tests-lib
         PRIVATE
             ../src/cache
     )

--- a/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
@@ -34,7 +34,7 @@ if (ANDROID OR IOS)
         ${OLP_SDK_DATASERVICE_READ_TEST_SOURCES}
     )
 
-    target_link_libraries(olp-cpp-sdk-dataservice-read-tests
+    target_link_libraries(olp-cpp-sdk-dataservice-read-tests-lib
     PRIVATE
         custom-params
         gmock

--- a/olp-cpp-sdk-dataservice-write/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-write/tests/CMakeLists.txt
@@ -41,7 +41,7 @@ if (ANDROID OR IOS)
         ${OLP_SDK_DATASERVICE_WRITE_TEST_SOURCES}
     )
 
-    target_link_libraries(olp-cpp-sdk-dataservice-write-tests
+    target_link_libraries(olp-cpp-sdk-dataservice-write-tests-lib
     PRIVATE
         custom-params
         gmock


### PR DESCRIPTION
- Fixed CMake and build errors, which were caused by refactoring of unit tests folder structure;
- Removed dependency on CustomParameters in iOS / Android tester applications;

Relates to: OLPEDGE-788, OLPEDGE-422, OLPEDGE-421

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>