### PR TITLE
Fix incorrect path to server.js in functional tests script

### DIFF
--- a/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test.sh
+++ b/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 #Start local server
-node $REPO_HOME/tests/utils/server.js & export SERVER_PID=$!
+node $REPO_HOME/tests/utils/mock_server/server.js & export SERVER_PID=$!
 
 # Node can start server in 1 second, but not faster.
 # Add waiter for server to be started. No other way to solve that.


### PR DESCRIPTION
skip ci

Relates-To: OLPEDGE-716
Signed-off-by: Yaroslav Stefinko <ystefinko@intellias.com>