### PR TITLE
Renamed logging macros in olp-cpp-sdk-authentication module

### DIFF
--- a/olp-cpp-sdk-authentication/src/TokenEndpoint.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenEndpoint.cpp
@@ -29,10 +29,9 @@
 #include "olp/authentication/TokenRequest.h"
 #include "olp/core/logging/Log.h"
 
-#define LOG_TAG "here::account::oauth2::TokenEndpoint"
-
 namespace {
 const std::string kOauth2TokenEndpoint = "/oauth2/token";
+constexpr auto kLogTag = "here::account::oauth2::TokenEndpoint";
 }  // namespace
 
 namespace olp {
@@ -97,8 +96,8 @@ TokenEndpoint::TokenEndpoint(const AuthenticationCredentials& credentials,
   if (pos != std::string::npos) {
     strippedEndpointUrl.erase(pos, kOauth2TokenEndpoint.size());
   } else {
-    EDGE_SDK_LOG_ERROR(
-        LOG_TAG,
+    OLP_SDK_LOG_ERROR(
+        kLogTag,
         "Expected '/oauth2/token' endpoint in the tokenEndpointUrl. Only "
         "standard "
         "OAuth2 token endpoint URLs are supported.");

--- a/olp-cpp-sdk-authentication/tests/ArcGisTestUtils.cpp
+++ b/olp-cpp-sdk-authentication/tests/ArcGisTestUtils.cpp
@@ -78,8 +78,8 @@ bool ArcGisTestUtils::Impl::getAccessToken(
   unsigned int retry = 0u;
   do {
     if (retry > 0u) {
-      EDGE_SDK_LOG_WARNING(__func__,
-                           "Request retry attempted (" << retry << ")");
+      OLP_SDK_LOG_WARNING(__func__,
+                          "Request retry attempted (" << retry << ")");
       std::this_thread::sleep_for(
           std::chrono::seconds(retry * RETRY_DELAY_SECS));
     }

--- a/olp-cpp-sdk-authentication/tests/AuthenticationOnlineTest.h
+++ b/olp-cpp-sdk-authentication/tests/AuthenticationOnlineTest.h
@@ -44,8 +44,8 @@ class AuthenticationOnlineTest : public AuthenticationBaseTest {
     unsigned int retry = 0u;
     do {
       if (retry > 0u) {
-        EDGE_SDK_LOG_WARNING(__func__,
-                             "Request retry attempted (" << retry << ")");
+        OLP_SDK_LOG_WARNING(__func__,
+                            "Request retry attempted (" << retry << ")");
         std::this_thread::sleep_for(
             std::chrono::seconds(retry * RETRY_DELAY_SECS));
       }
@@ -84,8 +84,8 @@ class AuthenticationOnlineTest : public AuthenticationBaseTest {
     unsigned int retry = 0u;
     do {
       if (retry > 0u) {
-        EDGE_SDK_LOG_WARNING(__func__,
-                             "Request retry attempted (" << retry << ")");
+        OLP_SDK_LOG_WARNING(__func__,
+                            "Request retry attempted (" << retry << ")");
         std::this_thread::sleep_for(
             std::chrono::seconds(retry * RETRY_DELAY_SECS));
       }
@@ -123,8 +123,8 @@ class AuthenticationOnlineTest : public AuthenticationBaseTest {
     unsigned int retry = 0u;
     do {
       if (retry > 0u) {
-        EDGE_SDK_LOG_WARNING(__func__,
-                             "Request retry attempted (" << retry << ")");
+        OLP_SDK_LOG_WARNING(__func__,
+                            "Request retry attempted (" << retry << ")");
         std::this_thread::sleep_for(
             std::chrono::seconds(retry * RETRY_DELAY_SECS));
       }
@@ -159,8 +159,8 @@ class AuthenticationOnlineTest : public AuthenticationBaseTest {
     unsigned int retry = 0u;
     do {
       if (retry > 0u) {
-        EDGE_SDK_LOG_WARNING(__func__,
-                             "Request retry attempted (" << retry << ")");
+        OLP_SDK_LOG_WARNING(__func__,
+                            "Request retry attempted (" << retry << ")");
         std::this_thread::sleep_for(
             std::chrono::seconds(retry * RETRY_DELAY_SECS));
       }
@@ -193,8 +193,8 @@ class AuthenticationOnlineTest : public AuthenticationBaseTest {
     unsigned int retry = 0u;
     do {
       if (retry > 0u) {
-        EDGE_SDK_LOG_WARNING(__func__,
-                             "Request retry attempted (" << retry << ")");
+        OLP_SDK_LOG_WARNING(__func__,
+                            "Request retry attempted (" << retry << ")");
         std::this_thread::sleep_for(
             std::chrono::seconds(retry * RETRY_DELAY_SECS));
       }

--- a/olp-cpp-sdk-authentication/tests/FacebookTestUtils.cpp
+++ b/olp-cpp-sdk-authentication/tests/FacebookTestUtils.cpp
@@ -103,8 +103,8 @@ bool FacebookTestUtils::Impl::CreateFacebookTestUser(
   unsigned int retry = 0u;
   do {
     if (retry > 0u) {
-      EDGE_SDK_LOG_WARNING(__func__,
-                           "Request retry attempted (" << retry << ")");
+      OLP_SDK_LOG_WARNING(__func__,
+                          "Request retry attempted (" << retry << ")");
       std::this_thread::sleep_for(
           std::chrono::seconds(retry * RETRY_DELAY_SECS));
     }
@@ -154,8 +154,8 @@ bool FacebookTestUtils::Impl::DeleteFacebookTestUser(
   unsigned int retry = 0u;
   do {
     if (retry > 0u) {
-      EDGE_SDK_LOG_WARNING(__func__,
-                           "Request retry attempted (" << retry << ")");
+      OLP_SDK_LOG_WARNING(__func__,
+                          "Request retry attempted (" << retry << ")");
       std::this_thread::sleep_for(
           std::chrono::seconds(retry * RETRY_DELAY_SECS));
     }

--- a/olp-cpp-sdk-authentication/tests/GoogleTestUtils.cpp
+++ b/olp-cpp-sdk-authentication/tests/GoogleTestUtils.cpp
@@ -83,8 +83,8 @@ bool GoogleTestUtils::Impl::getAccessToken(
   unsigned int retry = 0u;
   do {
     if (retry > 0u) {
-      EDGE_SDK_LOG_WARNING(__func__,
-                           "Request retry attempted (" << retry << ")");
+      OLP_SDK_LOG_WARNING(__func__,
+                          "Request retry attempted (" << retry << ")");
       std::this_thread::sleep_for(
           std::chrono::seconds(retry * RETRY_DELAY_SECS));
     }


### PR DESCRIPTION
Renamed logging macros in olp-cpp-sdk-authentication module from EDGE_SDK prefix to OLP_SDK

Relates to: OLPEDGE-650

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>