### PR TITLE
Renamed logging macros in olp-cpp-sdk-dataservice-read module

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.cpp
@@ -51,15 +51,15 @@ client::CancellationToken ApiClientLookup::LookupApi(
     std::shared_ptr<client::OlpClient> client, const std::string& service,
     const std::string& service_version, const client::HRN& hrn,
     const ApisCallback& callback) {
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "LookupApi(%s/%s): %s", service.c_str(),
-                       service_version.c_str(), hrn.partition.c_str());
+  OLP_SDK_LOG_TRACE_F(kLogTag, "LookupApi(%s/%s): %s", service.c_str(),
+                      service_version.c_str(), hrn.partition.c_str());
 
   // compare the hrn
   auto base_url = GetDatastoreServerUrl(hrn.partition);
   if (base_url.empty()) {
-    EDGE_SDK_LOG_INFO_F(kLogTag, "LookupApi(%s/%s): %s Lookup URL not found",
-                        service.c_str(), service_version.c_str(),
-                        hrn.partition.c_str());
+    OLP_SDK_LOG_INFO_F(kLogTag, "LookupApi(%s/%s): %s Lookup URL not found",
+                       service.c_str(), service_version.c_str(),
+                       hrn.partition.c_str());
     callback(
         client::ApiError(client::ErrorCode::NotFound, "Invalid or broken HRN"));
     return client::CancellationToken();
@@ -68,9 +68,9 @@ client::CancellationToken ApiClientLookup::LookupApi(
   client->SetBaseUrl(base_url);
 
   if (service == "config") {
-    EDGE_SDK_LOG_INFO_F(kLogTag, "LookupApi(%s/%s): %s - config service",
-                        service.c_str(), service_version.c_str(),
-                        hrn.partition.c_str());
+    OLP_SDK_LOG_INFO_F(kLogTag, "LookupApi(%s/%s): %s - config service",
+                       service.c_str(), service_version.c_str(),
+                       hrn.partition.c_str());
 
     // scan apis at platform apis
     return PlatformApi::GetApis(
@@ -78,9 +78,9 @@ client::CancellationToken ApiClientLookup::LookupApi(
         [callback](PlatformApi::ApisResponse response) { callback(response); });
   }
 
-  EDGE_SDK_LOG_INFO_F(kLogTag, "LookupApi(%s/%s): %s - resource service",
-                      service.c_str(), service_version.c_str(),
-                      hrn.partition.c_str());
+  OLP_SDK_LOG_INFO_F(kLogTag, "LookupApi(%s/%s): %s - resource service",
+                     service.c_str(), service_version.c_str(),
+                     hrn.partition.c_str());
 
   // scan apis at resource endpoint
   return ResourcesApi::GetApis(
@@ -92,20 +92,20 @@ client::CancellationToken ApiClientLookup::LookupApiClient(
     std::shared_ptr<client::OlpClient> client, const std::string& service,
     const std::string& service_version, const client::HRN& hrn,
     const ApiClientCallback& callback) {
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "LookupApiClient(%s/%s): %s", service.c_str(),
-                       service_version.c_str(), hrn.partition.c_str());
+  OLP_SDK_LOG_TRACE_F(kLogTag, "LookupApiClient(%s/%s): %s", service.c_str(),
+                      service_version.c_str(), hrn.partition.c_str());
 
   return ApiClientLookup::LookupApi(
       client, service, service_version, hrn, [=](ApisResponse response) {
         if (!response.IsSuccessful()) {
-          EDGE_SDK_LOG_INFO_F(
+          OLP_SDK_LOG_INFO_F(
               kLogTag, "LookupApiClient(%s/%s): %s - unsuccessful: %s",
               service.c_str(), service_version.c_str(), hrn.partition.c_str(),
               response.GetError().GetMessage().c_str());
 
           callback(response.GetError());
         } else if (response.GetResult().size() < 1) {
-          EDGE_SDK_LOG_INFO_F(
+          OLP_SDK_LOG_INFO_F(
               kLogTag, "LookupApiClient(%s/%s): %s - service not available",
               service.c_str(), service_version.c_str(), hrn.partition.c_str());
 
@@ -115,10 +115,10 @@ client::CancellationToken ApiClientLookup::LookupApiClient(
                                "Service/Version not available for given HRN"));
         } else {
           const auto& base_url = response.GetResult().at(0).GetBaseUrl();
-          EDGE_SDK_LOG_INFO_F(kLogTag,
-                              "LookupApiClient(%s/%s): %s - OK, base_url=%s",
-                              service.c_str(), service_version.c_str(),
-                              hrn.partition.c_str(), base_url.c_str());
+          OLP_SDK_LOG_INFO_F(kLogTag,
+                             "LookupApiClient(%s/%s): %s - OK, base_url=%s",
+                             service.c_str(), service_version.c_str(),
+                             hrn.partition.c_str(), base_url.c_str());
 
           client->SetBaseUrl(base_url);
           callback(*client);

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
@@ -71,19 +71,19 @@ CatalogClientImpl::CatalogClientImpl(
 CatalogClientImpl::~CatalogClientImpl() { CancelPendingRequests(); }
 
 bool CatalogClientImpl::CancelPendingRequests() {
-  EDGE_SDK_LOG_TRACE(kLogTag, "CancelPendingRequests");
+  OLP_SDK_LOG_TRACE(kLogTag, "CancelPendingRequests");
   return pending_requests_->CancelPendingRequests();
 }
 
 CancellationToken CatalogClientImpl::GetCatalog(
     const CatalogRequest& request, const CatalogResponseCallback& callback) {
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "GetCatalog '%s'", request.CreateKey().c_str());
+  OLP_SDK_LOG_TRACE_F(kLogTag, "GetCatalog '%s'", request.CreateKey().c_str());
   CancellationToken token;
   int64_t request_key = pending_requests_->GenerateRequestPlaceholder();
   auto pending_requests = pending_requests_;
   auto request_callback = [pending_requests, request_key,
                            callback](CatalogResponse response) {
-    EDGE_SDK_LOG_INFO_F(kLogTag, "GetCatalog remove key: %ld", request_key);
+    OLP_SDK_LOG_INFO(kLogTag, "GetCatalog remove key: " << request_key);
     if (pending_requests->Remove(request_key)) {
       callback(response);
     }
@@ -93,7 +93,7 @@ CancellationToken CatalogClientImpl::GetCatalog(
     token = catalog_repo_->getCatalog(req.WithFetchOption(CacheOnly),
                                       request_callback);
     auto onlineKey = pending_requests_->GenerateRequestPlaceholder();
-    EDGE_SDK_LOG_INFO_F(kLogTag, "GetCatalog add key: %ld", onlineKey);
+    OLP_SDK_LOG_INFO(kLogTag, "GetCatalog add key: " << onlineKey);
     pending_requests_->Insert(
         catalog_repo_->getCatalog(
             req.WithFetchOption(OnlineIfNotFound),
@@ -102,7 +102,7 @@ CancellationToken CatalogClientImpl::GetCatalog(
             }),
         onlineKey);
   } else {
-    EDGE_SDK_LOG_INFO_F(kLogTag, "GetCatalog existing: %ld", request_key);
+    OLP_SDK_LOG_INFO(kLogTag, "GetCatalog existing: " << request_key);
     token = catalog_repo_->getCatalog(request, request_callback);
   }
   pending_requests_->Insert(token, request_key);
@@ -120,13 +120,13 @@ CancellableFuture<CatalogResponse> CatalogClientImpl::GetCatalog(
 CancellationToken CatalogClientImpl::GetCatalogMetadataVersion(
     const CatalogVersionRequest& request,
     const CatalogVersionCallback& callback) {
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "GetCatalog '%s'", request.CreateKey().c_str());
+  OLP_SDK_LOG_TRACE_F(kLogTag, "GetCatalog '%s'", request.CreateKey().c_str());
   CancellationToken token;
   int64_t request_key = pending_requests_->GenerateRequestPlaceholder();
   auto pending_requests = pending_requests_;
   auto request_callback = [pending_requests, request_key,
                            callback](CatalogVersionResponse response) {
-    EDGE_SDK_LOG_INFO_F(kLogTag, "GetCatalog remove key: %ld", request_key);
+    OLP_SDK_LOG_INFO(kLogTag, "GetCatalog remove key: " << request_key);
     if (pending_requests->Remove(request_key)) {
       callback(response);
     }
@@ -136,7 +136,7 @@ CancellationToken CatalogClientImpl::GetCatalogMetadataVersion(
     token = catalog_repo_->getLatestCatalogVersion(
         req.WithFetchOption(CacheOnly), request_callback);
     auto onlineKey = pending_requests_->GenerateRequestPlaceholder();
-    EDGE_SDK_LOG_INFO_F(kLogTag, "GetCatalog add key: %ld", onlineKey);
+    OLP_SDK_LOG_INFO(kLogTag, "GetCatalog add key: " << onlineKey);
     pending_requests_->Insert(
         catalog_repo_->getLatestCatalogVersion(
             req.WithFetchOption(OnlineIfNotFound),
@@ -145,7 +145,7 @@ CancellationToken CatalogClientImpl::GetCatalogMetadataVersion(
             }),
         onlineKey);
   } else {
-    EDGE_SDK_LOG_INFO_F(kLogTag, "GetCatalog existing: %ld", request_key);
+    OLP_SDK_LOG_INFO(kLogTag, "GetCatalog existing: " << request_key);
     token = catalog_repo_->getLatestCatalogVersion(request, request_callback);
   }
   pending_requests_->Insert(token, request_key);

--- a/olp-cpp-sdk-dataservice-read/src/MultiRequestContext.h
+++ b/olp-cpp-sdk-dataservice-read/src/MultiRequestContext.h
@@ -61,9 +61,9 @@ class MultiRequestContext final {
 
     while (!active_reqs_->empty()) {
       auto itr = active_reqs_->begin();
-      EDGE_SDK_LOG_INFO_F(kMultiRequestContextLogTag,
-                          "~MultiRequestContext() -> cancelling id %s",
-                          itr->first.c_str());
+      OLP_SDK_LOG_INFO_F(kMultiRequestContextLogTag,
+                         "~MultiRequestContext() -> cancelling id %s",
+                         itr->first.c_str());
       itr->second->cancellation_token_.cancel();
     }
   }
@@ -73,10 +73,10 @@ class MultiRequestContext final {
       Callback callback_fn) {
     boost::uuids::uuid request_id = uuid_gen_();
 
-    EDGE_SDK_LOG_TRACE_F(kMultiRequestContextLogTag,
-                         "ExecuteOrAssociate(%s) -> request uuid = %s",
-                         key.c_str(),
-                         boost::uuids::to_string(request_id).c_str());
+    OLP_SDK_LOG_TRACE_F(kMultiRequestContextLogTag,
+                        "ExecuteOrAssociate(%s) -> request uuid = %s",
+                        key.c_str(),
+                        boost::uuids::to_string(request_id).c_str());
 
     std::shared_ptr<RequestContext> newContext;
 
@@ -85,15 +85,15 @@ class MultiRequestContext final {
 
       auto itr = active_reqs_->find(key);
       if (itr != active_reqs_->end()) {
-        EDGE_SDK_LOG_INFO_F(kMultiRequestContextLogTag,
-                            "ExecuteOrAssociate(%s) -> existing request key",
-                            key.c_str());
+        OLP_SDK_LOG_INFO_F(kMultiRequestContextLogTag,
+                           "ExecuteOrAssociate(%s) -> existing request key",
+                           key.c_str());
 
         itr->second->callbacks_[request_id] = callback_fn;
       } else {
-        EDGE_SDK_LOG_INFO_F(kMultiRequestContextLogTag,
-                            "ExecuteOrAssociate(%s) -> new request key",
-                            key.c_str());
+        OLP_SDK_LOG_INFO_F(kMultiRequestContextLogTag,
+                           "ExecuteOrAssociate(%s) -> new request key",
+                           key.c_str());
 
         newContext = std::make_shared<RequestContext>();
         newContext->callbacks_[request_id] = callback_fn;
@@ -109,9 +109,9 @@ class MultiRequestContext final {
         onRequestCompleted(mutex, reqs, response, key);
       };
 
-      EDGE_SDK_LOG_INFO_F(kMultiRequestContextLogTag,
-                          "ExecuteOrAssociate(%s) -> execute request()",
-                          key.c_str());
+      OLP_SDK_LOG_INFO_F(kMultiRequestContextLogTag,
+                         "ExecuteOrAssociate(%s) -> execute request()",
+                         key.c_str());
 
       newContext->cancellation_token_ = execute_fn(callback);
     }
@@ -140,8 +140,8 @@ class MultiRequestContext final {
   static void onRequestCompleted(std::shared_ptr<std::recursive_mutex> mutex,
                                  ReqsPtr reqs, Response response,
                                  std::string key) {
-    EDGE_SDK_LOG_TRACE_F(kMultiRequestContextLogTag, "onRequestCompleted(%s)",
-                         key.c_str());
+    OLP_SDK_LOG_TRACE_F(kMultiRequestContextLogTag, "onRequestCompleted(%s)",
+                        key.c_str());
     RequestContextPtr context;
 
     {
@@ -155,9 +155,9 @@ class MultiRequestContext final {
     }  // release the lock, then invoke the callbacks.
 
     if (context) {
-      EDGE_SDK_LOG_INFO_F(kMultiRequestContextLogTag,
-                          "onRequestCompleted(%s) -> callback count = %lu",
-                          key.c_str(), context->callbacks_.size());
+      OLP_SDK_LOG_INFO_F(kMultiRequestContextLogTag,
+                         "onRequestCompleted(%s) -> callback count = %lu",
+                         key.c_str(), context->callbacks_.size());
 
       for (auto& callback : context->callbacks_) {
         callback.second(response);
@@ -169,8 +169,8 @@ class MultiRequestContext final {
                                  std::shared_ptr<std::recursive_mutex> mutex,
                                  ReqsPtr reqs, const std::string& key,
                                  const boost::uuids::uuid& request_id) {
-    EDGE_SDK_LOG_TRACE_F(kMultiRequestContextLogTag, "onRequestCancelled(%s)",
-                         key.c_str());
+    OLP_SDK_LOG_TRACE_F(kMultiRequestContextLogTag, "onRequestCancelled(%s)",
+                        key.c_str());
     RequestContextPtr context;
 
     {
@@ -184,9 +184,9 @@ class MultiRequestContext final {
     }  // release the lock, then invoke the callbacks.
 
     if (context) {
-      EDGE_SDK_LOG_INFO_F(kMultiRequestContextLogTag,
-                          "onRequestCancelled(key=%s, id=%s)", key.c_str(),
-                          boost::uuids::to_string(request_id).c_str());
+      OLP_SDK_LOG_INFO_F(kMultiRequestContextLogTag,
+                         "onRequestCancelled(key=%s, id=%s)", key.c_str(),
+                         boost::uuids::to_string(request_id).c_str());
 
       // find the callback by request_id
       auto requestItr = context->callbacks_.find(request_id);

--- a/olp-cpp-sdk-dataservice-read/src/PrefetchTilesProvider.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/PrefetchTilesProvider.cpp
@@ -61,11 +61,11 @@ client::CancellationToken PrefetchTilesProvider::PrefetchTiles(
     const PrefetchTilesRequest& request,
     const PrefetchTilesResponseCallback& callback) {
   auto key = request.CreateKey();
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "getCatalog(%s)", key.c_str());
+  OLP_SDK_LOG_TRACE_F(kLogTag, "getCatalog(%s)", key.c_str());
   auto isBusy = prefetchProviderBusy_->exchange(true);
   if (isBusy) {
     repository::ExecuteOrSchedule(settings_.get(), [=]() {
-      EDGE_SDK_LOG_INFO_F(kLogTag, "getCatalog(%s) busy", key.c_str());
+      OLP_SDK_LOG_INFO_F(kLogTag, "getCatalog(%s) busy", key.c_str());
       callback(
           {{ErrorCode::SlowDown, "Busy prefetching at the moment.", true}});
     });
@@ -81,7 +81,7 @@ client::CancellationToken PrefetchTilesProvider::PrefetchTiles(
   auto cancel_context = std::make_shared<CancellationContext>();
 
   auto cancel_callback = [completionCallback, key]() {
-    EDGE_SDK_LOG_INFO_F(kLogTag, "getCatalog(%s) cancelled", key.c_str());
+    OLP_SDK_LOG_INFO_F(kLogTag, "getCatalog(%s) cancelled", key.c_str());
     completionCallback({{ErrorCode::Cancelled, "Operation cancelled.", true}});
   };
 
@@ -95,13 +95,13 @@ client::CancellationToken PrefetchTilesProvider::PrefetchTiles(
   catalogRequest.WithBillingTag(request.GetBillingTag());
   cancel_context->ExecuteOrCancelled(
       [=]() {
-        EDGE_SDK_LOG_INFO_F(kLogTag, "getCatalog(%s) execute", key.c_str());
+        OLP_SDK_LOG_INFO_F(kLogTag, "getCatalog(%s) execute", key.c_str());
 
         return catalogRepo->getCatalog(
             catalogRequest, [=](read::CatalogResponse catalogResponse) {
               if (!catalogResponse.IsSuccessful()) {
-                EDGE_SDK_LOG_INFO_F(kLogTag, "getCatalog(%s) unsuccessful",
-                                    key.c_str());
+                OLP_SDK_LOG_INFO_F(kLogTag, "getCatalog(%s) unsuccessful",
+                                   key.c_str());
                 completionCallback(catalogResponse.GetError());
                 return;
               }
@@ -113,7 +113,7 @@ client::CancellationToken PrefetchTilesProvider::PrefetchTiles(
                   });
               if (layerResult == layers.end()) {
                 // Layer not found
-                EDGE_SDK_LOG_INFO_F(
+                OLP_SDK_LOG_INFO_F(
                     kLogTag, "getLatestCatalogVersion(%s) layer not found",
                     key.c_str());
                 completionCallback(ApiError(client::ErrorCode::InvalidArgument,
@@ -129,9 +129,9 @@ client::CancellationToken PrefetchTilesProvider::PrefetchTiles(
               // Get the catalog version
               cancel_context->ExecuteOrCancelled(
                   [=]() {
-                    EDGE_SDK_LOG_INFO_F(kLogTag,
-                                        "getLatestCatalogVersion(%s) execute",
-                                        key.c_str());
+                    OLP_SDK_LOG_INFO_F(kLogTag,
+                                       "getLatestCatalogVersion(%s) execute",
+                                       key.c_str());
                     CatalogVersionRequest catalogVersionRequest;
                     catalogVersionRequest
                         .WithBillingTag(request.GetBillingTag())
@@ -140,7 +140,7 @@ client::CancellationToken PrefetchTilesProvider::PrefetchTiles(
                         catalogVersionRequest,
                         [=](CatalogVersionResponse response) {
                           if (!response.IsSuccessful()) {
-                            EDGE_SDK_LOG_INFO_F(
+                            OLP_SDK_LOG_INFO_F(
                                 kLogTag,
                                 "getLatestCatalogVersion(%s) unseccessful",
                                 key.c_str());
@@ -158,7 +158,7 @@ client::CancellationToken PrefetchTilesProvider::PrefetchTiles(
                                   request.GetMaxLevel());
 
                           if (calculatedTileKeys.size() == 0) {
-                            EDGE_SDK_LOG_INFO_F(
+                            OLP_SDK_LOG_INFO_F(
                                 kLogTag,
                                 "getLatestCatalogVersion(%s) tile/level "
                                 "mismatch",
@@ -169,16 +169,16 @@ client::CancellationToken PrefetchTilesProvider::PrefetchTiles(
                             return;
                           }
 
-                          EDGE_SDK_LOG_INFO_F(kLogTag,
-                                              "EffectiveTileKeys, count = %lu",
-                                              calculatedTileKeys.size());
+                          OLP_SDK_LOG_INFO_F(kLogTag,
+                                             "EffectiveTileKeys, count = %lu",
+                                             calculatedTileKeys.size());
                           prefetchTilesRepo->GetSubTiles(
                               cancel_context, request, version, expiry,
                               calculatedTileKeys,
                               [=](const repository::SubTilesResponse&
                                       response) {
                                 if (!response.IsSuccessful()) {
-                                  EDGE_SDK_LOG_INFO_F(
+                                  OLP_SDK_LOG_INFO_F(
                                       kLogTag,
                                       "SubTilesResponse(%s) unseccessful",
                                       key.c_str());
@@ -210,8 +210,8 @@ void PrefetchTilesProvider::QueryDataForEachSubTile(
     const PrefetchTilesRequest& request, const std::string& layerType,
     const repository::SubTilesResult& subtiles,
     const PrefetchTilesResponseCallback& callback) {
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "QueryDataForEachSubTile, count = %lu",
-                       subtiles.size());
+  OLP_SDK_LOG_TRACE_F(kLogTag, "QueryDataForEachSubTile, count = %lu",
+                      subtiles.size());
 
   std::vector<std::future<std::shared_ptr<PrefetchTileResult>>> futures;
 

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.cpp
@@ -125,8 +125,8 @@ client::CancellationToken QueryApi::QuadTreeIndex(
 
   client::NetworkAsyncCallback callback =
       [indexCallback](client::HttpResponse response) {
-        EDGE_SDK_LOG_TRACE_F(LOGTAG, "QuadTreeIndex callback, status=%d",
-                             response.status);
+        OLP_SDK_LOG_TRACE_F(LOGTAG, "QuadTreeIndex callback, status=%d",
+                            response.status);
         if (response.status != 200) {
           indexCallback(client::ApiError(response.status, response.response));
         } else {
@@ -134,7 +134,7 @@ client::CancellationToken QueryApi::QuadTreeIndex(
         }
       };
 
-  EDGE_SDK_LOG_TRACE(LOGTAG, "QuadTreeIndex");
+  OLP_SDK_LOG_TRACE(LOGTAG, "QuadTreeIndex");
 
   return client.CallApi(metadataUri, "GET", queryParams, headerParams,
                         formParams, nullptr, "", callback);

--- a/olp-cpp-sdk-dataservice-read/src/repositories/ApiCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/ApiCacheRepository.cpp
@@ -45,7 +45,7 @@ void ApiCacheRepository::Put(const std::string& service,
                              const std::string& serviceUrl) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, service, serviceVersion);
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "Put '%s'", key.c_str());
+  OLP_SDK_LOG_TRACE_F(kLogTag, "Put '%s'", key.c_str());
   cache_->Put(CreateKey(hrn, service, serviceVersion), serviceUrl,
               [serviceUrl]() { return serviceUrl; }, 3600);
 }
@@ -54,7 +54,7 @@ boost::optional<std::string> ApiCacheRepository::Get(
     const std::string& service, const std::string& serviceVersion) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, service, serviceVersion);
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "Get '%s'", key.c_str());
+  OLP_SDK_LOG_TRACE_F(kLogTag, "Get '%s'", key.c_str());
   auto url = cache_->Get(key, [](const std::string& value) { return value; });
   if (url.empty()) {
     return boost::none;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogCacheRepository.cpp
@@ -54,7 +54,7 @@ CatalogCacheRepository::CatalogCacheRepository(
 void CatalogCacheRepository::Put(const model::Catalog& catalog) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn);
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "Put '%s'", key.c_str());
+  OLP_SDK_LOG_TRACE_F(kLogTag, "Put '%s'", key.c_str());
   cache_->Put(key, catalog,
               [catalog]() { return olp::serializer::serialize(catalog); });
 }
@@ -62,7 +62,7 @@ void CatalogCacheRepository::Put(const model::Catalog& catalog) {
 boost::optional<model::Catalog> CatalogCacheRepository::Get() {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn);
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "Get '%s'", key.c_str());
+  OLP_SDK_LOG_TRACE_F(kLogTag, "Get '%s'", key.c_str());
   auto cachedCatalog =
       cache_->Get(key, [](const std::string& serializedObject) {
         return parser::parse<model::Catalog>(serializedObject);
@@ -76,7 +76,7 @@ boost::optional<model::Catalog> CatalogCacheRepository::Get() {
 
 void CatalogCacheRepository::PutVersion(const model::VersionResponse& version) {
   std::string hrn(hrn_.ToCatalogHRNString());
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "PutVersion '%s'", hrn.c_str());
+  OLP_SDK_LOG_TRACE_F(kLogTag, "PutVersion '%s'", hrn.c_str());
   cache_->Put(VersionKey(hrn), version,
               [version]() { return olp::serializer::serialize(version); });
 }
@@ -84,7 +84,7 @@ void CatalogCacheRepository::PutVersion(const model::VersionResponse& version) {
 boost::optional<model::VersionResponse> CatalogCacheRepository::GetVersion() {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = VersionKey(hrn);
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "GetVersion '%s'", key.c_str());
+  OLP_SDK_LOG_TRACE_F(kLogTag, "GetVersion '%s'", key.c_str());
   auto cachedVersion =
       cache_->Get(key, [](const std::string& serializedObject) {
         return parser::parse<model::VersionResponse>(serializedObject);
@@ -97,7 +97,7 @@ boost::optional<model::VersionResponse> CatalogCacheRepository::GetVersion() {
 
 void CatalogCacheRepository::Clear() {
   std::string hrn(hrn_.ToCatalogHRNString());
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "Clear '%s'", CreateKey(hrn).c_str());
+  OLP_SDK_LOG_TRACE_F(kLogTag, "Clear '%s'", CreateKey(hrn).c_str());
   cache_->RemoveKeysWithPrefix(hrn);
 }
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.cpp
@@ -45,7 +45,7 @@ void DataCacheRepository::Put(const model::Data& data,
                               const std::string& data_handle) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, layer_id, data_handle);
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "Put '%s'", key.c_str());
+  OLP_SDK_LOG_TRACE_F(kLogTag, "Put '%s'", key.c_str());
   cache_->Put(key, data);
 }
 
@@ -53,7 +53,7 @@ boost::optional<model::Data> DataCacheRepository::Get(
     const std::string& layer_id, const std::string& data_handle) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, layer_id, data_handle);
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "Get '%s'", key.c_str());
+  OLP_SDK_LOG_TRACE_F(kLogTag, "Get '%s'", key.c_str());
   auto cachedData = cache_->Get(key);
   if (!cachedData) {
     return boost::none;
@@ -66,7 +66,7 @@ void DataCacheRepository::Clear(const std::string& layer_id,
                                 const std::string& data_handle) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, layer_id, data_handle);
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "Clear '%s'", key.c_str());
+  OLP_SDK_LOG_TRACE_F(kLogTag, "Clear '%s'", key.c_str());
   cache_->RemoveKeysWithPrefix(key);
 }
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
@@ -66,14 +66,14 @@ void PartitionsCacheRepository::Put(const PartitionsRequest& request,
                                     const boost::optional<time_t>& expiry,
                                     bool allLayer) {
   std::string hrn(hrn_.ToCatalogHRNString());
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "Put '%s'", hrn.c_str());
+  OLP_SDK_LOG_TRACE_F(kLogTag, "Put '%s'", hrn.c_str());
   std::vector<std::string> partitionIds;
   time_t no_expiry = std::numeric_limits<time_t>::max();
 
   for (auto partition : partitions.GetPartitions()) {
     auto key = CreateKey(hrn, request.GetLayerId(), partition.GetPartition(),
                          request.GetVersion());
-    EDGE_SDK_LOG_INFO_F(kLogTag, "Put '%s'", key.c_str());
+    OLP_SDK_LOG_INFO_F(kLogTag, "Put '%s'", key.c_str());
     cache_->Put(key, partition,
                 [=]() { return olp::serializer::serialize(partition); },
                 expiry.get_value_or(no_expiry));
@@ -83,7 +83,7 @@ void PartitionsCacheRepository::Put(const PartitionsRequest& request,
   }
   if (allLayer) {
     auto key = CreateKey(hrn, request.GetLayerId(), request.GetVersion());
-    EDGE_SDK_LOG_INFO_F(kLogTag, "Put '%s'", key.c_str());
+    OLP_SDK_LOG_INFO_F(kLogTag, "Put '%s'", key.c_str());
     cache_->Put(key, partitionIds,
                 [=]() { return olp::serializer::serialize(partitionIds); },
                 expiry.get_value_or(no_expiry));
@@ -94,13 +94,13 @@ model::Partitions PartitionsCacheRepository::Get(
     const PartitionsRequest& request,
     const std::vector<std::string>& partitionIds) {
   std::string hrn(hrn_.ToCatalogHRNString());
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "Get '%s'", hrn.c_str());
+  OLP_SDK_LOG_TRACE_F(kLogTag, "Get '%s'", hrn.c_str());
   model::Partitions cachedPartitionsModel;
   std::vector<model::Partition> cachedPartitions;
   for (auto partitionId : partitionIds) {
     auto key =
         CreateKey(hrn, request.GetLayerId(), partitionId, request.GetVersion());
-    EDGE_SDK_LOG_INFO_F(kLogTag, "Get '%s'", key.c_str());
+    OLP_SDK_LOG_INFO_F(kLogTag, "Get '%s'", key.c_str());
     auto cachedPartition =
         cache_->Get(key, [](const std::string& serializedObject) {
           return parser::parse<model::Partition>(serializedObject);
@@ -118,7 +118,7 @@ boost::optional<model::Partitions> PartitionsCacheRepository::Get(
     const PartitionsRequest& request) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, request.GetLayerId(), request.GetVersion());
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "Get '%s'", key.c_str());
+  OLP_SDK_LOG_TRACE_F(kLogTag, "Get '%s'", key.c_str());
   auto cachedIds = cache_->Get(key, [](const std::string& serializedIds) {
     return parser::parse<std::vector<std::string>>(serializedIds);
   });
@@ -132,7 +132,7 @@ boost::optional<model::Partitions> PartitionsCacheRepository::Get(
 void PartitionsCacheRepository::Put(int64_t catalogVersion,
                                     const model::LayerVersions& layerVersions) {
   std::string hrn(hrn_.ToCatalogHRNString());
-  EDGE_SDK_LOG_INFO_F(kLogTag, "Put '%s'", hrn.c_str());
+  OLP_SDK_LOG_INFO_F(kLogTag, "Put '%s'", hrn.c_str());
   cache_->Put(CreateKey(hrn, catalogVersion), layerVersions,
               [=]() { return olp::serializer::serialize(layerVersions); });
 }
@@ -141,7 +141,7 @@ boost::optional<model::LayerVersions> PartitionsCacheRepository::Get(
     int64_t catalogVersion) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, catalogVersion);
-  EDGE_SDK_LOG_INFO_F(kLogTag, "Get '%s'", key.c_str());
+  OLP_SDK_LOG_INFO_F(kLogTag, "Get '%s'", key.c_str());
   auto cachedLayerVersions =
       cache_->Get(key, [](const std::string& serializedObject) {
         return parser::parse<model::LayerVersions>(serializedObject);
@@ -155,7 +155,7 @@ boost::optional<model::LayerVersions> PartitionsCacheRepository::Get(
 void PartitionsCacheRepository::Clear(const std::string& layer_id) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, layer_id, boost::none);
-  EDGE_SDK_LOG_INFO_F(kLogTag, "Clear '%s'", key.c_str());
+  OLP_SDK_LOG_INFO_F(kLogTag, "Clear '%s'", key.c_str());
   cache_->RemoveKeysWithPrefix(key);
 }
 
@@ -163,7 +163,7 @@ void PartitionsCacheRepository::ClearPartitions(
     const PartitionsRequest& request,
     const std::vector<std::string>& partitionIds) {
   std::string hrn(hrn_.ToCatalogHRNString());
-  EDGE_SDK_LOG_INFO_F(kLogTag, "ClearPartitions '%s'", hrn.c_str());
+  OLP_SDK_LOG_INFO_F(kLogTag, "ClearPartitions '%s'", hrn.c_str());
   auto cachedPartitions = Get(request, partitionIds);
   // Partitions not processed here are not cached to begin with.
   for (auto partition : cachedPartitions.GetPartitions()) {

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -191,13 +191,13 @@ void PrefetchTilesRepository::GetSubQuads(
     const PrefetchTilesRequest& prefetchRequest, geo::TileKey tile,
     int64_t version, boost::optional<time_t> expiry, int32_t depth,
     const SubQuadsResponseCallback& callback) {
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "GetSubQuads(%s, %" PRId64 ", %" PRId32 ")",
-                       tile.ToHereTile().c_str(), version, depth);
+  OLP_SDK_LOG_TRACE_F(kLogTag, "GetSubQuads(%s, %" PRId64 ", %" PRId32 ")",
+                      tile.ToHereTile().c_str(), version, depth);
 
   auto cancel_callback = [callback, tile, version, depth]() {
-    EDGE_SDK_LOG_INFO_F(kLogTag,
-                        "GetSubQuads cancelled(%s, %" PRId64 ", %" PRId32 ")",
-                        tile.ToHereTile().c_str(), version, depth);
+    OLP_SDK_LOG_INFO_F(kLogTag,
+                       "GetSubQuads cancelled(%s, %" PRId64 ", %" PRId32 ")",
+                       tile.ToHereTile().c_str(), version, depth);
     callback({{ErrorCode::Cancelled, "Operation cancelled.", true}});
   };
 
@@ -214,7 +214,7 @@ void PrefetchTilesRepository::GetSubQuads(
 
               cancel_context->ExecuteOrCancelled(
                   [=, &partitionsCache]() {
-                    EDGE_SDK_LOG_INFO_F(
+                    OLP_SDK_LOG_INFO_F(
                         kLogTag,
                         "QuadTreeIndex execute(%s, %" PRId64 ", %" PRId32 ")",
                         tile.ToHereTile().c_str(), version, depth);
@@ -225,7 +225,7 @@ void PrefetchTilesRepository::GetSubQuads(
                         [=, &partitionsCache](
                             QueryApi::QuadTreeIndexResponse indexResponse) {
                           if (!indexResponse.IsSuccessful()) {
-                            EDGE_SDK_LOG_INFO_F(
+                            OLP_SDK_LOG_INFO_F(
                                 kLogTag,
                                 "QuadTreeIndex Error(%s, %" PRId64 ", %" PRId32
                                 ")",
@@ -234,7 +234,7 @@ void PrefetchTilesRepository::GetSubQuads(
                             return;
                           }
 
-                          EDGE_SDK_LOG_INFO(kLogTag, "QuadTreeIndex Success");
+                          OLP_SDK_LOG_INFO(kLogTag, "QuadTreeIndex Success");
                           SubQuadsResult result;
                           model::Partitions partitions;
                           for (auto subquad :


### PR DESCRIPTION
Renamed logging macros in olp-cpp-sdk-dataservice-read module from EDGE_SDK prefix to OLP_SDK
+ fixed warning regarding invalid usage of format usage in formatting log macros

Relates to: OLPEDGE-650

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>