### PR TITLE
Adds the KeyValueCache as shared to the OlpClientSettings.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
@@ -28,14 +28,12 @@
 #include "olp/core/client/CancellationToken.h"
 #include "olp/core/client/HttpResponse.h"
 #include "olp/core/http/Network.h"
-#include "olp/core/client/HttpResponse.h"
 
 namespace olp {
 
-namespace network {
-class NetworkRequest;
-class NetworkConfig;
-}  // namespace network
+namespace cache {
+class KeyValueCache;
+}  // namespace cache
 
 namespace thread {
 class TaskScheduler;
@@ -176,6 +174,13 @@ struct OlpClientSettings {
    * services.
    */
   std::shared_ptr<http::Network> network_request_handler = nullptr;
+
+  /**
+   * @brief The key/value cache will be used for storing different request
+   * results, like metadata, partition data, URLs from Look-up API and others.
+   * Set to nullptr to only use in-memory LRU cache with limited size.
+   */
+  std::shared_ptr<cache::KeyValueCache> cache = nullptr;
 };
 
 }  // namespace client

--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettingsFactory.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettingsFactory.h
@@ -25,6 +25,11 @@
 #include <memory>
 
 namespace olp {
+namespace cache {
+class KeyValueCache;
+struct CacheSettings;
+}  // namespace cache
+
 namespace http {
 class Network;
 }  // namespace http
@@ -52,6 +57,18 @@ class CORE_API OlpClientSettingsFactory final {
    */
   static std::shared_ptr<http::Network> CreateDefaultNetworkRequestHandler(
       size_t max_requests_count = 30u);
+
+  /**
+   * @brief Creates a KeyValueCache instance that includes both a small
+   * in-memory LRU cache and a larger persistent database cache.
+   * The returned cache instance is initialized, opened and ready to be used.
+   * @note The database cache is only created if the provided CacheSettings
+   * include a valid disk path with according write permissions set.
+   * @param[in] settings The cache settings.
+   * @return An instance of KeyValueCache.
+   */
+  static std::unique_ptr<cache::KeyValueCache> CreateDefaultCache(
+      const cache::CacheSettings& settings);
 };
 
 }  // namespace client

--- a/olp-cpp-sdk-core/src/client/OlpClientSettingsFactory.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClientSettingsFactory.cpp
@@ -19,10 +19,11 @@
 
 #include "olp/core/client/OlpClientSettingsFactory.h"
 
+#include "olp/core/cache/CacheSettings.h"
+#include "olp/core/cache/DefaultCache.h"
+#include "olp/core/http/Network.h"
 #include "olp/core/porting/make_unique.h"
 #include "olp/core/thread/ThreadPoolTaskScheduler.h"
-
-#include "olp/core/http/Network.h"
 
 namespace olp {
 namespace client {
@@ -33,8 +34,17 @@ OlpClientSettingsFactory::CreateDefaultTaskScheduler(size_t thread_count) {
 }
 
 std::shared_ptr<http::Network>
-OlpClientSettingsFactory::CreateDefaultNetworkRequestHandler(size_t max_requests_count) {
+OlpClientSettingsFactory::CreateDefaultNetworkRequestHandler(
+    size_t max_requests_count) {
   return http::CreateDefaultNetwork(max_requests_count);
+}
+
+std::unique_ptr<cache::KeyValueCache>
+OlpClientSettingsFactory::CreateDefaultCache(
+    const cache::CacheSettings& settings) {
+  auto cache = std::make_unique<cache::DefaultCache>(settings);
+  cache->Open();
+  return std::move(cache);
 }
 
 }  // namespace client


### PR DESCRIPTION
Instead of passing the KeyValueCache to the clients trough constructor,
rather pass it as part of OlpClientSettings and keep the constructor clean.
This is the first step towards splitting the CatalogClient into layers.

- Add KeyValueCache as shared_ptr to OlpClientSettings struct.
- Add default cache method to OlpClientSettingsFactory.

Relates-to: OLPEDGE-671

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>