### PR TITLE
Renamed logging macros in examples and docs

### DIFF
--- a/docs/dataservice-read-catalog-example.md
+++ b/docs/dataservice-read-catalog-example.md
@@ -199,11 +199,11 @@ olp::dataservice::read::CatalogResponse catalogResponse =
 if (catalogResponse.IsSuccessful()) {
     const olp::dataservice::read::CatalogResult& responseResult =
         catalogResponse.GetResult();
-    EDGE_SDK_LOG_INFO_F("read-example", "Catalog description: %s",
-                        responseResult.GetDescription().c_str());
+    OLP_SDK_LOG_INFO_F("read-example", "Catalog description: %s",
+                       responseResult.GetDescription().c_str());
 } else {
-    EDGE_SDK_LOG_ERROR("read-example",
-                       "Request catalog metadata - Failure");
+    OLP_SDK_LOG_ERROR("read-example",
+                      "Request catalog metadata - Failure");
 }
 ```
 
@@ -268,11 +268,11 @@ if (partitionsResponse.IsSuccessful()) {
         partitionsResponse.GetResult();
     const std::vector<olp::dataservice::read::model::Partition>& partitions =
         responseResult.GetPartitions();
-    EDGE_SDK_LOG_INFO_F("read-example", "Layer contains %d partitions.",
-                        partitions.size());
+    OLP_SDK_LOG_INFO_F("read-example", "Layer contains %d partitions.",
+                       partitions.size());
 } else {
-    EDGE_SDK_LOG_ERROR("read-example",
-                       "Request partition metadata - Failure");
+    OLP_SDK_LOG_ERROR("read-example",
+                      "Request partition metadata - Failure");
 }
 ```
 
@@ -324,12 +324,12 @@ olp::dataservice::read::DataResponse dataResponse =
 if (dataResponse.IsSuccessful()) {
     const olp::dataservice::read::DataResult& responseResult =
         dataResponse.GetResult();
-    EDGE_SDK_LOG_INFO_F("read-example",
-                        "Request partition data - Success, data size - %d",
-                        responseResult->size());
+    OLP_SDK_LOG_INFO_F("read-example",
+                       "Request partition data - Success, data size - %d",
+                       responseResult->size());
 } else {
-    EDGE_SDK_LOG_ERROR("read-example",
-                       "Request partition data - Failure");
+    OLP_SDK_LOG_ERROR("read-example",
+                      "Request partition data - Failure");
 }
 ```
 

--- a/docs/dataservice-write-example.md
+++ b/docs/dataservice-write-example.md
@@ -188,13 +188,13 @@ auto response = futureResponse.GetFuture().get();
 
 // Check the response
 if (!response.IsSuccessful()) {
-    EDGE_SDK_LOG_INFO_F("write-example",
-                        "Error writing data - HTTP Status: %d Message: %s",
-                        response.GetError().GetHttpStatusCode(),
-                        response.GetError().GetMessage().c_str());
+    OLP_SDK_LOG_INFO_F("write-example",
+                       "Error writing data - HTTP Status: %d Message: %s",
+                       response.GetError().GetHttpStatusCode(),
+                       response.GetError().GetMessage().c_str());
     return -1;
 } else {
-    EDGE_SDK_LOG_ERROR_F("write-example", "Publish Successful - TraceID: %s",
-                         response.GetResult().GetTraceID().c_str());
+    OLP_SDK_LOG_ERROR_F("write-example", "Publish Successful - TraceID: %s",
+                        response.GetResult().GetTraceID().c_str());
 }
 ```

--- a/examples/dataservice-read/example.cpp
+++ b/examples/dataservice-read/example.cpp
@@ -47,8 +47,8 @@ std::string HandleCatalogResponse(
   std::string first_layer_id;
   if (catalog_response.IsSuccessful()) {
     const auto& response_result = catalog_response.GetResult();
-    EDGE_SDK_LOG_INFO_F(kLogTag, "Catalog description: %s",
-                        response_result.GetDescription().c_str());
+    OLP_SDK_LOG_INFO_F(kLogTag, "Catalog description: %s",
+                       response_result.GetDescription().c_str());
 
     auto layers = response_result.GetLayers();
     if (!layers.empty()) {
@@ -58,12 +58,12 @@ std::string HandleCatalogResponse(
     auto end = layers.size() <= kMaxLayers ? layers.end()
                                            : layers.begin() + kMaxLayers;
     for (auto it = layers.cbegin(); it != end; ++it) {
-      EDGE_SDK_LOG_INFO_F(kLogTag, "Layer '%s' (%s): %s", it->GetId().c_str(),
-                          it->GetLayerType().c_str(),
-                          it->GetDescription().c_str());
+      OLP_SDK_LOG_INFO_F(kLogTag, "Layer '%s' (%s): %s", it->GetId().c_str(),
+                         it->GetLayerType().c_str(),
+                         it->GetDescription().c_str());
     }
   } else {
-    EDGE_SDK_LOG_ERROR_F(
+    OLP_SDK_LOG_ERROR_F(
         kLogTag, "Request catalog metadata - Failure(%d): %s",
         static_cast<int>(catalog_response.GetError().GetErrorCode()),
         catalog_response.GetError().GetMessage().c_str());
@@ -79,8 +79,8 @@ std::string HandlePartitionsResponse(
   if (partitions_response.IsSuccessful()) {
     const auto& response_result = partitions_response.GetResult();
     auto partitions = response_result.GetPartitions();
-    EDGE_SDK_LOG_INFO_F(kLogTag, "Layer contains %ld partitions.",
-                        partitions.size());
+    OLP_SDK_LOG_INFO_F(kLogTag, "Layer contains %ld partitions.",
+                       partitions.size());
 
     if (!partitions.empty()) {
       first_partition_id = partitions.front().GetPartition();
@@ -90,10 +90,10 @@ std::string HandlePartitionsResponse(
                    ? partitions.end()
                    : partitions.begin() + kMaxPartitions;
     for (auto it = partitions.cbegin(); it != end; ++it) {
-      EDGE_SDK_LOG_INFO_F(kLogTag, "Partition: %s", it->GetPartition().c_str());
+      OLP_SDK_LOG_INFO_F(kLogTag, "Partition: %s", it->GetPartition().c_str());
     }
   } else {
-    EDGE_SDK_LOG_ERROR_F(
+    OLP_SDK_LOG_ERROR_F(
         kLogTag, "Request partition metadata - Failure(%d): %s",
         static_cast<int>(partitions_response.GetError().GetErrorCode()),
         partitions_response.GetError().GetMessage().c_str());
@@ -106,12 +106,12 @@ bool HandleDataResponse(
     const olp::dataservice::read::DataResponse& data_response) {
   if (data_response.IsSuccessful()) {
     const auto& response_result = data_response.GetResult();
-    EDGE_SDK_LOG_INFO_F(kLogTag,
-                        "Request partition data - Success, data size - %ld",
-                        response_result->size());
+    OLP_SDK_LOG_INFO_F(kLogTag,
+                       "Request partition data - Success, data size - %ld",
+                       response_result->size());
     return true;
   } else {
-    EDGE_SDK_LOG_ERROR_F(
+    OLP_SDK_LOG_ERROR_F(
         kLogTag, "Request partition data - Failure(%d): %s",
         static_cast<int>(data_response.GetError().GetErrorCode()),
         data_response.GetError().GetMessage().c_str());
@@ -185,7 +185,7 @@ int RunExample() {
     // Retrieve data from the response
     first_partition_id = HandlePartitionsResponse(partitions_response);
   } else {
-    EDGE_SDK_LOG_WARNING(kLogTag, "Request partition metadata is not present!");
+    OLP_SDK_LOG_WARNING(kLogTag, "Request partition metadata is not present!");
   }
 
   int return_code = -1;
@@ -207,7 +207,7 @@ int RunExample() {
     // Retrieve data from the response
     return_code = HandleDataResponse(data_response) ? 0 : -1;
   } else {
-    EDGE_SDK_LOG_WARNING(kLogTag, "Request partition data is not present!");
+    OLP_SDK_LOG_WARNING(kLogTag, "Request partition data is not present!");
   }
 
   return return_code;

--- a/examples/dataservice-write/example.cpp
+++ b/examples/dataservice-write/example.cpp
@@ -89,15 +89,15 @@ int RunExample() {
 
     // Check the response
     if (!response.IsSuccessful()) {
-      EDGE_SDK_LOG_ERROR_F(kLogTag,
-                           "Error writing data - HTTP Status: %d Message: %s",
-                           response.GetError().GetHttpStatusCode(),
-                           response.GetError().GetMessage().c_str());
+      OLP_SDK_LOG_ERROR_F(kLogTag,
+                          "Error writing data - HTTP Status: %d Message: %s",
+                          response.GetError().GetHttpStatusCode(),
+                          response.GetError().GetMessage().c_str());
       return -1;
     }
 
-    EDGE_SDK_LOG_INFO_F(kLogTag, "Publish Successful - TraceID: %s",
-                        response.GetResult().GetTraceID().c_str());
+    OLP_SDK_LOG_INFO_F(kLogTag, "Publish Successful - TraceID: %s",
+                       response.GetResult().GetTraceID().c_str());
   }
 
   // Multi-publish to stream layer
@@ -106,7 +106,7 @@ int RunExample() {
     for (size_t idx = 0; idx < kPublishRequestsSize; ++idx) {
       auto status = client->Queue(request);
       if (status) {
-        EDGE_SDK_LOG_ERROR_F(kLogTag, "Queue failed - %s", status->c_str());
+        OLP_SDK_LOG_ERROR_F(kLogTag, "Queue failed - %s", status->c_str());
         return -1;
       }
     }
@@ -115,22 +115,22 @@ int RunExample() {
     auto future_response = client->Flush();
     auto responses = future_response.GetFuture().get();
     if (responses.empty()) {
-      EDGE_SDK_LOG_ERROR_F(kLogTag, "Error on Flush()");
+      OLP_SDK_LOG_ERROR_F(kLogTag, "Error on Flush()");
       return -1;
     }
 
     // Check all publishes succeeded
     for (auto response : responses) {
       if (!response.IsSuccessful()) {
-        EDGE_SDK_LOG_ERROR_F(
-            kLogTag, "Error flushing data - HTTP Status: %d Message: %s",
-            response.GetError().GetHttpStatusCode(),
-            response.GetError().GetMessage().c_str());
+        OLP_SDK_LOG_ERROR_F(kLogTag,
+                            "Error flushing data - HTTP Status: %d Message: %s",
+                            response.GetError().GetHttpStatusCode(),
+                            response.GetError().GetMessage().c_str());
         return -1;
       }
 
-      EDGE_SDK_LOG_INFO_F(kLogTag, "Flush Successful - TraceID: %s",
-                          response.GetResult().GetTraceID().c_str());
+      OLP_SDK_LOG_INFO_F(kLogTag, "Flush Successful - TraceID: %s",
+                         response.GetResult().GetTraceID().c_str());
     }
   }
 


### PR DESCRIPTION
Renamed logging macros in examples and docs from EDGE_SDK prefix to OLP_SDK

Relates to: OLPEDGE-650

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>