### PR TITLE
Common tests mocks refactoring

### DIFF
--- a/olp-cpp-sdk-authentication/tests/AuthenticationOfflineTest.h
+++ b/olp-cpp-sdk-authentication/tests/AuthenticationOfflineTest.h
@@ -18,19 +18,7 @@
  */
 
 #include "AuthenticationBaseTest.h"
-
-class NetworkMock : public olp::http::Network {
- public:
-  MOCK_METHOD(olp::http::SendOutcome, Send,
-              (olp::http::NetworkRequest request,
-               olp::http::Network::Payload payload,
-               olp::http::Network::Callback callback,
-               olp::http::Network::HeaderCallback header_callback,
-               olp::http::Network::DataCallback data_callback),
-              (override));
-
-  MOCK_METHOD(void, Cancel, (olp::http::RequestId id), (override));
-};
+#include <mocks/NetworkMock.h>
 
 class AuthenticationOfflineTest : public AuthenticationBaseTest {
  public:

--- a/olp-cpp-sdk-authentication/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-authentication/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ if (ANDROID OR IOS)
     target_link_libraries(olp-cpp-sdk-authentication-tests-lib
     PRIVATE
         custom-params
+        olp-cpp-sdk-tests-common
         gmock
         gtest
         olp-cpp-sdk-authentication
@@ -87,6 +88,7 @@ else()
     target_link_libraries(olp-cpp-sdk-authentication-tests
         PRIVATE
             custom-params
+            olp-cpp-sdk-tests-common
             gmock
             gtest
             gtest_main

--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ if (ANDROID OR IOS)
     target_link_libraries(olp-cpp-sdk-core-tests-lib
         PRIVATE
             custom-params
+            olp-cpp-sdk-tests-common
             gmock
             gtest
             olp-cpp-sdk-core
@@ -78,6 +79,7 @@ else()
     target_link_libraries(olp-cpp-sdk-core-tests
         PRIVATE
             custom-params
+            olp-cpp-sdk-tests-common
             gmock
             gtest
             gtest_main

--- a/olp-cpp-sdk-core/tests/olpclient/OlpClientTest.cpp
+++ b/olp-cpp-sdk-core/tests/olpclient/OlpClientTest.cpp
@@ -19,31 +19,18 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-
+#include <matchers/NetworkUrlMatchers.h>
+#include <mocks/NetworkMock.h>
+#include <olp/core/client/OlpClient.h>
+#include <olp/core/client/OlpClientFactory.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
 #include <chrono>
 #include <future>
 #include <string>
 
-#include <olp/core/client/OlpClient.h>
-#include <olp/core/client/OlpClientFactory.h>
-#include <olp/core/client/OlpClientSettingsFactory.h>
-
 #include <olp/core/http/Network.h>
 
 using ::testing::_;
-
-class NetworkMock : public olp::http::Network {
- public:
-  MOCK_METHOD(olp::http::SendOutcome, Send,
-              (olp::http::NetworkRequest request,
-               olp::http::Network::Payload payload,
-               olp::http::Network::Callback callback,
-               olp::http::Network::HeaderCallback header_callback,
-               olp::http::Network::DataCallback data_callback),
-              (override));
-
-  MOCK_METHOD(void, Cancel, (olp::http::RequestId id), (override));
-};
 
 class OlpClientTest : public ::testing::Test {
  protected:

--- a/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ if (ANDROID OR IOS)
     target_link_libraries(olp-cpp-sdk-dataservice-read-tests-lib
     PRIVATE
         custom-params
+        olp-cpp-sdk-tests-common
         gmock
         gtest
         olp-cpp-sdk-authentication
@@ -73,6 +74,7 @@ else()
     target_link_libraries(olp-cpp-sdk-dataservice-read-tests
         PRIVATE
             custom-params
+            olp-cpp-sdk-tests-common
             gmock
             gtest
             gtest_main

--- a/olp-cpp-sdk-dataservice-read/tests/HttpResponses.h
+++ b/olp-cpp-sdk-dataservice-read/tests/HttpResponses.h
@@ -78,8 +78,11 @@
 #define URL_LOOKUP_VOLATILE_BLOB \
   R"(https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data:::hereos-internal-test-v2/apis/volatile-blob/v1)"
 
-#define HTTP_RESPONSE_LOOKUP_CONFIG \
-  R"jsonString([{"api":"config","version":"v1","baseURL":"https://config.data.api.platform.in.here.com/config/v1","parameters":{}},{"api":"pipelines","version":"v1","baseURL":"https://pipelines.api.platform.in.here.com/pipeline-service","parameters":{}},{"api":"pipelines","version":"v2","baseURL":"https://pipelines.api.platform.in.here.com/pipeline-service","parameters":{}}])jsonString"
+#define CONFIG_BASE_URL "https://config.data.api.platform.in.here.com/config/v1"
+
+#define HTTP_RESPONSE_LOOKUP_CONFIG                                                    \
+  R"jsonString([{"api":"config","version":"v1","baseURL":")jsonString" CONFIG_BASE_URL \
+  R"jsonString(","parameters":{}},{"api":"pipelines","version":"v1","baseURL":"https://pipelines.api.platform.in.here.com/pipeline-service","parameters":{}},{"api":"pipelines","version":"v2","baseURL":"https://pipelines.api.platform.in.here.com/pipeline-service","parameters":{}}])jsonString"
 
 #define HTTP_RESPONSE_LOOKUP_METADATA \
   R"jsonString([{"api":"metadata","version":"v1","baseURL":"https://metadata.data.api.platform.here.com/metadata/v1/catalogs/hereos-internal-test-v2","parameters":{}}])jsonString"

--- a/olp-cpp-sdk-dataservice-write/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-write/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ if (ANDROID OR IOS)
     target_link_libraries(olp-cpp-sdk-dataservice-write-tests-lib
     PRIVATE
         custom-params
+        olp-cpp-sdk-tests-common
         gmock
         gtest
         olp-cpp-sdk-authentication
@@ -98,6 +99,7 @@ else()
     target_link_libraries(olp-cpp-sdk-dataservice-write-tests
         PRIVATE
             custom-params
+            olp-cpp-sdk-tests-common
             gmock
             gtest
             gtest_main

--- a/olp-cpp-sdk-dataservice-write/tests/TestIndexLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/TestIndexLayerClient.cpp
@@ -18,6 +18,8 @@
  */
 
 #include <gmock/gmock.h>
+#include <matchers/NetworkUrlMatchers.h>
+#include <mocks/NetworkMock.h>
 #include <olp/authentication/TokenProvider.h>
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/HRN.h>
@@ -301,91 +303,6 @@ TEST_P(IndexLayerClientOnlineTest, PublishNoLayer) {
 
 using ::testing::_;
 
-namespace {
-
-MATCHER_P(IsGetRequest, url, "") {
-  // uri, verb, null body
-  return olp::http::NetworkRequest::HttpVerb::GET == arg.GetVerb() &&
-         url == arg.GetUrl() && (!arg.GetBody() || arg.GetBody()->empty());
-}
-
-MATCHER_P(IsPutRequest, url, "") {
-  return olp::http::NetworkRequest::HttpVerb::PUT == arg.GetVerb() &&
-         url == arg.GetUrl();
-}
-
-MATCHER_P(IsPutRequestPrefix, url, "") {
-  if (olp::http::NetworkRequest::HttpVerb::PUT != arg.GetVerb()) {
-    return false;
-  }
-
-  std::string url_string(url);
-  auto res =
-      std::mismatch(url_string.begin(), url_string.end(), arg.GetUrl().begin());
-
-  return (res.first == url_string.end());
-}
-
-MATCHER_P(IsPostRequest, url, "") {
-  return olp::http::NetworkRequest::HttpVerb::POST == arg.GetVerb() &&
-         url == arg.GetUrl();
-}
-
-MATCHER_P(IsDeleteRequest, url, "") {
-  return olp::http::NetworkRequest::HttpVerb::DEL == arg.GetVerb() &&
-         url == arg.GetUrl();
-}
-
-MATCHER_P(IsDeleteRequestPrefix, url, "") {
-  if (olp::http::NetworkRequest::HttpVerb::DEL != arg.GetVerb()) {
-    return false;
-  }
-
-  std::string url_string(url);
-  auto res =
-      std::mismatch(url_string.begin(), url_string.end(), arg.GetUrl().begin());
-
-  return (res.first == url_string.end());
-}
-
-class NetworkMock : public olp::http::Network {
- public:
-  MOCK_METHOD(olp::http::SendOutcome, Send,
-              (olp::http::NetworkRequest request,
-               olp::http::Network::Payload payload,
-               olp::http::Network::Callback callback,
-               olp::http::Network::HeaderCallback header_callback,
-               olp::http::Network::DataCallback data_callback),
-              (override));
-
-  MOCK_METHOD(void, Cancel, (olp::http::RequestId id), (override));
-};
-
-std::function<olp::http::SendOutcome(
-    olp::http::NetworkRequest request, olp::http::Network::Payload payload,
-    olp::http::Network::Callback callback,
-    olp::http::Network::HeaderCallback header_callback,
-    olp::http::Network::DataCallback data_callback)>
-ReturnHttpResponse(olp::http::NetworkResponse response,
-                   const std::string& response_body) {
-  return [=](olp::http::NetworkRequest request,
-             olp::http::Network::Payload payload,
-             olp::http::Network::Callback callback,
-             olp::http::Network::HeaderCallback header_callback,
-             olp::http::Network::DataCallback data_callback)
-             -> olp::http::SendOutcome {
-    std::thread([=]() {
-      *payload << response_body;
-      callback(response);
-    })
-        .detach();
-
-    return olp::http::SendOutcome(5);
-  };
-}
-
-}  // namespace
-
 class IndexLayerClientMockTest : public IndexLayerClientTestBase {
  protected:
   std::shared_ptr<NetworkMock> network_;
@@ -404,7 +321,8 @@ class IndexLayerClientMockTest : public IndexLayerClientTestBase {
     // Catch unexpected calls and fail immediatley
     ON_CALL(network, Send(_, _, _, _, _))
         .WillByDefault(testing::DoAll(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(-1), ""),
+            NetworkMock::ReturnHttpResponse(
+                olp::http::NetworkResponse().WithStatus(-1), ""),
             [](olp::http::NetworkRequest request,
                olp::http::Network::Payload payload,
                olp::http::Network::Callback callback,
@@ -415,41 +333,41 @@ class IndexLayerClientMockTest : public IndexLayerClientTestBase {
               return olp::http::SendOutcome(5);
             }));
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .WillByDefault(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                               HTTP_RESPONSE_LOOKUP_CONFIG));
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(200),
+            HTTP_RESPONSE_LOOKUP_CONFIG));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_INDEX), _, _, _, _))
-        .WillByDefault(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                               HTTP_RESPONSE_LOOKUP_INDEX));
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(200),
+            HTTP_RESPONSE_LOOKUP_INDEX));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
-        .WillByDefault(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                               HTTP_RESPONSE_LOOKUP_BLOB));
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(200),
+            HTTP_RESPONSE_LOOKUP_BLOB));
 
     ON_CALL(network, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
-        .WillByDefault(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                               HTTP_RESPONSE_GET_CATALOG));
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(200),
+            HTTP_RESPONSE_GET_CATALOG));
 
     ON_CALL(network,
             Send(IsPutRequestPrefix(URL_PUT_BLOB_INDEX_PREFIX), _, _, _, _))
-        .WillByDefault(ReturnHttpResponse(
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(200), ""));
 
     ON_CALL(network, Send(IsPostRequest(URL_INSERT_INDEX), _, _, _, _))
-        .WillByDefault(ReturnHttpResponse(
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(201), ""));
 
     ON_CALL(network, Send(IsDeleteRequestPrefix(URL_DELETE_BLOB_INDEX_PREFIX),
                           _, _, _, _))
-        .WillByDefault(ReturnHttpResponse(
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(200), ""));
 
     ON_CALL(network, Send(IsPutRequest(URL_INSERT_INDEX), _, _, _, _))
-        .WillByDefault(ReturnHttpResponse(
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(200), ""));
   }
 };

--- a/olp-cpp-sdk-dataservice-write/tests/TestStreamLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/TestStreamLayerClient.cpp
@@ -26,6 +26,8 @@
 #include <openssl/sha.h>
 #endif
 
+#include <matchers/NetworkUrlMatchers.h>
+#include <mocks/NetworkMock.h>
 #include <olp/authentication/TokenProvider.h>
 #include <olp/core/cache/DefaultCache.h>
 #include <olp/core/client/ApiError.h>
@@ -764,91 +766,6 @@ TEST_P(StreamLayerClientOnlineTest, SDIIConcurrentPublishSameIngestApi) {
   async5.get();
 }
 
-namespace {
-
-class NetworkMock : public olp::http::Network {
- public:
-  MOCK_METHOD(olp::http::SendOutcome, Send,
-              (olp::http::NetworkRequest request,
-               olp::http::Network::Payload payload,
-               olp::http::Network::Callback callback,
-               olp::http::Network::HeaderCallback header_callback,
-               olp::http::Network::DataCallback data_callback),
-              (override));
-
-  MOCK_METHOD(void, Cancel, (olp::http::RequestId id), (override));
-};
-
-std::function<olp::http::SendOutcome(
-    olp::http::NetworkRequest request, olp::http::Network::Payload payload,
-    olp::http::Network::Callback callback,
-    olp::http::Network::HeaderCallback header_callback,
-    olp::http::Network::DataCallback data_callback)>
-ReturnHttpResponse(olp::http::NetworkResponse response,
-                   const std::string& response_body) {
-  return [=](olp::http::NetworkRequest request,
-             olp::http::Network::Payload payload,
-             olp::http::Network::Callback callback,
-             olp::http::Network::HeaderCallback header_callback,
-             olp::http::Network::DataCallback data_callback)
-             -> olp::http::SendOutcome {
-    std::thread([=]() {
-      *payload << response_body;
-      callback(response);
-    })
-        .detach();
-
-    return olp::http::SendOutcome(5);
-  };
-}
-
-MATCHER_P(IsGetRequest, url, "") {
-  // uri, verb, null body
-  return olp::http::NetworkRequest::HttpVerb::GET == arg.GetVerb() &&
-         url == arg.GetUrl() && (!arg.GetBody() || arg.GetBody()->empty());
-}
-
-MATCHER_P(IsPutRequest, url, "") {
-  return olp::http::NetworkRequest::HttpVerb::PUT == arg.GetVerb() &&
-         url == arg.GetUrl();
-}
-
-MATCHER_P(IsPutRequestPrefix, url, "") {
-  if (olp::http::NetworkRequest::HttpVerb::PUT != arg.GetVerb()) {
-    return false;
-  }
-
-  std::string url_string(url);
-  auto res =
-      std::mismatch(url_string.begin(), url_string.end(), arg.GetUrl().begin());
-
-  return (res.first == url_string.end());
-}
-
-MATCHER_P(IsPostRequest, url, "") {
-  return olp::http::NetworkRequest::HttpVerb::POST == arg.GetVerb() &&
-         url == arg.GetUrl();
-}
-
-MATCHER_P(IsDeleteRequest, url, "") {
-  return olp::http::NetworkRequest::HttpVerb::DEL == arg.GetVerb() &&
-         url == arg.GetUrl();
-}
-
-MATCHER_P(IsDeleteRequestPrefix, url, "") {
-  if (olp::http::NetworkRequest::HttpVerb::DEL != arg.GetVerb()) {
-    return false;
-  }
-
-  std::string url_string(url);
-  auto res =
-      std::mismatch(url_string.begin(), url_string.end(), arg.GetUrl().begin());
-
-  return (res.first == url_string.end());
-}
-
-}  // namespace
-
 using testing::_;
 
 class StreamLayerClientMockTest : public StreamLayerClientTestBase {
@@ -875,7 +792,8 @@ class StreamLayerClientMockTest : public StreamLayerClientTestBase {
     // Catch unexpected calls and fail immediatley
     ON_CALL(network, Send(_, _, _, _, _))
         .WillByDefault(testing::DoAll(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(-1), ""),
+            NetworkMock::NetworkMock::ReturnHttpResponse(
+                olp::http::NetworkResponse().WithStatus(-1), ""),
             [](olp::http::NetworkRequest request,
                olp::http::Network::Payload payload,
                olp::http::Network::Callback callback,
@@ -887,68 +805,68 @@ class StreamLayerClientMockTest : public StreamLayerClientTestBase {
             }));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_INGEST), _, _, _, _))
-        .WillByDefault(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                               HTTP_RESPONSE_LOOKUP_INGEST));
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(200),
+            HTTP_RESPONSE_LOOKUP_INGEST));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .WillByDefault(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                               HTTP_RESPONSE_LOOKUP_CONFIG));
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(200),
+            HTTP_RESPONSE_LOOKUP_CONFIG));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_PUBLISH_V2), _, _, _, _))
-        .WillByDefault(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                               HTTP_RESPONSE_LOOKUP_PUBLISH_V2));
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(200),
+            HTTP_RESPONSE_LOOKUP_PUBLISH_V2));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
-        .WillByDefault(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                               HTTP_RESPONSE_LOOKUP_BLOB));
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(200),
+            HTTP_RESPONSE_LOOKUP_BLOB));
 
     ON_CALL(network,
             Send(testing::AnyOf(IsGetRequest(URL_GET_CATALOG),
                                 IsGetRequest(URL_GET_CATALOG_BILLING_TAG)),
                  _, _, _, _))
-        .WillByDefault(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                               HTTP_RESPONSE_GET_CATALOG));
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(200),
+            HTTP_RESPONSE_GET_CATALOG));
 
     ON_CALL(network,
             Send(testing::AnyOf(IsPostRequest(URL_INGEST_DATA),
                                 IsPostRequest(URL_INGEST_DATA_BILLING_TAG)),
                  _, _, _, _))
-        .WillByDefault(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                               HTTP_RESPONSE_INGEST_DATA));
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(200),
+            HTTP_RESPONSE_INGEST_DATA));
 
     ON_CALL(network, Send(IsPostRequest(URL_INGEST_DATA_LAYER_2), _, _, _, _))
-        .WillByDefault(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                               HTTP_RESPONSE_INGEST_DATA_LAYER_2));
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(200),
+            HTTP_RESPONSE_INGEST_DATA_LAYER_2));
 
     ON_CALL(network, Send(IsPostRequest(URL_INIT_PUBLICATION), _, _, _, _))
-        .WillByDefault(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                               HTTP_RESPONSE_INIT_PUBLICATION));
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(200),
+            HTTP_RESPONSE_INIT_PUBLICATION));
 
     ON_CALL(network, Send(IsPutRequestPrefix(URL_PUT_BLOB_PREFIX), _, _, _, _))
-        .WillByDefault(ReturnHttpResponse(
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(200), ""));
 
     ON_CALL(network, Send(testing::AnyOf(IsPostRequest(URL_UPLOAD_PARTITIONS),
                                          IsPutRequest(URL_SUBMIT_PUBLICATION)),
                           _, _, _, _))
-        .WillByDefault(ReturnHttpResponse(
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(204), ""));
 
     ON_CALL(network,
             Send(testing::AnyOf(IsPostRequest(URL_INGEST_SDII),
                                 IsPostRequest(URL_INGEST_SDII_BILLING_TAG)),
                  _, _, _, _))
-        .WillByDefault(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                               HTTP_RESPONSE_INGEST_SDII));
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(200),
+            HTTP_RESPONSE_INGEST_SDII));
   }
 };
 

--- a/olp-cpp-sdk-dataservice-write/tests/TestVolatileLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/TestVolatileLayerClient.cpp
@@ -18,6 +18,8 @@
  */
 
 #include <gmock/gmock.h>
+#include <matchers/NetworkUrlMatchers.h>
+#include <mocks/NetworkMock.h>
 #include <olp/authentication/TokenProvider.h>
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/HRN.h>
@@ -464,79 +466,6 @@ olp::client::NetworkAsyncHandler volatileSetsPromiseWaitsAndReturns(
 }
 #endif
 
-namespace {
-
-class NetworkMock : public olp::http::Network {
- public:
-  MOCK_METHOD(olp::http::SendOutcome, Send,
-              (olp::http::NetworkRequest request,
-               olp::http::Network::Payload payload,
-               olp::http::Network::Callback callback,
-               olp::http::Network::HeaderCallback header_callback,
-               olp::http::Network::DataCallback data_callback),
-              (override));
-
-  MOCK_METHOD(void, Cancel, (olp::http::RequestId id), (override));
-};
-
-std::function<olp::http::SendOutcome(
-    olp::http::NetworkRequest request, olp::http::Network::Payload payload,
-    olp::http::Network::Callback callback,
-    olp::http::Network::HeaderCallback header_callback,
-    olp::http::Network::DataCallback data_callback)>
-ReturnHttpResponse(olp::http::NetworkResponse response,
-                   const std::string& response_body) {
-  return [=](olp::http::NetworkRequest request,
-             olp::http::Network::Payload payload,
-             olp::http::Network::Callback callback,
-             olp::http::Network::HeaderCallback header_callback,
-             olp::http::Network::DataCallback data_callback)
-             -> olp::http::SendOutcome {
-    std::thread([=]() {
-      *payload << response_body;
-      callback(response);
-    })
-        .detach();
-
-    return olp::http::SendOutcome(5);
-  };
-}
-
-MATCHER_P(IsGetRequest, url, "") {
-  // uri, verb, null body
-  return olp::http::NetworkRequest::HttpVerb::GET == arg.GetVerb() &&
-         url == arg.GetUrl() && (!arg.GetBody() || arg.GetBody()->empty());
-}
-
-MATCHER_P(IsPutRequest, url, "") {
-  return olp::http::NetworkRequest::HttpVerb::PUT == arg.GetVerb() &&
-         url == arg.GetUrl();
-}
-
-MATCHER_P(IsPutRequestPrefix, url, "") {
-  if (olp::http::NetworkRequest::HttpVerb::PUT != arg.GetVerb()) {
-    return false;
-  }
-
-  std::string url_string(url);
-  auto res =
-      std::mismatch(url_string.begin(), url_string.end(), arg.GetUrl().begin());
-
-  return (res.first == url_string.end());
-}
-
-MATCHER_P(IsPostRequest, url, "") {
-  return olp::http::NetworkRequest::HttpVerb::POST == arg.GetVerb() &&
-         url == arg.GetUrl();
-}
-
-MATCHER_P(IsDeleteRequest, url, "") {
-  return olp::http::NetworkRequest::HttpVerb::DEL == arg.GetVerb() &&
-         url == arg.GetUrl();
-}
-
-}  // namespace
-
 using testing::_;
 
 class VolatileLayerClientMockTest : public VolatileLayerClientTestBase {
@@ -562,7 +491,8 @@ class VolatileLayerClientMockTest : public VolatileLayerClientTestBase {
     // Catch unexpected calls and fail immediatley
     ON_CALL(network, Send(_, _, _, _, _))
         .WillByDefault(testing::DoAll(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(-1), ""),
+            NetworkMock::ReturnHttpResponse(
+                olp::http::NetworkResponse().WithStatus(-1), ""),
             [](olp::http::NetworkRequest request,
                olp::http::Network::Payload payload,
                olp::http::Network::Callback callback,
@@ -574,43 +504,43 @@ class VolatileLayerClientMockTest : public VolatileLayerClientTestBase {
             }));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .WillByDefault(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                               HTTP_RESPONSE_LOOKUP_CONFIG));
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(200),
+            HTTP_RESPONSE_LOOKUP_CONFIG));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_METADATA), _, _, _, _))
-        .WillByDefault(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                               HTTP_RESPONSE_LOOKUP_METADATA));
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(200),
+            HTTP_RESPONSE_LOOKUP_METADATA));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_VOLATILE_BLOB), _, _, _, _))
-        .WillByDefault(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                               HTTP_RESPONSE_LOOKUP_VOLATILE_BLOB));
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(200),
+            HTTP_RESPONSE_LOOKUP_VOLATILE_BLOB));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_QUERY), _, _, _, _))
-        .WillByDefault(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                               HTTP_RESPONSE_LOOKUP_QUERY));
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(200),
+            HTTP_RESPONSE_LOOKUP_QUERY));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_PUBLISH_V2), _, _, _, _))
-        .WillByDefault(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                               HTTP_RESPONSE_LOOKUP_PUBLISH_V2));
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(200),
+            HTTP_RESPONSE_LOOKUP_PUBLISH_V2));
 
     ON_CALL(network, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
-        .WillByDefault(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                               HTTP_RESPONSE_GET_CATALOG));
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(200),
+            HTTP_RESPONSE_GET_CATALOG));
 
     ON_CALL(network, Send(IsGetRequest(URL_QUERY_PARTITION_1111), _, _, _, _))
-        .WillByDefault(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                               HTTP_RESPONSE_QUERY_DATA_HANDLE));
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(200),
+            HTTP_RESPONSE_QUERY_DATA_HANDLE));
 
     ON_CALL(network,
             Send(IsPutRequestPrefix(URL_PUT_VOLATILE_BLOB_PREFIX), _, _, _, _))
-        .WillByDefault(ReturnHttpResponse(
+        .WillByDefault(NetworkMock::ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(200), ""));
   }
 };
@@ -706,8 +636,9 @@ TEST_P(VolatileLayerClientMockTest, PublishDataCancelBlob) {
   NetworkCallback send_mock;
   CancelCallback cancel_mock;
 
-  std::tie(request_id, send_mock, cancel_mock) = generateNetworkMocks(
-      wait_for_cancel, pause_for_cancel, {200, HTTP_RESPONSE_LOOKUP_VOLATILE_BLOB});
+  std::tie(request_id, send_mock, cancel_mock) =
+      generateNetworkMocks(wait_for_cancel, pause_for_cancel,
+                           {200, HTTP_RESPONSE_LOOKUP_VOLATILE_BLOB});
 
   {
     testing::InSequence s;

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -18,7 +18,9 @@
 cmake_minimum_required(VERSION 3.5)
 
 set(OLP_SDK_TESTS_COMMON_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/matchers/NetworkUrlMatchers.h
     ${CMAKE_CURRENT_SOURCE_DIR}/mocks/NetworkMock.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/mocks/CacheMock.h
 )
 
 set(OLP_SDK_TESTS_COMMON_SOURCES

--- a/tests/common/matchers/NetworkUrlMatchers.h
+++ b/tests/common/matchers/NetworkUrlMatchers.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <gmock/gmock.h>
+#include <olp/core/http/NetworkRequest.h>
+
+MATCHER_P(IsGetRequest, url, "") {
+  // uri, verb, null body
+  return olp::http::NetworkRequest::HttpVerb::GET == arg.GetVerb() &&
+         url == arg.GetUrl() && (!arg.GetBody() || arg.GetBody()->empty());
+}
+
+MATCHER_P(IsPutRequest, url, "") {
+  return olp::http::NetworkRequest::HttpVerb::PUT == arg.GetVerb() &&
+         url == arg.GetUrl();
+}
+
+MATCHER_P(IsPutRequestPrefix, url, "") {
+  if (olp::http::NetworkRequest::HttpVerb::PUT != arg.GetVerb()) {
+    return false;
+  }
+
+  std::string url_string(url);
+  auto res =
+      std::mismatch(url_string.begin(), url_string.end(), arg.GetUrl().begin());
+
+  return (res.first == url_string.end());
+}
+
+MATCHER_P(IsPostRequest, url, "") {
+  return olp::http::NetworkRequest::HttpVerb::POST == arg.GetVerb() &&
+         url == arg.GetUrl();
+}
+
+MATCHER_P(IsDeleteRequest, url, "") {
+  return olp::http::NetworkRequest::HttpVerb::DEL == arg.GetVerb() &&
+         url == arg.GetUrl();
+}
+
+MATCHER_P(IsDeleteRequestPrefix, url, "") {
+  if (olp::http::NetworkRequest::HttpVerb::DEL != arg.GetVerb()) {
+    return false;
+  }
+
+  std::string url_string(url);
+  auto res =
+      std::mismatch(url_string.begin(), url_string.end(), arg.GetUrl().begin());
+
+  return (res.first == url_string.end());
+}

--- a/tests/common/mocks/CacheMock.h
+++ b/tests/common/mocks/CacheMock.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <gmock/gmock.h>
+#include "olp/core/cache/KeyValueCache.h"
+
+class CacheMock : public olp::cache::KeyValueCache {
+ public:
+  MOCK_METHOD(bool, Put,
+              (const std::string&, const boost::any&,
+               const olp::cache::Encoder&, time_t),
+              (override));
+
+  MOCK_METHOD(bool, Put,
+              (const std::string&,
+               const std::shared_ptr<std::vector<unsigned char>>,
+               time_t expiry),
+              (override));
+
+  MOCK_METHOD(boost::any, Get, (const std::string&, const olp::cache::Decoder&),
+              (override));
+
+  MOCK_METHOD(std::shared_ptr<std::vector<unsigned char>>, Get,
+              (const std::string&), (override));
+
+  MOCK_METHOD(bool, Remove, (const std::string&), (override));
+
+  MOCK_METHOD(bool, RemoveKeysWithPrefix, (const std::string&), (override));
+};

--- a/tests/common/mocks/NetworkMock.cpp
+++ b/tests/common/mocks/NetworkMock.cpp
@@ -22,3 +22,27 @@
 NetworkMock::NetworkMock() {}
 
 NetworkMock::~NetworkMock() {}
+
+std::function<olp::http::SendOutcome(
+    olp::http::NetworkRequest request, olp::http::Network::Payload payload,
+    olp::http::Network::Callback callback,
+    olp::http::Network::HeaderCallback header_callback,
+    olp::http::Network::DataCallback data_callback)>
+NetworkMock::ReturnHttpResponse(olp::http::NetworkResponse response,
+                                const std::string& response_body) {
+  return [=](olp::http::NetworkRequest request,
+             olp::http::Network::Payload payload,
+             olp::http::Network::Callback callback,
+             olp::http::Network::HeaderCallback header_callback,
+             olp::http::Network::DataCallback data_callback)
+             -> olp::http::SendOutcome {
+    std::thread([=]() {
+      *payload << response_body;
+      callback(response);
+    })
+        .detach();
+
+    constexpr auto unused_request_id = 5;
+    return olp::http::SendOutcome(unused_request_id);
+  };
+}

--- a/tests/common/mocks/NetworkMock.h
+++ b/tests/common/mocks/NetworkMock.h
@@ -20,13 +20,14 @@
 #pragma once
 
 #include <gmock/gmock.h>
+#include <thread>
 
 #include <olp/core/http/Network.h>
 
 class NetworkMock : public olp::http::Network {
  public:
   NetworkMock();
-  virtual ~NetworkMock();
+  ~NetworkMock() override;
 
   MOCK_METHOD(olp::http::SendOutcome, Send,
               (olp::http::NetworkRequest request,
@@ -37,4 +38,12 @@ class NetworkMock : public olp::http::Network {
               (override));
 
   MOCK_METHOD(void, Cancel, (olp::http::RequestId id), (override));
+
+  static std::function<olp::http::SendOutcome(
+      olp::http::NetworkRequest request, olp::http::Network::Payload payload,
+      olp::http::Network::Callback callback,
+      olp::http::Network::HeaderCallback header_callback,
+      olp::http::Network::DataCallback data_callback)>
+  ReturnHttpResponse(olp::http::NetworkResponse response,
+                     const std::string& response_body);
 };


### PR DESCRIPTION
Network and Cache mocks moved to tests/common
IsGetRequest matcher moved from inline definition to a dedicated place

Relates-to: OLPEDGE-768

Signed-off-by: Sergii Vostrikov <ext-sergii.vostrikov@here.com>