### PR TITLE
Updated .gitlab-ci.yml with nv job. No script execution yet, only echo.[skip travis]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,12 @@ build_fv:
   script:
   - $CI_PROJECT_DIR/scripts/linux/fv/gitlab_build_fv.sh
   - $CI_PROJECT_DIR/scripts/linux/fv/gitlab_test_fv.sh
+  only:
+    refs:
+      - master
+      - schedules
+    variables:
+      - $FULLY
   artifacts:
     when: always
     paths:
@@ -24,12 +30,33 @@ build_fv:
     # https://gitlab.com/gitlab-org/gitlab-ce/issues/17081
     # Check this issue status in Gitlab 12.4 (Oct 2019)
     #   junit: "reports/*.xml"
+
+build_nv:
+  stage: build
+  tags:
+  - docker-prod
+  script:
+  - echo "NIGHTLY BUILD OK !"
   only:
-    - master
+    refs:
+      - master
+      - schedules
+    variables:
+      - $NIGHTLY
+  artifacts:
+    when: always
+    paths:
+      - reports
+    expire_in: 1 year
+    # reports:
+    # https://gitlab.com/gitlab-org/gitlab-ce/issues/17081
+    # Check this issue status in Gitlab 12.4 (Oct 2019)
+    #   junit: "reports/*.xml"
+
 
 translate_report:
   stage: translate_report
-  tags: 
+  tags:
   - docker-prod
   image: python:3.6
   when: always


### PR DESCRIPTION
Updated .gitlab-ci.yml with nv job. No script execution yet, only echo.
Gitlab CI will have now two "Schedules":
- nightly (once at midnight). Env. variable to be defined in schedule: $NIGHTLY ;
- full (every hour). Env. variable to be defined in schedule: $FULLY;
skip travis

Resolves: OLPEDGE-485

Signed-off-by: Yaroslav Stefinko <ystefinko@intellias.com>