### PR TITLE
Common tests mocks refactoring

### DIFF
--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -18,10 +18,13 @@
 cmake_minimum_required(VERSION 3.5)
 
 set(OLP_SDK_TESTS_COMMON_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/matchers/NetworkUrlMatchers.h
     ${CMAKE_CURRENT_SOURCE_DIR}/mocks/NetworkMock.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/mocks/CacheMock.h
 )
 
 set(OLP_SDK_TESTS_COMMON_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/mocks/CacheMock.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mocks/NetworkMock.cpp
 )
 

--- a/tests/common/matchers/NetworkUrlMatchers.h
+++ b/tests/common/matchers/NetworkUrlMatchers.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <olp/core/http/NetworkRequest.h>
+
+MATCHER_P(IsGetRequest, url, "") {
+  // uri, verb, null body
+  return olp::http::NetworkRequest::HttpVerb::GET == arg.GetVerb() &&
+         url == arg.GetUrl() && (!arg.GetBody() || arg.GetBody()->empty());
+}
+
+MATCHER_P(IsPutRequest, url, "") {
+  return olp::http::NetworkRequest::HttpVerb::PUT == arg.GetVerb() &&
+         url == arg.GetUrl();
+}
+
+MATCHER_P(IsPutRequestPrefix, url, "") {
+  if (olp::http::NetworkRequest::HttpVerb::PUT != arg.GetVerb()) {
+    return false;
+  }
+
+  std::string url_string(url);
+  auto res =
+      std::mismatch(url_string.begin(), url_string.end(), arg.GetUrl().begin());
+
+  return (res.first == url_string.end());
+}
+
+MATCHER_P(IsPostRequest, url, "") {
+  return olp::http::NetworkRequest::HttpVerb::POST == arg.GetVerb() &&
+         url == arg.GetUrl();
+}
+
+MATCHER_P(IsDeleteRequest, url, "") {
+  return olp::http::NetworkRequest::HttpVerb::DEL == arg.GetVerb() &&
+         url == arg.GetUrl();
+}
+
+MATCHER_P(IsDeleteRequestPrefix, url, "") {
+  if (olp::http::NetworkRequest::HttpVerb::DEL != arg.GetVerb()) {
+    return false;
+  }
+
+  std::string url_string(url);
+  auto res =
+      std::mismatch(url_string.begin(), url_string.end(), arg.GetUrl().begin());
+
+  return (res.first == url_string.end());
+}

--- a/tests/common/mocks/CacheMock.cpp
+++ b/tests/common/mocks/CacheMock.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "CacheMock.h"
+
+CacheMock::CacheMock() = default;
+
+CacheMock::~CacheMock() = default;

--- a/tests/common/mocks/CacheMock.h
+++ b/tests/common/mocks/CacheMock.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <gmock/gmock.h>
+#include <olp/core/cache/KeyValueCache.h>
+
+class CacheMock : public olp::cache::KeyValueCache {
+ public:
+  CacheMock();
+
+  ~CacheMock() override;
+
+  MOCK_METHOD(bool, Put,
+              (const std::string&, const boost::any&,
+               const olp::cache::Encoder&, time_t),
+              (override));
+
+  MOCK_METHOD(bool, Put,
+              (const std::string&,
+               const std::shared_ptr<std::vector<unsigned char>>,
+               time_t expiry),
+              (override));
+
+  MOCK_METHOD(boost::any, Get, (const std::string&, const olp::cache::Decoder&),
+              (override));
+
+  MOCK_METHOD(std::shared_ptr<std::vector<unsigned char>>, Get,
+              (const std::string&), (override));
+
+  MOCK_METHOD(bool, Remove, (const std::string&), (override));
+
+  MOCK_METHOD(bool, RemoveKeysWithPrefix, (const std::string&), (override));
+};

--- a/tests/common/mocks/NetworkMock.cpp
+++ b/tests/common/mocks/NetworkMock.cpp
@@ -19,6 +19,32 @@
 
 #include "NetworkMock.h"
 
-NetworkMock::NetworkMock() {}
+#include <thread>
 
-NetworkMock::~NetworkMock() {}
+NetworkMock::NetworkMock() = default;
+
+NetworkMock::~NetworkMock() = default;
+
+std::function<olp::http::SendOutcome(
+    olp::http::NetworkRequest request, olp::http::Network::Payload payload,
+    olp::http::Network::Callback callback,
+    olp::http::Network::HeaderCallback header_callback,
+    olp::http::Network::DataCallback data_callback)>
+NetworkMock::ReturnHttpResponse(olp::http::NetworkResponse response,
+                                const std::string& response_body) {
+  return [=](olp::http::NetworkRequest request,
+             olp::http::Network::Payload payload,
+             olp::http::Network::Callback callback,
+             olp::http::Network::HeaderCallback header_callback,
+             olp::http::Network::DataCallback data_callback)
+             -> olp::http::SendOutcome {
+    std::thread([=]() {
+      *payload << response_body;
+      callback(response);
+    })
+        .detach();
+
+    constexpr auto unused_request_id = 5;
+    return olp::http::SendOutcome(unused_request_id);
+  };
+}

--- a/tests/common/mocks/NetworkMock.h
+++ b/tests/common/mocks/NetworkMock.h
@@ -20,13 +20,13 @@
 #pragma once
 
 #include <gmock/gmock.h>
-
 #include <olp/core/http/Network.h>
 
 class NetworkMock : public olp::http::Network {
  public:
   NetworkMock();
-  virtual ~NetworkMock();
+
+  ~NetworkMock() override;
 
   MOCK_METHOD(olp::http::SendOutcome, Send,
               (olp::http::NetworkRequest request,
@@ -37,4 +37,12 @@ class NetworkMock : public olp::http::Network {
               (override));
 
   MOCK_METHOD(void, Cancel, (olp::http::RequestId id), (override));
+
+  static std::function<olp::http::SendOutcome(
+      olp::http::NetworkRequest request, olp::http::Network::Payload payload,
+      olp::http::Network::Callback callback,
+      olp::http::Network::HeaderCallback header_callback,
+      olp::http::Network::DataCallback data_callback)>
+  ReturnHttpResponse(olp::http::NetworkResponse response,
+                     const std::string& response_body);
 };


### PR DESCRIPTION
Network and Cache mocks moved to tests/common
IsGetRequest matcher moved from inline definition to a dedicated place

Relates-to: OLPEDGE-768

Signed-off-by: Sergii Vostrikov <ext-sergii.vostrikov@here.com>