### PR TITLE
Fixed minor bug, so translate_report and deploy will run on schedule only. [skip travis]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,7 +72,12 @@ translate_report:
     paths:
       - .public
   only:
-    - master
+    refs:
+      - master
+      - schedules
+    variables:
+      - $NIGHTLY
+      - $FULLY
 
 pages:
   stage: deploy
@@ -85,4 +90,9 @@ pages:
       - public
     expire_in: 1 year
   only:
-    - master
+    refs:
+      - master
+      - schedules
+    variables:
+      - $NIGHTLY
+      - $FULLY


### PR DESCRIPTION
Fixed minor bug, so translate_report and deploy will run on schedule only. [skip ci]
[skip travis]

Resolves: OLPEDGE-485