### PR TITLE
ApiClientLookupTest online mocks implementation

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/CancellationContext.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/CancellationContext.h
@@ -53,7 +53,7 @@ class CORE_API CancellationContext {
    * @deprecated Will be removed once TaskScheduler will be used.
    */
   void ExecuteOrCancelled(const ExecuteFuncType& execute_fn,
-                          const CancelFuncType& cancel_fn);
+                          const CancelFuncType& cancel_fn = nullptr);
 
   /**
    * @brief Allows the user to cancel an ongoing operation in a threadsafe way.

--- a/olp-cpp-sdk-core/include/olp/core/client/CancellationContext.inl
+++ b/olp-cpp-sdk-core/include/olp/core/client/CancellationContext.inl
@@ -34,8 +34,10 @@ inline void CancellationContext::ExecuteOrCancelled(
 
   std::lock_guard<std::recursive_mutex> lock(impl_->mutex_);
 
-  if (impl_->is_cancelled_ && cancel_fn) {
-    cancel_fn();
+  if (impl_->is_cancelled_) {
+    if (cancel_fn) {
+      cancel_fn();
+    }
     return;
   }
 

--- a/olp-cpp-sdk-core/include/olp/core/client/Condition.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/Condition.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <olp/core/client/CancellationContext.h>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+
+namespace olp {
+namespace client {
+
+/**
+ * @brief The Condition helper class allows to wait until the notification is
+ * called by a task or cancellation is performed by the user.
+ */
+class Condition final {
+ public:
+  Condition(olp::client::CancellationContext context,
+            std::chrono::milliseconds timeout = std::chrono::seconds(60))
+      : context_{context}, timeout_{timeout} {}
+
+  /**
+   * @brief Should be called by task's callback to notify \c Wait to unblock the
+   * routine.
+   */
+  void Notify() {
+    {
+      std::unique_lock<std::mutex> lock(mutex_);
+      signaled_ = true;
+    }
+    condition_.notify_one();
+  }
+
+  /**
+   * @brief Waits a task for a \c Notify or \c CancellationContext to be
+   * cancelled by the user.
+   */
+  bool Wait() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    bool triggered = condition_.wait_for(
+        lock, timeout_, [&] { return signaled_ || context_.IsCancelled(); });
+
+    signaled_ = false;
+    return triggered;
+  }
+
+ private:
+  olp::client::CancellationContext context_;
+  const std::chrono::milliseconds timeout_;
+  std::condition_variable condition_;
+  std::mutex mutex_;
+  bool signaled_{false};
+};
+
+}  // namespace client
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.h
+++ b/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.h
@@ -23,9 +23,11 @@
 
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>
+#include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClient.h>
 #include "generated/model/Api.h"
+#include "olp/dataservice/read/FetchOptions.h"
 
 namespace olp {
 namespace dataservice {
@@ -51,6 +53,12 @@ class ApiClientLookup {
       std::shared_ptr<client::OlpClient> client, const std::string& service,
       const std::string& service_version, const client::HRN& hrn,
       const ApiClientCallback& callback);
+
+  static ApiClientResponse LookupApi(
+      const client::HRN& catalog,
+      client::CancellationContext cancellation_context, std::string service,
+      std::string service_version, FetchOptions options,
+      client::OlpClientSettings settings);
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/tests/ApiClientLookupTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/ApiClientLookupTest.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gmock/gmock.h>
+#include <matchers/NetworkUrlMatchers.h>
+#include <mocks/CacheMock.h>
+#include <mocks/NetworkMock.h>
+#include "../src/ApiClientLookup.h"
+#include "HttpResponses.h"
+
+using namespace olp;
+using namespace client;
+using namespace dataservice::read;
+
+TEST(ApiClientLookup, LookupApiSync) {
+  using namespace testing;
+  using testing::Return;
+
+  auto cache = std::make_shared<testing::StrictMock<CacheMock>>();
+  auto network = std::make_shared<testing::StrictMock<NetworkMock>>();
+
+  OlpClientSettings settings;
+  settings.cache = cache;
+  settings.network_request_handler = network;
+
+  const std::string catalog = "hrn:here:data:::hereos-internal-test-v2";
+  const auto catalog_hrn = HRN::FromString(catalog);
+  const std::string service_name = "random_service";
+  const std::string service_url = "http://random_service.com";
+  const std::string service_version = "v8";
+  const std::string config_url =
+      "https://config.data.api.platform.in.here.com/config/v1";
+  const std::string cache_key =
+      catalog + "::" + service_name + "::" + service_version + "::api";
+  const std::string lookup_url =
+      "https://api-lookup.data.api.platform.here.com/lookup/v1/resources/" +
+      catalog + "/apis/" + service_name + "/" + service_version;
+
+  {
+    SCOPED_TRACE("Fetch from cache [CacheOnly] positive");
+    EXPECT_CALL(*cache, Get(cache_key, _))
+        .Times(1)
+        .WillOnce(Return(service_url));
+
+    client::CancellationContext context;
+    auto response = ApiClientLookup::LookupApi(
+        catalog_hrn, context, service_name, service_version,
+        FetchOptions::CacheOnly, settings);
+
+    EXPECT_TRUE(response.IsSuccessful());
+    EXPECT_EQ(response.GetResult().GetBaseUrl(), service_url);
+    Mock::VerifyAndClearExpectations(cache.get());
+  }
+  {
+    SCOPED_TRACE("Fetch from cache [CacheOnly] negative");
+    EXPECT_CALL(*cache, Get(cache_key, _))
+        .Times(1)
+        .WillOnce(Return(boost::any()));
+
+    client::CancellationContext context;
+    auto response = ApiClientLookup::LookupApi(
+        catalog_hrn, context, service_name, service_version,
+        FetchOptions::CacheOnly, settings);
+
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(), ErrorCode::NotFound);
+    Mock::VerifyAndClearExpectations(cache.get());
+  }
+  {
+    SCOPED_TRACE("Fetch from network");
+    EXPECT_CALL(*network, Send(IsGetRequest(lookup_url), _, _, _, _))
+        .Times(1)
+        .WillOnce(NetworkMock::ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(200),
+            HTTP_RESPONSE_LOOKUP_CONFIG));
+    EXPECT_CALL(*cache, Put(cache_key, _, _, _))
+        .Times(1)
+        .WillOnce(Return(true));
+
+    client::CancellationContext context;
+    auto response = ApiClientLookup::LookupApi(
+        catalog_hrn, context, service_name, service_version,
+        FetchOptions::OnlineOnly, settings);
+
+    EXPECT_TRUE(response.IsSuccessful());
+    EXPECT_EQ(response.GetResult().GetBaseUrl(), CONFIG_BASE_URL);
+    Mock::VerifyAndClearExpectations(network.get());
+  }
+  {
+      // SCOPED_TRACE("Network error propagated to the user");
+  } {
+      // SCOPED_TRACE("Network request cancelled by the user");
+  } {
+    // SCOPED_TRACE("Network error propagated to the user");
+  }
+}

--- a/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
@@ -19,6 +19,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 set(OLP_SDK_DATASERVICE_READ_TEST_SOURCES
+    ApiClientLookupTest.cpp
     CatalogClientTest.cpp
     HttpResponses.h
     MultiRequestContextTest.cpp
@@ -39,6 +40,7 @@ if (ANDROID OR IOS)
         gtest
         olp-cpp-sdk-authentication
         olp-cpp-sdk-dataservice-read
+        olp-cpp-sdk-tests-common
     )
 
     # For internal testing
@@ -76,6 +78,7 @@ else()
             gtest_main
             olp-cpp-sdk-authentication
             olp-cpp-sdk-dataservice-read
+            olp-cpp-sdk-tests-common
     )
 
     # For internal testing

--- a/olp-cpp-sdk-dataservice-read/tests/HttpResponses.h
+++ b/olp-cpp-sdk-dataservice-read/tests/HttpResponses.h
@@ -78,8 +78,11 @@
 #define URL_LOOKUP_VOLATILE_BLOB \
   R"(https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data:::hereos-internal-test-v2/apis/volatile-blob/v1)"
 
-#define HTTP_RESPONSE_LOOKUP_CONFIG \
-  R"jsonString([{"api":"config","version":"v1","baseURL":"https://config.data.api.platform.in.here.com/config/v1","parameters":{}},{"api":"pipelines","version":"v1","baseURL":"https://pipelines.api.platform.in.here.com/pipeline-service","parameters":{}},{"api":"pipelines","version":"v2","baseURL":"https://pipelines.api.platform.in.here.com/pipeline-service","parameters":{}}])jsonString"
+#define CONFIG_BASE_URL "https://config.data.api.platform.in.here.com/config/v1"
+
+#define HTTP_RESPONSE_LOOKUP_CONFIG                                                    \
+  R"jsonString([{"api":"config","version":"v1","baseURL":")jsonString" CONFIG_BASE_URL \
+  R"jsonString(","parameters":{}},{"api":"pipelines","version":"v1","baseURL":"https://pipelines.api.platform.in.here.com/pipeline-service","parameters":{}},{"api":"pipelines","version":"v2","baseURL":"https://pipelines.api.platform.in.here.com/pipeline-service","parameters":{}}])jsonString"
 
 #define HTTP_RESPONSE_LOOKUP_METADATA \
   R"jsonString([{"api":"metadata","version":"v1","baseURL":"https://metadata.data.api.platform.here.com/metadata/v1/catalogs/hereos-internal-test-v2","parameters":{}}])jsonString"


### PR DESCRIPTION
ApiClientLookup class now has a static LookupApi() method.
It is aimed to provide synchronous interface for querying lookup api.
ApiClientLookupTest introduced to test it.

Relates-to: OLPEDGE-832

Signed-off-by: Sergii Vostrikov <ext-sergii.vostrikov@here.com>
