### PR TITLE
Renamed prefix of public CMake variables from EDGE_SDK to OLP_SDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,26 +34,26 @@ else()
 endif()
 
 # Options
-option(EDGE_SDK_ENABLE_TESTING "Flag to enable/disable building unit and integration tests" ON)
-option(EDGE_SDK_BUILD_DOC "Build SDK documentation" OFF)
-option(EDGE_SDK_NO_EXCEPTION "Turn off EXCEPTION" OFF)
-option(EDGE_SDK_BUILD_EXTERNAL_DEPS "Download and build external dependencies" ON)
-option(EDGE_SDK_BUILD_EXAMPLES "Enable examples targets" OFF)
-option(EDGE_SDK_MSVC_PARALLEL_BUILD_ENABLE "Enable parallel build on MSVC" ON)
+option(OLP_SDK_ENABLE_TESTING "Flag to enable/disable building unit and integration tests" ON)
+option(OLP_SDK_BUILD_DOC "Build SDK documentation" OFF)
+option(OLP_SDK_NO_EXCEPTION "Turn off EXCEPTION" OFF)
+option(OLP_SDK_BUILD_EXTERNAL_DEPS "Download and build external dependencies" ON)
+option(OLP_SDK_BUILD_EXAMPLES "Enable examples targets" OFF)
+option(OLP_SDK_MSVC_PARALLEL_BUILD_ENABLE "Enable parallel build on MSVC" ON)
 
 # C++ standard version. Minimum supported version is 11.
 set(CMAKE_CXX_STANDARD 11)
 
 # Set no exception
-if (EDGE_SDK_NO_EXCEPTION)
+if (OLP_SDK_NO_EXCEPTION)
     set(CMAKE_CXX_FLAGS "-fno-exceptions ${CMAKE_CXX_FLAGS}")
     set(CMAKE_C_FLAGS "-fno-exceptions ${CMAKE_C_FLAGS}")
 endif()
 
-if (MSVC AND EDGE_SDK_MSVC_PARALLEL_BUILD_ENABLE)
+if (MSVC AND OLP_SDK_MSVC_PARALLEL_BUILD_ENABLE)
     add_compile_options(/MP)
     message(STATUS "MSVC - Using parallel compilation (/MP)")
-endif (MSVC AND EDGE_SDK_MSVC_PARALLEL_BUILD_ENABLE)
+endif (MSVC AND OLP_SDK_MSVC_PARALLEL_BUILD_ENABLE)
 
 # Add cmake dir to search list
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
@@ -67,7 +67,7 @@ include(common)
 # Include code coverage variables
 include(coverage)
 
-if(EDGE_SDK_BUILD_EXTERNAL_DEPS)
+if(OLP_SDK_BUILD_EXTERNAL_DEPS)
     # Add third-party dependencies
     add_subdirectory(external)
 endif()
@@ -81,14 +81,14 @@ add_sdks()
 # Add docs
 add_subdirectory(docs)
 
-if(EDGE_SDK_ENABLE_TESTING)
+if(OLP_SDK_ENABLE_TESTING)
     # Add tests
     add_subdirectory(tests/functional)
     add_subdirectory(tests/integration)
 endif()
 
 # Add example
-if(EDGE_SDK_BUILD_EXAMPLES)
+if(OLP_SDK_BUILD_EXAMPLES)
     add_subdirectory(examples/dataservice-read)
     add_subdirectory(examples/dataservice-write)
 endif()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -308,7 +308,7 @@ A sample component CMake files would look like this:
 <br />// install component
 <br />**install** (FILES ${COMPONENT_INC} DESTINATION ${INCLUDE_DIRECTORY}/olp/component)
 <br />**export_config()**
-<br />  if(**EDGE_SDK_ENABLE_TESTING**)
+<br />  if(**OLP_SDK_ENABLE_TESTING**)
 <br />add_subdirectory(**test/unit**)
 <br />endif()
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The dependencies of the HERE OLP SDK for C++ are the following:
 
 [CMake](https://cmake.org/download/) is the main build system. The minimal required version of CMake is 3.5.
 
-CMake downloads [leveldb](https://github.com/google/leveldb), [snappy](https://github.com/google/snappy), [rapidjson](https://github.com/Tencent/rapidjson), and [Boost](https://www.boost.org/). This can be disabled by setting `EDGE_SDK_BUILD_EXTERNAL_DEPS` to `OFF`. For details on CMake flags, see [below](#cmake-flags).
+CMake downloads [leveldb](https://github.com/google/leveldb), [snappy](https://github.com/google/snappy), [rapidjson](https://github.com/Tencent/rapidjson), and [Boost](https://www.boost.org/). This can be disabled by setting `OLP_SDK_BUILD_EXTERNAL_DEPS` to `OFF`. For details on CMake flags, see [below](#cmake-flags).
 
 Optionally, if you want to build documentation from annotated source code, you need to install [Doxygen](http://www.doxygen.nl/).
 
@@ -93,11 +93,11 @@ cmake ..
 make
 ```
 
-To build the [Doxygen](http://www.doxygen.nl/) documentation, you need to have CMake version 3.9 or later, and set `EDGE_SDK_BUILD_DOC=ON` when running CMake configuration:
+To build the [Doxygen](http://www.doxygen.nl/) documentation, you need to have CMake version 3.9 or later, and set `OLP_SDK_BUILD_DOC=ON` when running CMake configuration:
 
 ```bash
 mkdir build && cd build
-cmake -DEDGE_SDK_BUILD_DOC=ON ..
+cmake -DOLP_SDK_BUILD_DOC=ON ..
 make docs
 ```
 
@@ -105,7 +105,7 @@ make docs
 
 By default this SDK downloads and compiles its dependencies. The versions of downloaded dependencies may conflict with versions already installed on your system, so they are not added to the install targets.
 
-Therefore, to install the HERE OLP SDK for C++, you must first install all its dependencies. Then you need to configure the SDK with `EDGE_SDK_BUILD_EXTERNAL_DEPS` set to `OFF` so that it finds required dependencies in the system.
+Therefore, to install the HERE OLP SDK for C++, you must first install all its dependencies. Then you need to configure the SDK with `OLP_SDK_BUILD_EXTERNAL_DEPS` set to `OFF` so that it finds required dependencies in the system.
 
 Another option is to build the SDK as a shared library, setting the `BUILD_SHARED_LIBS` flag to `ON`.
 
@@ -133,26 +133,26 @@ Using the provided CMake menu by the Visual C++ tools for CMake, generate the `.
 
 Defaults to `OFF`. If enabled, this causes all libraries to be built as shared.
 
-#### `EDGE_SDK_BUILD_DOC`
+#### `OLP_SDK_BUILD_DOC`
 
 Defaults to `OFF`. If enabled, the API reference is to be generated in your build directory.
 
 > **Note:**
 > This requires [Doxygen](http://www.doxygen.nl/) to be installed.
 
-#### `EDGE_SDK_ENABLE_TESTING`
+#### `OLP_SDK_ENABLE_TESTING`
 
 Defaults to `ON`. If enabled, unit tests are to be built for each library.
 
-#### `EDGE_SDK_BUILD_EXTERNAL_DEPS`
+#### `OLP_SDK_BUILD_EXTERNAL_DEPS`
 
 Defaults to `ON`. If enabled, CMake downloads and compiles dependencies.
 
-#### `EDGE_SDK_NO_EXCEPTION`
+#### `OLP_SDK_NO_EXCEPTION`
 
 Defaults to `OFF`. If enabled, this causes all libraries to be built without exceptions.
 
-#### `EDGE_SDK_MSVC_PARALLEL_BUILD_ENABLE` (Windows Only)
+#### `OLP_SDK_MSVC_PARALLEL_BUILD_ENABLE` (Windows Only)
 
 Defaults to `ON`. If enabled, this adds `/MP` compilation flag to build SDK using multiple cores.
 

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-if(NOT EDGE_SDK_BUILD_DOC)
+if(NOT OLP_SDK_BUILD_DOC)
     message(STATUS "Build SDK documentation disabled")
     return()
 endif()

--- a/docs/dataservice-read-catalog-example.md
+++ b/docs/dataservice-read-catalog-example.md
@@ -11,11 +11,11 @@ const std::string kKeySecret(""); // your here.access.key.secret
 
 ## Building and running on Linux
 
-Configure the project with `EDGE_SDK_BUILD_EXAMPLES` set to `ON` to enable examples `CMake` targets:
+Configure the project with `OLP_SDK_BUILD_EXAMPLES` set to `ON` to enable examples `CMake` targets:
 
 ```bash
 mkdir build && cd build
-cmake -DEDGE_SDK_BUILD_EXAMPLES=ON ..
+cmake -DOLP_SDK_BUILD_EXAMPLES=ON ..
 ```
 
 To build the example, run the following command in the `build` folder:
@@ -57,14 +57,14 @@ This example shows how to integrate the HERE OLP SDK for C++ libraries into the 
 
 Before you build the example, complete the following:
 
-* Configure the SDK with `EDGE_SDK_BUILD_EXAMPLES` set to `ON`.
-* Optionally, disable tests with `EDGE_SDK_ENABLE_TESTING` set to `OFF`.
+* Configure the SDK with `OLP_SDK_BUILD_EXAMPLES` set to `ON`.
+* Optionally, disable tests with `OLP_SDK_ENABLE_TESTING` set to `OFF`.
 * Specify the path to Android NDK's toolchain file set via the `CMAKE_TOOLCHAIN_FILE` variable.
 * In case you want to build SDK for a specific Android platform, use `-DANDROID_PLATFORM CMake` flag, and `-DANDROID_ABI`, if you want to build for specific Android architecture. For more details, see [NDK-specific CMake variables](https://developer.android.com/ndk/guides/cmake#variables).
 
 ```bash
 mkdir build && cd build
-cmake .. -DCMAKE_TOOLCHAIN_FILE=$NDK_ROOT/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a -DEDGE_SDK_BUILD_EXAMPLES=ON -DEDGE_SDK_ENABLE_TESTING=OFF
+cmake .. -DCMAKE_TOOLCHAIN_FILE=$NDK_ROOT/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a -DOLP_SDK_BUILD_EXAMPLES=ON -DOLP_SDK_ENABLE_TESTING=OFF
 ```
 
 The `CMake` command generates a `Gradle` project in the `build/examples/dataservice-read/android` folder. Before using the project, install the HERE OLP SDK for C++ libraries into the sysroot directory:
@@ -88,7 +88,7 @@ Alternatively, you can use Android Studio IDE by opening the `build/examples/dat
 
 After you provide your app access key id and secret access key, install and run `dataservice_read_example` APK, the main UI screen displays a message `Reading the partition data from the specified catalog completed successfully`. If you encounter an error, please check the device's logcat for the error message.
 
-> **Note:** you can run `CMake` command directly from the `<olp-sdk-root>/examples/dataservice-read/` folder if you have already built and installed HERE OLP SDK for C++ libraries for Android. Make sure you provide the correct path to the `LevelDB` library and `EDGE_SDK_NETWORK_PROTOCOL_JAR` parameter in the `CMake` command, invoked by the `build/examples/dataservice-read/android/app/build.gradle` script.
+> **Note:** you can run `CMake` command directly from the `<olp-sdk-root>/examples/dataservice-read/` folder if you have already built and installed HERE OLP SDK for C++ libraries for Android. Make sure you provide the correct path to the `LevelDB` library and `OLP_SDK_NETWORK_PROTOCOL_JAR` parameter in the `CMake` command, invoked by the `build/examples/dataservice-read/android/app/build.gradle` script.
 
 ## Building and running on iOS
 
@@ -104,13 +104,13 @@ This example shows how to integrate the HERE OLP SDK for C++ libraries into a ba
 
 Before you build the example, complete the following:
 
-* Configure the HERE OLP SDK for C++ with `EDGE_SDK_BUILD_EXAMPLES` set to `ON`.
-* Optionally, disable tests with `EDGE_SDK_ENABLE_TESTING` set to `OFF`.
+* Configure the HERE OLP SDK for C++ with `OLP_SDK_BUILD_EXAMPLES` set to `ON`.
+* Optionally, disable tests with `OLP_SDK_ENABLE_TESTING` set to `OFF`.
 * Specify the path to the iOS toolchain file shipped together with the SDK, located under the `<olp-sdk-root>/cmake/toolchains/iOS.cmake`:
 
 ```bash
 mkdir build && cd build
-cmake .. -GXcode  -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/iOS.cmake -DPLATFORM=iphoneos -DEDGE_SDK_BUILD_EXAMPLES=ON -DEDGE_SDK_ENABLE_TESTING=OFF
+cmake .. -GXcode  -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/iOS.cmake -DPLATFORM=iphoneos -DOLP_SDK_BUILD_EXAMPLES=ON -DOLP_SDK_ENABLE_TESTING=OFF
 ```
 
 > **Note:** to configure the HERE OLP SDK for C++ for a simulator, set the `SIMULATOR` variable to `ON`.

--- a/docs/dataservice-write-example.md
+++ b/docs/dataservice-write-example.md
@@ -13,11 +13,11 @@ const std::string gLayer("");            // layer name inside catalog to use
 
 ## Building and running on Linux
 
-Configure the project with `EDGE_SDK_BUILD_EXAMPLES` set to `ON` to enable examples `CMake` targets:
+Configure the project with `OLP_SDK_BUILD_EXAMPLES` set to `ON` to enable examples `CMake` targets:
 
 ```bash
 mkdir build && cd build
-cmake -DEDGE_SDK_BUILD_EXAMPLES=ON ..
+cmake -DOLP_SDK_BUILD_EXAMPLES=ON ..
 ```
 
 To build the example, run the following command in the `build` folder:
@@ -47,13 +47,13 @@ This example shows how to integrate and use the HERE OLP SDK for C++ for an Andr
 
 Before you build the example, complete the following:
 
-* Configure the SDK with `EDGE_SDK_BUILD_EXAMPLES` set to `ON`.
+* Configure the SDK with `OLP_SDK_BUILD_EXAMPLES` set to `ON`.
 * Specify the path to Android NDK's toolchain file set via the `CMAKE_TOOLCHAIN_FILE` variable.
 * In case you want to build SDK for a specific Android platform, use `-DANDROID_PLATFORM CMake` flag, and `-DANDROID_ABI`, if you want to build for specific Android architecture. For more details, see [NDK-specific CMake variables](https://developer.android.com/ndk/guides/cmake#variables).
 
 ```bash
 mkdir build && cd build
-cmake .. -DEDGE_SDK_BUILD_EXAMPLES=ON -DCMAKE_TOOLCHAIN_FILE=$NDK_ROOT/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a
+cmake .. -DOLP_SDK_BUILD_EXAMPLES=ON -DCMAKE_TOOLCHAIN_FILE=$NDK_ROOT/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a
 ```
 
 The `CMake` command generates a `Gradle` project in the `build/examples/dataservice-write/android` folder. Before using the project, install HERE OLP SDK for C++ libraries into the sysroot directory:
@@ -77,7 +77,7 @@ Alternatively, you can use Android Studio IDE by opening the `build/examples/dat
 
 After you provide your app access key id, secret access key, catalog, and layer information, install and run `dataservice_write_example` APK, the main UI screen displays a message `Publish Successful`. If you encounter an error, please check the device's logcat for the error message.
 
-> **Note:** you can run `CMake` command directly from the `<olp-sdk-root>/examples/dataservice-write/` folder if you have already built and installed HERE OLP SDK for C++ libraries for Android. Make sure you provide correct path to the `LevelDB` library, and correct `EDGE_SDK_HTTP_CLIENT_JAR` parameter in the `CMake` command, invoked by the `build/examples/dataservice-write/android/app/build.gradle` script.
+> **Note:** you can run `CMake` command directly from the `<olp-sdk-root>/examples/dataservice-write/` folder if you have already built and installed HERE OLP SDK for C++ libraries for Android. Make sure you provide correct path to the `LevelDB` library, and correct `OLP_SDK_HTTP_CLIENT_JAR` parameter in the `CMake` command, invoked by the `build/examples/dataservice-write/android/app/build.gradle` script.
 
 ## Building and running on iOS
 
@@ -93,13 +93,13 @@ This example shows how to integrate and use the HERE OLP SDK for C++ for a basic
 
 Before building the example, complete the following:
 
-* Configure the HERE OLP SDK for C++ with `EDGE_SDK_BUILD_EXAMPLES` set to `ON`.
-* Optionally, disable tests with `EDGE_SDK_ENABLE_TESTING` set to `OFF`.
+* Configure the HERE OLP SDK for C++ with `OLP_SDK_BUILD_EXAMPLES` set to `ON`.
+* Optionally, disable tests with `OLP_SDK_ENABLE_TESTING` set to `OFF`.
 * Specify the path to the iOS toolchain file shipped together with the SDK, which is located under the `<olp-sdk-root>/cmake/toolchains/iOS.cmake`:
 
 ```bash
 mkdir build && cd build
-cmake .. -GXcode  -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/iOS.cmake -DPLATFORM=iphoneos -DEDGE_SDK_BUILD_EXAMPLES=ON -DEDGE_SDK_ENABLE_TESTING=OFF
+cmake .. -GXcode  -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/iOS.cmake -DPLATFORM=iphoneos -DOLP_SDK_BUILD_EXAMPLES=ON -DOLP_SDK_ENABLE_TESTING=OFF
 ```
 
 > **Note:** to configure the HERE OLP SDK for C++ for a simulator, set the `SIMULATOR` variable to `ON`.

--- a/external/googletest/CMakeLists.txt
+++ b/external/googletest/CMakeLists.txt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-if(NOT EDGE_SDK_ENABLE_TESTING)
+if(NOT OLP_SDK_ENABLE_TESTING)
     return()
 endif()
 

--- a/olp-cpp-sdk-authentication/CMakeLists.txt
+++ b/olp-cpp-sdk-authentication/CMakeLists.txt
@@ -50,6 +50,6 @@ install (FILES ${AUTHENTICATION_INC} DESTINATION ${INCLUDE_DIRECTORY}/olp/authen
 
 export_config()
 
-if(EDGE_SDK_ENABLE_TESTING)
+if(OLP_SDK_ENABLE_TESTING)
     add_subdirectory(tests)
 endif()

--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -325,6 +325,6 @@ install (FILES ${GEOTYPE_HEADER} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/geo)
 
 export_config()
 
-if(EDGE_SDK_ENABLE_TESTING)
+if(OLP_SDK_ENABLE_TESTING)
     add_subdirectory(tests)
 endif()

--- a/olp-cpp-sdk-dataservice-read/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/CMakeLists.txt
@@ -55,7 +55,7 @@ install (FILES ${MODEL_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/dataservice
 
 export_config()
 
-if(EDGE_SDK_ENABLE_TESTING)
+if(OLP_SDK_ENABLE_TESTING)
     add_subdirectory(tests)
 endif()
 

--- a/olp-cpp-sdk-dataservice-write/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-write/CMakeLists.txt
@@ -50,6 +50,6 @@ install (FILES ${DATASERVICE_WRITE_MODEL_HEADERS} DESTINATION ${INCLUDE_DIRECTOR
 
 export_config()
 
-if(EDGE_SDK_ENABLE_TESTING)
+if(OLP_SDK_ENABLE_TESTING)
     add_subdirectory(tests)
 endif()

--- a/scripts/android/build.sh
+++ b/scripts/android/build.sh
@@ -4,8 +4,8 @@ mkdir -p build && cd build
 cmake .. -DCMAKE_TOOLCHAIN_FILE="$WORKSPACE/android-ndk-r20/build/cmake/android.toolchain.cmake" \
 	-DANDROID_PLATFORM=android-28 \
 	-DANDROID_ABI=arm64-v8a \
-	-DEDGE_SDK_ENABLE_TESTING=NO \
-	-DEDGE_SDK_BUILD_EXAMPLES=ON 
+	-DOLP_SDK_ENABLE_TESTING=NO \
+	-DOLP_SDK_BUILD_EXAMPLES=ON 
 
 #cmake --build .
 sudo make install -j16

--- a/scripts/ios/build.sh
+++ b/scripts/ios/build.sh
@@ -3,9 +3,9 @@ mkdir -p build && cd build
 cmake ../ -GXcode \
     -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/iOS.cmake \
     -DPLATFORM=iphoneos \
-    -DEDGE_SDK_ENABLE_TESTING=NO \
+    -DOLP_SDK_ENABLE_TESTING=NO \
     -DSIMULATOR=YES \
-    -DEDGE_SDK_BUILD_EXAMPLES=ON
+    -DOLP_SDK_BUILD_EXAMPLES=ON
 
 xcodebuild
 cd ..

--- a/scripts/linux/fv/gitlab_build_fv.sh
+++ b/scripts/linux/fv/gitlab_build_fv.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 mkdir -p build && cd build
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -EDGE_SDK_BUILD_EXAMPLES=ON -DEDGE_SDK_BUILD_DOC=ON -DBUILD_SHARED_LIBS=ON ..
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -OLP_SDK_BUILD_EXAMPLES=ON -DOLP_SDK_BUILD_DOC=ON -DBUILD_SHARED_LIBS=ON ..
 make -j8
 make docs
 cd ..

--- a/scripts/linux/psv/travis_build_psv.sh
+++ b/scripts/linux/psv/travis_build_psv.sh
@@ -2,7 +2,7 @@
 mkdir -p build
 cd build
 cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-    -EDGE_SDK_BUILD_EXAMPLES=ON \
+    -OLP_SDK_BUILD_EXAMPLES=ON \
     -DBUILD_SHARED_LIBS=ON \
     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
     ..

--- a/scripts/macos/psv/travis_build_psv.sh
+++ b/scripts/macos/psv/travis_build_psv.sh
@@ -2,7 +2,7 @@
 mkdir -p build
 cd build
 cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-    -EDGE_SDK_BUILD_EXAMPLES=ON \
+    -OLP_SDK_BUILD_EXAMPLES=ON \
     -DBUILD_SHARED_LIBS=ON \
     ..
 make -j

--- a/testutils/custom-params/CMakeLists.txt
+++ b/testutils/custom-params/CMakeLists.txt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-if(NOT EDGE_SDK_ENABLE_TESTING)
+if(NOT OLP_SDK_ENABLE_TESTING)
     return()
 endif()
 


### PR DESCRIPTION
Renamed prefix of all the public CMake variables, which are accessible for the user, from EDGE_SDK to OLP_SDK;

Relates to: OLPEDGE-650

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>