### PR TITLE
Copy authentication functional tests to <root>/tests folder

### DIFF
--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -22,10 +22,27 @@ set(OLP_SDK_FUNCTIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-core/OlpClientDefaultAsyncHttpTest.cpp
     ./olp-cpp-sdk-dataservice-read/ApiTest.cpp
     ./olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
+    ./olp-cpp-sdk-authentication/ArcGisAuthenticationTest.cpp
+    ./olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.cpp
+    ./olp-cpp-sdk-authentication/AuthenticationTestUtils.cpp
+    ./olp-cpp-sdk-authentication/AuthenticationFunctionalTest.cpp
+    ./olp-cpp-sdk-authentication/AuthenticationProductionTest.cpp
+    ./olp-cpp-sdk-authentication/FacebookAuthenticationTest.cpp
+    ./olp-cpp-sdk-authentication/GoogleAuthenticationTest.cpp
+)
+
+set(OLP_SDK_FUNCTIONAL_TESTS_HEADERS
+    ./olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.h
+    ./olp-cpp-sdk-authentication/AuthenticationTestUtils.h
+    ./olp-cpp-sdk-authentication/ErrorCodes.h
+    ./olp-cpp-sdk-authentication/ErrorMessages.h
+    ./olp-cpp-sdk-authentication/TestConstants.h
 )
 
 if (ANDROID OR IOS)
-    add_library(olp-cpp-sdk-functional-tests-lib ${OLP_SDK_FUNCTIONAL_TESTS_SOURCES})
+    add_library(olp-cpp-sdk-functional-tests-lib
+        ${OLP_SDK_FUNCTIONAL_TESTS_SOURCES}
+        ${OLP_SDK_FUNCTIONAL_TESTS_HEADERS})
     target_include_directories(olp-cpp-sdk-functional-lib
         PRIVATE
             ${PROJECT_SOURCE_DIR}/olp-cpp-sdk-dataservice-read/src
@@ -55,7 +72,9 @@ if (ANDROID OR IOS)
     endif()
 
 else()
-    add_executable(olp-cpp-sdk-functional-tests ${OLP_SDK_FUNCTIONAL_TESTS_SOURCES})
+    add_executable(olp-cpp-sdk-functional-tests
+        ${OLP_SDK_FUNCTIONAL_TESTS_SOURCES}
+        ${OLP_SDK_FUNCTIONAL_TESTS_HEADERS})
     target_include_directories(olp-cpp-sdk-functional-tests
     PRIVATE
         ${PROJECT_SOURCE_DIR}/olp-cpp-sdk-dataservice-read/src

--- a/tests/functional/olp-cpp-sdk-authentication/ArcGisAuthenticationTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/ArcGisAuthenticationTest.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <olp/core/http/HttpStatusCode.h>
+#include <olp/core/logging/Log.h>
+#include <olp/core/porting/make_unique.h>
+#include "AuthenticationCommonTestFixture.h"
+#include "AuthenticationTestUtils.h"
+#include "ErrorCodes.h"
+#include "ErrorMessages.h"
+#include "TestConstants.h"
+
+namespace {
+constexpr auto kErrorArcGisFailedCode = 400300;
+
+const std::string kErrorArcGisFailedMessage = "Invalid token.";
+
+}  // namespace
+
+using namespace ::olp::authentication;
+
+class ArcGisAuthenticationTest : public AuthenticationCommonTestFixture {
+ protected:
+  void SetUp() override {
+    AuthenticationCommonTestFixture::SetUp();
+
+    ASSERT_TRUE(AuthenticationTestUtils::GetArcGisAccessToken(
+        *network_, olp::http::NetworkSettings(), token_));
+  }
+
+  void TearDown() override {
+    token_ = AccessTokenOutcome{};
+
+    AuthenticationCommonTestFixture::TearDown();
+  }
+
+  AuthenticationClient::SignInUserResponse SignInArcGis(
+      const std::string& email, const std::string& token = "") {
+    AuthenticationCredentials credentials(GetAppKey(), GetAppSecretKey());
+    std::promise<AuthenticationClient::SignInUserResponse> request;
+    auto request_future = request.get_future();
+    AuthenticationClient::FederatedProperties properties;
+    properties.access_token = token.empty() ? token_.access_token : token;
+    properties.country_code = "usa";
+    properties.language = "en";
+    properties.email = email;
+    client_->SignInArcGis(
+        credentials, properties,
+        [&](const AuthenticationClient::SignInUserResponse& response) {
+          request.set_value(response);
+        });
+    request_future.wait();
+    return request_future.get();
+  }
+
+  std::string GetAppKey() const override { return kTestAppKeyId; }
+
+  std::string GetAppSecretKey() const override { return kTestAppKeySecret; }
+
+ protected:
+  AccessTokenOutcome token_;
+};
+
+// The ArcGIS refresh token will eventually expire. This requires a manual
+// update of ARCGIS_TEST_accessToken in ArcGisTestUtils.cpp
+TEST_F(ArcGisAuthenticationTest, SignInArcGis) {
+  const std::string email = GetEmail();
+  OLP_SDK_LOG_TRACE("ArcGisAuthenticationTest",
+                    "Running test with e-mail=" << email);
+
+  AuthenticationClient::SignInUserResponse response = SignInArcGis(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::CREATED,
+            response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorPreconditionCreatedCode,
+            response.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorPreconditionCreatedMessage,
+            response.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response.GetResult().GetUserIdentifier().empty());
+  EXPECT_FALSE(response.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_FALSE(response.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_FALSE(response.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_FALSE(response.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_FALSE(response.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::SignInUserResponse response2 = AcceptTerms(response);
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT,
+            response2.GetResult().GetStatus());
+  EXPECT_EQ(kErrorNoContent, response2.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response2.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response2.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response2.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response2.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::AuthenticationClient::SignInUserResponse response3 =
+      SignInArcGis(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response3.GetResult().GetStatus());
+  EXPECT_EQ(kErrorOk, response3.GetResult().GetErrorResponse().message);
+  EXPECT_FALSE(response3.GetResult().GetAccessToken().empty());
+  EXPECT_FALSE(response3.GetResult().GetTokenType().empty());
+  EXPECT_FALSE(response3.GetResult().GetRefreshToken().empty());
+  EXPECT_FALSE(response3.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response3.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response3.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  DeleteUserResponse response4 =
+      DeleteUser(response3.GetResult().GetAccessToken());
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT, response4.status);
+  EXPECT_STREQ(kErrorNoContent.c_str(), response4.error.c_str());
+
+  // SignIn with invalid token
+  AuthenticationClient::SignInUserResponse response5 =
+      SignInArcGis(email, "12345");
+  EXPECT_EQ(olp::http::HttpStatusCode::UNAUTHORIZED,
+            response5.GetResult().GetStatus());
+  EXPECT_EQ(kErrorArcGisFailedCode,
+            response5.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorArcGisFailedMessage,
+            response5.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response5.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response5.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response5.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response5.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response5.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response5.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response5.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response5.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response5.GetResult().GetPrivatePolicyUrlJson().empty());
+}

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.cpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "AuthenticationCommonTestFixture.h"
+
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <olp/core/logging/Log.h>
+#include <olp/core/porting/make_unique.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include "TestConstants.h"
+
+using namespace ::olp::authentication;
+
+std::shared_ptr<olp::http::Network> AuthenticationCommonTestFixture::s_network_;
+
+void AuthenticationCommonTestFixture::SetUpTestSuite() {
+  s_network_ =
+      olp::client::OlpClientSettingsFactory::CreateDefaultNetworkRequestHandler(
+          1);
+}
+
+void AuthenticationCommonTestFixture::TearDownTestSuite() {
+  s_network_.reset();
+}
+
+void AuthenticationCommonTestFixture::SetUp() {
+  client_ = std::make_unique<AuthenticationClient>(kHereAccountStagingURL);
+  network_ = s_network_;
+  task_scheduler_ =
+      olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler();
+  client_->SetNetwork(network_);
+  client_->SetTaskScheduler(task_scheduler_);
+}
+
+void AuthenticationCommonTestFixture::TearDown() {
+  client_.reset();
+  network_.reset();
+}
+
+AuthenticationClient::SignInUserResponse
+AuthenticationCommonTestFixture::AcceptTerms(
+    const AuthenticationClient::SignInUserResponse& precond_failed_response,
+    bool do_cancel) {
+  AuthenticationCredentials credentials(GetAppKey(), GetAppSecretKey());
+
+  std::shared_ptr<AuthenticationClient::SignInUserResponse> response;
+  unsigned int retry = 0u;
+  do {
+    if (retry > 0u) {
+      OLP_SDK_LOG_WARNING(__func__, "Request retry attempted (" << retry
+                                                                << ")");
+      std::this_thread::sleep_for(
+          std::chrono::seconds(retry * kRetryDelayInSecs));
+    }
+
+    std::promise<AuthenticationClient::SignInUserResponse> request;
+    auto request_future = request.get_future();
+    auto cancel_token = client_->AcceptTerms(
+        credentials,
+        precond_failed_response.GetResult().GetTermAcceptanceToken(),
+        [&request](const AuthenticationClient::SignInUserResponse& resp) {
+          request.set_value(resp);
+        });
+
+    if (do_cancel) {
+      cancel_token.cancel();
+    }
+
+    request_future.wait();
+    response = std::make_shared<AuthenticationClient::SignInUserResponse>(
+        request_future.get());
+  } while ((!response->IsSuccessful()) && (++retry < kMaxRetryCount) &&
+           !do_cancel);
+
+  return *response;
+}
+
+AuthenticationCommonTestFixture::DeleteUserResponse
+AuthenticationCommonTestFixture::DeleteUser(
+    const std::string& user_bearer_token) {
+  std::shared_ptr<DeleteUserResponse> response;
+  unsigned int retry = 0u;
+  do {
+    if (retry > 0u) {
+      OLP_SDK_LOG_WARNING(__func__, "Request retry attempted (" << retry
+                                                                << ")");
+      std::this_thread::sleep_for(
+          std::chrono::seconds(retry * kRetryDelayInSecs));
+    }
+
+    std::promise<DeleteUserResponse> request;
+    auto request_future = request.get_future();
+    DeleteHereUser(*network_, olp::http::NetworkSettings(), user_bearer_token,
+                   [&request](const DeleteUserResponse& resp) {
+                     request.set_value(resp);
+                   });
+    request_future.wait();
+    response = std::make_shared<DeleteUserResponse>(request_future.get());
+  } while ((response->status < 0) && (++retry < kMaxRetryCount));
+
+  return *response;
+}
+
+AuthenticationClient::SignOutUserResponse
+AuthenticationCommonTestFixture::SignOutUser(const std::string& access_token,
+                                             bool do_cancel) {
+  AuthenticationCredentials credentials(GetAppKey(), GetAppSecretKey());
+  std::promise<AuthenticationClient::SignOutUserResponse> request;
+  auto request_future = request.get_future();
+  auto cancel_token = client_->SignOut(
+      credentials, access_token,
+      [&](const AuthenticationClient::SignOutUserResponse& response) {
+        request.set_value(response);
+      });
+
+  if (do_cancel) {
+    cancel_token.cancel();
+  }
+
+  request_future.wait();
+  return request_future.get();
+}
+
+std::string AuthenticationCommonTestFixture::GetEmail() const {
+  return kTestUserName + "-" + GenerateRandomSequence() + "@example.com";
+}
+
+void AuthenticationCommonTestFixture::DeleteHereUser(
+    olp::http::Network& network,
+    const olp::http::NetworkSettings& network_settings,
+    const std::string& user_bearer_token,
+    const DeleteHereUserCallback& callback) {
+  constexpr auto kAuthorization = "Authorization";
+  constexpr auto kContentType = "Content-Type";
+  constexpr auto kApplicationJson = "application/json";
+  constexpr auto kDeleteUserEndpoint = "/user/me";
+
+  std::string url = kHereAccountStagingURL;
+  url.append(kDeleteUserEndpoint);
+
+  olp::http::NetworkRequest request(url);
+  request.WithVerb(olp::http::NetworkRequest::HttpVerb::DEL);
+  request.WithHeader(kAuthorization, GenerateBearerHeader(user_bearer_token));
+  request.WithHeader(kContentType, kApplicationJson);
+  request.WithSettings(network_settings);
+
+  std::shared_ptr<std::stringstream> payload =
+      std::make_shared<std::stringstream>();
+  network.Send(
+      request, payload,
+      [callback, payload](const olp::http::NetworkResponse& network_response) {
+        DeleteUserResponse response;
+        response.status = network_response.GetStatus();
+        response.error = network_response.GetError();
+        callback(response);
+      });
+}
+
+std::string AuthenticationCommonTestFixture::GenerateBearerHeader(
+    const std::string& user_bearer_token) {
+  std::string authorization = "Bearer ";
+  authorization += user_bearer_token;
+  return authorization;
+}
+
+std::string AuthenticationCommonTestFixture::GenerateRandomSequence() const {
+  static boost::uuids::random_generator gen;
+  return boost::uuids::to_string(gen());
+}

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.h
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <gtest/gtest.h>
+#include <olp/core/http/Network.h>
+#include <olp/authentication/AuthenticationClient.h>
+
+class AuthenticationCommonTestFixture : public ::testing::Test {
+ protected:
+  struct DeleteUserResponse {
+    int status;
+    std::string error;
+  };
+
+  static void SetUpTestSuite();
+
+  static void TearDownTestSuite();
+
+  void SetUp() override;
+
+  void TearDown() override;
+
+  olp::authentication::AuthenticationClient::SignInUserResponse AcceptTerms(
+      const olp::authentication::AuthenticationClient::SignInUserResponse&
+          precond_failed_response,
+      bool do_cancel = false);
+
+  DeleteUserResponse DeleteUser(const std::string& user_bearer_token);
+
+  olp::authentication::AuthenticationClient::SignOutUserResponse SignOutUser(
+      const std::string& access_token, bool do_cancel = false);
+
+  std::string GetEmail() const;
+
+  virtual std::string GetAppKey() const = 0;
+
+  virtual std::string GetAppSecretKey() const = 0;
+
+ protected:
+  std::shared_ptr<olp::authentication::AuthenticationClient> client_;
+  std::shared_ptr<olp::http::Network> network_;
+  std::shared_ptr<olp::thread::TaskScheduler> task_scheduler_;
+
+  static std::shared_ptr<olp::http::Network> s_network_;
+
+ private:
+  using DeleteHereUserCallback =
+      std::function<void(const DeleteUserResponse& response)>;
+
+  void DeleteHereUser(olp::http::Network& network,
+                      const olp::http::NetworkSettings& network_settings,
+                      const std::string& user_bearer_token,
+                      const DeleteHereUserCallback& callback);
+
+  std::string GenerateBearerHeader(const std::string& user_bearer_token);
+
+  std::string GenerateRandomSequence() const;
+};

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationFunctionalTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationFunctionalTest.cpp
@@ -1,0 +1,629 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <olp/core/http/HttpStatusCode.h>
+#include <olp/core/logging/Log.h>
+#include <testutils/CustomParameters.hpp>
+#include "AuthenticationCommonTestFixture.h"
+#include "ErrorCodes.h"
+#include "ErrorMessages.h"
+#include "TestConstants.h"
+
+using namespace ::olp::authentication;
+
+class AuthenticationFunctionalTest : public AuthenticationCommonTestFixture {
+ protected:
+  void SetUp() override {
+    AuthenticationCommonTestFixture::SetUp();
+
+    id_ = CustomParameters::getArgument("service_id");
+    secret_ = CustomParameters::getArgument("service_secret");
+  }
+
+  AuthenticationClient::SignInClientResponse SignInClient(
+      const AuthenticationCredentials& credentials, std::time_t& now,
+      unsigned int expires_in = kLimitExpiry, bool do_cancel = false) {
+    std::shared_ptr<AuthenticationClient::SignInClientResponse> response;
+    unsigned int retry = 0u;
+    do {
+      if (retry > 0u) {
+        OLP_SDK_LOG_WARNING(__func__, "Request retry attempted (" << retry
+                                                                  << ")");
+        std::this_thread::sleep_for(
+            std::chrono::seconds(retry * kRetryDelayInSecs));
+      }
+
+      std::promise<AuthenticationClient::SignInClientResponse> request;
+      auto request_future = request.get_future();
+
+      now = std::time(nullptr);
+      auto cancel_token = client_->SignInClient(
+          credentials,
+          [&](const AuthenticationClient::SignInClientResponse& resp) {
+            request.set_value(resp);
+          },
+          std::chrono::seconds(expires_in));
+
+      if (do_cancel) {
+        cancel_token.cancel();
+      }
+      request_future.wait();
+      response = std::make_shared<AuthenticationClient::SignInClientResponse>(
+          request_future.get());
+    } while ((!response->IsSuccessful()) && (++retry < kMaxRetryCount) &&
+             !do_cancel);
+
+    return *response;
+  }
+
+  AuthenticationClient::SignInUserResponse SignInUser(const std::string& email,
+                                                      bool do_cancel = false) {
+    AuthenticationCredentials credentials(GetAppKey(), GetAppSecretKey());
+    AuthenticationClient::UserProperties properties;
+    properties.email = email;
+    properties.password = "password123";
+
+    std::shared_ptr<AuthenticationClient::SignInUserResponse> response;
+    unsigned int retry = 0u;
+    do {
+      if (retry > 0u) {
+        OLP_SDK_LOG_WARNING(__func__, "Request retry attempted (" << retry
+                                                                  << ")");
+        std::this_thread::sleep_for(
+            std::chrono::seconds(retry * kRetryDelayInSecs));
+      }
+
+      std::promise<AuthenticationClient::SignInUserResponse> request;
+      auto request_future = request.get_future();
+      auto cancel_token = client_->SignInHereUser(
+          credentials, properties,
+          [&request](const AuthenticationClient::SignInUserResponse& resp) {
+            request.set_value(resp);
+          });
+
+      if (do_cancel) {
+        cancel_token.cancel();
+      }
+
+      request_future.wait();
+      response = std::make_shared<AuthenticationClient::SignInUserResponse>(
+          request_future.get());
+    } while ((!response->IsSuccessful()) && (++retry < kMaxRetryCount) &&
+             !do_cancel);
+
+    return *response;
+  }
+
+  AuthenticationClient::SignInUserResponse SignInRefesh(
+      const std::string& access_token, const std::string& refresh_token,
+      bool do_cancel = false) {
+    AuthenticationCredentials credentials(GetAppKey(), GetAppSecretKey());
+    AuthenticationClient::RefreshProperties properties;
+    properties.access_token = access_token;
+    properties.refresh_token = refresh_token;
+
+    std::shared_ptr<AuthenticationClient::SignInUserResponse> response;
+    unsigned int retry = 0u;
+    do {
+      if (retry > 0u) {
+        OLP_SDK_LOG_WARNING(__func__, "Request retry attempted (" << retry
+                                                                  << ")");
+        std::this_thread::sleep_for(
+            std::chrono::seconds(retry * kRetryDelayInSecs));
+      }
+
+      std::promise<AuthenticationClient::SignInUserResponse> request;
+      auto request_future = request.get_future();
+      auto cancel_token = client_->SignInRefresh(
+          credentials, properties,
+          [&request](const AuthenticationClient::SignInUserResponse& resp) {
+            request.set_value(resp);
+          });
+
+      if (do_cancel) {
+        cancel_token.cancel();
+      }
+
+      request_future.wait();
+      response = std::make_shared<AuthenticationClient::SignInUserResponse>(
+          request_future.get());
+    } while ((!response->IsSuccessful()) && (++retry < kMaxRetryCount) &&
+             !do_cancel);
+
+    return *response;
+  }
+
+  AuthenticationClient::SignUpResponse SignUpUser(
+      const std::string& email, const std::string& password = "password123",
+      bool do_cancel = false) {
+    AuthenticationCredentials credentials(GetAppKey(), GetAppSecretKey());
+    std::promise<AuthenticationClient::SignUpResponse> request;
+    auto request_future = request.get_future();
+    AuthenticationClient::SignUpProperties properties;
+    properties.email = email;
+    properties.password = password;
+    properties.date_of_birth = "31/01/1980";
+    properties.first_name = "AUTH_TESTER";
+    properties.last_name = "HEREOS";
+    properties.country_code = "USA";
+    properties.language = "en";
+    properties.phone_number = "+1234567890";
+    auto cancel_token = client_->SignUpHereUser(
+        credentials, properties,
+        [&](const AuthenticationClient::SignUpResponse& response) {
+          request.set_value(response);
+        });
+
+    if (do_cancel) {
+      cancel_token.cancel();
+    }
+
+    request_future.wait();
+    return request_future.get();
+  }
+
+  std::string GetAppKey() const override { return id_; }
+
+  std::string GetAppSecretKey() const override { return secret_; }
+
+ private:
+  std::string id_;
+  std::string secret_;
+};
+
+TEST_F(AuthenticationFunctionalTest, SignInClient) {
+  AuthenticationCredentials credentials(GetAppKey(), GetAppSecretKey());
+  std::time_t now;
+  AuthenticationClient::SignInClientResponse response =
+      SignInClient(credentials, now, kExpiryTime);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response.GetResult().GetStatus());
+  EXPECT_STREQ(kErrorOk.c_str(),
+               response.GetResult().GetErrorResponse().message.c_str());
+  EXPECT_FALSE(response.GetResult().GetAccessToken().empty());
+  EXPECT_GE(now + kMaxExpiry, response.GetResult().GetExpiryTime());
+  EXPECT_LT(now + kMinExpiry, response.GetResult().GetExpiryTime());
+  EXPECT_FALSE(response.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response.GetResult().GetUserIdentifier().empty());
+
+  now = std::time(nullptr);
+  AuthenticationClient::SignInClientResponse response_2 =
+      SignInClient(credentials, now, kExtendedExpiryTime);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response_2.GetResult().GetStatus());
+  EXPECT_FALSE(response_2.GetResult().GetAccessToken().empty());
+  EXPECT_GE(now + kMaxExtendedExpiry, response_2.GetResult().GetExpiryTime());
+  EXPECT_LT(now + kMinExtendedExpiry, response_2.GetResult().GetExpiryTime());
+  EXPECT_FALSE(response_2.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response_2.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response_2.GetResult().GetUserIdentifier().empty());
+
+  now = std::time(nullptr);
+  AuthenticationClient::SignInClientResponse response_3 =
+      SignInClient(credentials, now, kCustomExpiryTime);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response_3.GetResult().GetStatus());
+  EXPECT_FALSE(response_3.GetResult().GetAccessToken().empty());
+  EXPECT_GE(now + kMaxCustomExpiry, response_3.GetResult().GetExpiryTime());
+  EXPECT_LT(now + kMinCustomExpiry, response_3.GetResult().GetExpiryTime());
+  EXPECT_FALSE(response_3.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response_3.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response_3.GetResult().GetUserIdentifier().empty());
+}
+
+TEST_F(AuthenticationFunctionalTest, SignInClientMaxExpiration) {
+  // Test maximum token expiration 24 h
+  AuthenticationCredentials credentials(GetAppKey(), GetAppSecretKey());
+
+  std::time_t now;
+  AuthenticationClient::SignInClientResponse response =
+      SignInClient(credentials, now);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response.GetResult().GetStatus());
+  EXPECT_FALSE(response.GetResult().GetAccessToken().empty());
+  EXPECT_STREQ(kErrorOk.c_str(),
+               response.GetResult().GetErrorResponse().message.c_str());
+  EXPECT_GE(now + kMaxLimitExpiry, response.GetResult().GetExpiryTime());
+  EXPECT_LT(now + kMinLimitExpiry, response.GetResult().GetExpiryTime());
+
+  // Test token expiration greater than 24h
+  AuthenticationClient::SignInClientResponse response_2 =
+      SignInClient(credentials, now, 90000);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response_2.GetResult().GetStatus());
+  EXPECT_FALSE(response_2.GetResult().GetAccessToken().empty());
+  EXPECT_GE(now + kMaxLimitExpiry, response_2.GetResult().GetExpiryTime());
+  EXPECT_LT(now + kMinLimitExpiry, response_2.GetResult().GetExpiryTime());
+  EXPECT_FALSE(response_2.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response_2.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response_2.GetResult().GetUserIdentifier().empty());
+}
+
+TEST_F(AuthenticationFunctionalTest, InvalidCredentials) {
+  AuthenticationCredentials credentials(GetAppKey(), GetAppKey());
+
+  std::time_t now;
+  AuthenticationClient::SignInClientResponse response =
+      SignInClient(credentials, now);
+  EXPECT_EQ(olp::http::HttpStatusCode::UNAUTHORIZED,
+            response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorUnauthorizedCode,
+            response.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorUnauthorizedMessage,
+            response.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response.GetResult().GetUserIdentifier().empty());
+}
+
+TEST_F(AuthenticationFunctionalTest, SignInClientCancel) {
+  AuthenticationCredentials credentials(GetAppKey(), GetAppSecretKey());
+
+  std::time_t now;
+  AuthenticationClient::SignInClientResponse response =
+      SignInClient(credentials, now, kLimitExpiry, true);
+
+  EXPECT_FALSE(response.IsSuccessful());
+  EXPECT_EQ(olp::client::ErrorCode::Cancelled,
+            response.GetError().GetErrorCode());
+}
+
+TEST_F(AuthenticationFunctionalTest, SignUpInUser) {
+  const std::string email = GetEmail();
+  OLP_SDK_LOG_TRACE("AuthenticationFunctionalTest",
+                    "Creating an account for=" << email);
+
+  AuthenticationClient::SignUpResponse signup_response = SignUpUser(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::CREATED,
+            signup_response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorSignUpCreated,
+            signup_response.GetResult().GetErrorResponse().message);
+  EXPECT_FALSE(signup_response.GetResult().GetUserIdentifier().empty());
+
+  AuthenticationClient::SignInUserResponse response = SignInUser(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::PRECONDITION_FAILED,
+            response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorPreconditionFailedCode,
+            response.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorPreconditionFailedMessage,
+            response.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response.GetResult().GetUserIdentifier().empty());
+  EXPECT_FALSE(response.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_FALSE(response.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_FALSE(response.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_FALSE(response.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_FALSE(response.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::SignInUserResponse response2 = AcceptTerms(response);
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT,
+            response2.GetResult().GetStatus());
+  EXPECT_EQ(kErrorNoContent, response2.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response2.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response2.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response2.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response2.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::SignInUserResponse response3 = SignInUser(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response3.GetResult().GetStatus());
+  EXPECT_STREQ(kErrorOk.c_str(),
+               response3.GetResult().GetErrorResponse().message.c_str());
+  EXPECT_FALSE(response3.GetResult().GetAccessToken().empty());
+  EXPECT_FALSE(response3.GetResult().GetTokenType().empty());
+  EXPECT_FALSE(response3.GetResult().GetRefreshToken().empty());
+  EXPECT_FALSE(response3.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response3.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response3.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  DeleteUserResponse response4 =
+      DeleteUser(response3.GetResult().GetAccessToken());
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT, response4.status);
+  EXPECT_STREQ(kErrorNoContent.c_str(), response4.error.c_str());
+
+  AuthenticationClient::SignInUserResponse response5 = SignInUser(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::UNAUTHORIZED,
+            response5.GetResult().GetStatus());
+  EXPECT_EQ(kErrorAccountNotFoundCode,
+            response5.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorAccountNotFoundMessage,
+            response5.GetResult().GetErrorResponse().message);
+}
+
+TEST_F(AuthenticationFunctionalTest, SignUpUserCancel) {
+  const std::string email = GetEmail();
+  OLP_SDK_LOG_TRACE("AuthenticationFunctionalTest",
+                    "Creating an account for:" << email);
+
+  AuthenticationClient::SignUpResponse response =
+      SignUpUser(email, "password123", true);
+  EXPECT_FALSE(response.IsSuccessful());
+  EXPECT_EQ(olp::client::ErrorCode::Cancelled,
+            response.GetError().GetErrorCode());
+}
+
+TEST_F(AuthenticationFunctionalTest, SignInUserCancel) {
+  const std::string email = GetEmail();
+  OLP_SDK_LOG_TRACE("AuthenticationFunctionalTest",
+                    "Creating an account for:" << email);
+
+  AuthenticationClient::SignUpResponse signup_response = SignUpUser(email);
+  EXPECT_TRUE(signup_response.IsSuccessful());
+
+  AuthenticationClient::SignInUserResponse response = SignInUser(email, true);
+  EXPECT_FALSE(response.IsSuccessful());
+  EXPECT_EQ(olp::client::ErrorCode::Cancelled,
+            response.GetError().GetErrorCode());
+}
+
+TEST_F(AuthenticationFunctionalTest, AcceptTermCancel) {
+  const std::string email = GetEmail();
+  OLP_SDK_LOG_TRACE("AuthenticationFunctionalTest",
+                    "Creating an account for:" << email);
+
+  AuthenticationClient::SignUpResponse signup_response = SignUpUser(email);
+  EXPECT_TRUE(signup_response.IsSuccessful());
+
+  AuthenticationClient::SignInUserResponse response = SignInUser(email);
+  EXPECT_TRUE(response.IsSuccessful());
+
+  AuthenticationClient::SignInUserResponse response2 =
+      AcceptTerms(response, true);
+  EXPECT_FALSE(response2.IsSuccessful());
+  EXPECT_EQ(olp::client::ErrorCode::Cancelled,
+            response2.GetError().GetErrorCode());
+
+  AuthenticationClient::SignInUserResponse response3 = SignInUser(email);
+  EXPECT_TRUE(response.IsSuccessful());
+
+  AuthenticationClient::SignOutUserResponse signOutResponse =
+      SignOutUser(response3.GetResult().GetAccessToken());
+  EXPECT_FALSE(response2.IsSuccessful());
+  EXPECT_EQ(olp::client::ErrorCode::Cancelled,
+            response2.GetError().GetErrorCode());
+
+  DeleteUserResponse response4 =
+      DeleteUser(response3.GetResult().GetAccessToken());
+}
+
+TEST_F(AuthenticationFunctionalTest, SignInRefresh) {
+  const std::string email = GetEmail();
+  OLP_SDK_LOG_TRACE("AuthenticationFunctionalTest",
+                    "Creating an account for:" << email);
+
+  AuthenticationClient::SignUpResponse signup_response = SignUpUser(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::CREATED,
+            signup_response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorSignUpCreated,
+            signup_response.GetResult().GetErrorResponse().message);
+  EXPECT_FALSE(signup_response.GetResult().GetUserIdentifier().empty());
+
+  AuthenticationClient::SignInUserResponse response = SignInUser(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::PRECONDITION_FAILED,
+            response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorPreconditionFailedCode,
+            response.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorPreconditionFailedMessage,
+            response.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response.GetResult().GetUserIdentifier().empty());
+  EXPECT_FALSE(response.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_FALSE(response.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_FALSE(response.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_FALSE(response.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_FALSE(response.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::SignInUserResponse response2 = AcceptTerms(response);
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT,
+            response2.GetResult().GetStatus());
+  EXPECT_EQ(kErrorNoContent, response2.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response2.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response2.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response2.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response2.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::SignInUserResponse response3 = SignInUser(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response3.GetResult().GetStatus());
+  EXPECT_EQ(kErrorOk, response3.GetResult().GetErrorResponse().message);
+  EXPECT_FALSE(response3.GetResult().GetAccessToken().empty());
+  EXPECT_FALSE(response3.GetResult().GetTokenType().empty());
+  EXPECT_FALSE(response3.GetResult().GetRefreshToken().empty());
+  EXPECT_FALSE(response3.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response3.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response3.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::SignInUserResponse response4 =
+      SignInRefesh(response3.GetResult().GetAccessToken(),
+                   response3.GetResult().GetRefreshToken());
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response4.GetResult().GetStatus());
+  EXPECT_EQ(kErrorOk, response4.GetResult().GetErrorResponse().message);
+  EXPECT_FALSE(response4.GetResult().GetAccessToken().empty());
+  EXPECT_FALSE(response4.GetResult().GetTokenType().empty());
+  EXPECT_FALSE(response4.GetResult().GetRefreshToken().empty());
+  EXPECT_FALSE(response4.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response4.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response4.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response4.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response4.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response4.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::SignInUserResponse response5 =
+      SignInRefesh("12345", response3.GetResult().GetRefreshToken());
+  EXPECT_EQ(olp::http::HttpStatusCode::UNAUTHORIZED,
+            response5.GetResult().GetStatus());
+  EXPECT_EQ(kErrorRefreshFailedCode,
+            response5.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorRefreshFailedMessage,
+            response5.GetResult().GetErrorResponse().message);
+
+  DeleteUserResponse response6 =
+      DeleteUser(response4.GetResult().GetAccessToken());
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT, response6.status);
+  EXPECT_STREQ(kErrorNoContent.c_str(), response6.error.c_str());
+
+  AuthenticationClient::SignInUserResponse response7 = SignInUser(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::UNAUTHORIZED,
+            response7.GetResult().GetStatus());
+  EXPECT_EQ(kErrorAccountNotFoundCode,
+            response7.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorAccountNotFoundMessage,
+            response7.GetResult().GetErrorResponse().message);
+}
+
+TEST_F(AuthenticationFunctionalTest, SignInRefreshCancel) {
+  const std::string email = GetEmail();
+  OLP_SDK_LOG_TRACE("AuthenticationFunctionalTest",
+                    "Creating an account for:" << email);
+
+  AuthenticationClient::SignUpResponse signup_response = SignUpUser(email);
+  EXPECT_TRUE(signup_response.IsSuccessful());
+
+  AuthenticationClient::SignInUserResponse response = SignInUser(email);
+  EXPECT_TRUE(response.IsSuccessful());
+  EXPECT_EQ(olp::http::HttpStatusCode::PRECONDITION_FAILED,
+            response.GetResult().GetStatus());
+
+  AuthenticationClient::SignInUserResponse response2 = AcceptTerms(response);
+  EXPECT_TRUE(response2.IsSuccessful());
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT,
+            response2.GetResult().GetStatus());
+
+  AuthenticationClient::SignInUserResponse response3 = SignInUser(email);
+  EXPECT_TRUE(response3.IsSuccessful());
+
+  AuthenticationClient::SignInUserResponse response4 =
+      SignInRefesh(response3.GetResult().GetAccessToken(),
+                   response3.GetResult().GetRefreshToken(), true);
+  EXPECT_FALSE(response4.IsSuccessful());
+  EXPECT_EQ(olp::client::ErrorCode::Cancelled,
+            response4.GetError().GetErrorCode());
+
+  DeleteUserResponse response5 =
+      DeleteUser(response3.GetResult().GetAccessToken());
+}
+
+TEST_F(AuthenticationFunctionalTest, SignOutUser) {
+  const std::string email = GetEmail();
+  OLP_SDK_LOG_TRACE("AuthenticationFunctionalTest",
+                    "Creating an account for:" << email);
+
+  AuthenticationClient::SignUpResponse signup_response = SignUpUser(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::CREATED,
+            signup_response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorSignUpCreated,
+            signup_response.GetResult().GetErrorResponse().message);
+  EXPECT_FALSE(signup_response.GetResult().GetUserIdentifier().empty());
+
+  AuthenticationClient::SignInUserResponse response = SignInUser(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::PRECONDITION_FAILED,
+            response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorPreconditionFailedCode,
+            response.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorPreconditionFailedMessage,
+            response.GetResult().GetErrorResponse().message);
+
+  AuthenticationClient::SignInUserResponse response2 = AcceptTerms(response);
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT,
+            response2.GetResult().GetStatus());
+  EXPECT_STREQ(kErrorNoContent.c_str(),
+               response2.GetResult().GetErrorResponse().message.c_str());
+
+  AuthenticationClient::SignInUserResponse response3 = SignInUser(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response3.GetResult().GetStatus());
+  EXPECT_STREQ(kErrorOk.c_str(),
+               response3.GetResult().GetErrorResponse().message.c_str());
+
+  AuthenticationClient::SignOutUserResponse signOutResponse =
+      SignOutUser(response3.GetResult().GetAccessToken());
+  EXPECT_TRUE(signOutResponse.IsSuccessful());
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT,
+            signOutResponse.GetResult().GetStatus());
+  EXPECT_EQ(kErrorNoContent,
+            signOutResponse.GetResult().GetErrorResponse().message);
+
+  DeleteUserResponse response4 =
+      DeleteUser(response3.GetResult().GetAccessToken());
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT, response4.status);
+  EXPECT_STREQ(kErrorNoContent.c_str(), response4.error.c_str());
+}
+
+TEST_F(AuthenticationFunctionalTest, NetworkProxySettings) {
+  AuthenticationCredentials credentials(GetAppKey(), GetAppSecretKey());
+
+  auto proxy_settings = olp::http::NetworkProxySettings();
+  client_->SetNetworkProxySettings(proxy_settings);
+  proxy_settings.WithHostname("$.?");
+  proxy_settings.WithPort(42);
+  proxy_settings.WithType(olp::http::NetworkProxySettings::Type::SOCKS4);
+
+  client_->SetNetworkProxySettings(proxy_settings);
+  std::time_t now;
+  auto response = SignInClient(credentials, now, kExpiryTime);
+  // Bad proxy error code and message varies by platform
+  EXPECT_FALSE(response.IsSuccessful());
+  EXPECT_TRUE(response.GetError().GetErrorCode() ==
+              olp::client::ErrorCode::ServiceUnavailable);
+  EXPECT_STRNE(response.GetError().GetMessage().c_str(), kErrorOk.c_str());
+}
+
+TEST_F(AuthenticationFunctionalTest, ErrorFields) {
+  static const std::string PASSWORD = "password";
+  static const std::string EMAIL = "email";
+
+  AuthenticationClient::SignUpResponse signup_response =
+      SignUpUser("a/*<@test.com", "password");
+  EXPECT_TRUE(signup_response.IsSuccessful());
+  EXPECT_EQ(olp::http::HttpStatusCode::BAD_REQUEST,
+            signup_response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorFieldsCode,
+            signup_response.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorFieldsMessage,
+            signup_response.GetResult().GetErrorResponse().message);
+  EXPECT_EQ(2, signup_response.GetResult().GetErrorFields().size());
+  int count = 0;
+  for (ErrorFields::const_iterator it =
+           signup_response.GetResult().GetErrorFields().begin();
+       it != signup_response.GetResult().GetErrorFields().end(); it++) {
+    const std::string name = count == 0 ? EMAIL : PASSWORD;
+    const std::string message =
+        count == 0 ? kErrorIllegalEmail : kErrorBlacklistedPassword;
+    unsigned int code =
+        count == 0 ? kErrorIllegalEmailCode : kErrorBlacklistedPasswordCode;
+    count++;
+    EXPECT_EQ(name, it->name);
+    EXPECT_EQ(message, it->message);
+    EXPECT_EQ(code, it->code);
+  }
+}

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationProductionTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationProductionTest.cpp
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <future>
+#include <memory>
+
+#include <gtest/gtest.h>
+#include <olp/authentication/AuthenticationClient.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/http/HttpStatusCode.h>
+#include <olp/core/porting/make_unique.h>
+#include <testutils/CustomParameters.hpp>
+#include "ErrorCodes.h"
+#include "ErrorMessages.h"
+#include "TestConstants.h"
+
+using namespace ::olp::authentication;
+
+class AuthenticationProductionTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    s_network_ = olp::client::OlpClientSettingsFactory::
+        CreateDefaultNetworkRequestHandler(1);
+  }
+
+  static void TearDownTestSuite() { s_network_.reset(); }
+
+  void SetUp() override {
+    // Use production HERE Account server
+    client = std::make_unique<AuthenticationClient>();
+    client->SetTaskScheduler(
+        olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler());
+    client->SetNetwork(s_network_);
+  }
+
+  void TearDown() override { client.reset(); }
+
+ protected:
+  std::unique_ptr<AuthenticationClient> client;
+
+  static std::shared_ptr<olp::http::Network> s_network_;
+};
+
+// Static network instance is necessary as it needs to outlive any created
+// clients. This is a known limitation as triggered send requests capture the
+// network instance inside the callbacks.
+std::shared_ptr<olp::http::Network> AuthenticationProductionTest::s_network_;
+
+TEST_F(AuthenticationProductionTest, SignInClient) {
+  AuthenticationCredentials credentials(
+      CustomParameters::getArgument("production_service_id"),
+      CustomParameters::getArgument("production_service_secret"));
+  std::promise<AuthenticationClient::SignInClientResponse> request;
+  auto request_future = request.get_future();
+  client->SignInClient(
+      credentials,
+      [&](const AuthenticationClient::SignInClientResponse& response) {
+        request.set_value(response);
+      },
+      std::chrono::seconds(kExpiryTime));
+  request_future.wait();
+
+  AuthenticationClient::SignInClientResponse response = request_future.get();
+  std::time_t now = std::time(nullptr);
+  EXPECT_TRUE(response.IsSuccessful());
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response.GetResult().GetStatus());
+  EXPECT_STREQ(kErrorOk.c_str(),
+               response.GetResult().GetErrorResponse().message.c_str());
+  EXPECT_FALSE(response.GetResult().GetAccessToken().empty());
+  EXPECT_GE(now + kMaxExpiry, response.GetResult().GetExpiryTime());
+  EXPECT_LT(now + kMinExpiry, response.GetResult().GetExpiryTime());
+  EXPECT_FALSE(response.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response.GetResult().GetUserIdentifier().empty());
+
+  std::promise<AuthenticationClient::SignInClientResponse> request_2;
+  now = std::time(nullptr);
+  auto request_future_2 = request_2.get_future();
+  client->SignInClient(
+      credentials,
+      [&](const AuthenticationClient::SignInClientResponse& response) {
+        request_2.set_value(response);
+      },
+      std::chrono::seconds(kExtendedExpiryTime));
+  request_future_2.wait();
+
+  AuthenticationClient::SignInClientResponse response_2 =
+      request_future_2.get();
+  EXPECT_TRUE(response_2.IsSuccessful());
+  EXPECT_FALSE(response_2.GetResult().GetAccessToken().empty());
+  EXPECT_GE(now + kMaxExtendedExpiry, response_2.GetResult().GetExpiryTime());
+  EXPECT_LT(now + kMinExtendedExpiry, response_2.GetResult().GetExpiryTime());
+  EXPECT_FALSE(response_2.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response_2.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response_2.GetResult().GetUserIdentifier().empty());
+
+  std::promise<AuthenticationClient::SignInClientResponse> request_3;
+  now = std::time(nullptr);
+  auto request_future_3 = request_3.get_future();
+  client->SignInClient(
+      credentials,
+      [&](const AuthenticationClient::SignInClientResponse& response) {
+        request_3.set_value(response);
+      },
+      std::chrono::seconds(kCustomExpiryTime));
+  request_future_3.wait();
+
+  AuthenticationClient::SignInClientResponse response_3 =
+      request_future_3.get();
+  EXPECT_TRUE(response_3.IsSuccessful());
+  EXPECT_FALSE(response_3.GetResult().GetAccessToken().empty());
+  EXPECT_GE(now + kMaxCustomExpiry, response_3.GetResult().GetExpiryTime());
+  EXPECT_LT(now + kMinCustomExpiry, response_3.GetResult().GetExpiryTime());
+  EXPECT_FALSE(response_3.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response_3.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response_3.GetResult().GetUserIdentifier().empty());
+}
+
+TEST_F(AuthenticationProductionTest, SignInClientMaxExpiration) {
+  // Test maximum token expiration 24 h
+  AuthenticationCredentials credentials(
+      CustomParameters::getArgument("production_service_id"),
+      CustomParameters::getArgument("production_service_secret"));
+  std::promise<AuthenticationClient::SignInClientResponse> request;
+  auto request_future = request.get_future();
+  time_t now = std::time(nullptr);
+  client->SignInClient(
+      credentials,
+      [&](const AuthenticationClient::SignInClientResponse& response) {
+        request.set_value(response);
+      });
+  request_future.wait();
+
+  AuthenticationClient::SignInClientResponse response = request_future.get();
+  EXPECT_TRUE(response.IsSuccessful());
+  EXPECT_FALSE(response.GetResult().GetAccessToken().empty());
+  EXPECT_GE(now + kMaxLimitExpiry, response.GetResult().GetExpiryTime());
+  EXPECT_LT(now + kMinLimitExpiry, response.GetResult().GetExpiryTime());
+
+  // Test token expiration greater than 24h
+  std::promise<AuthenticationClient::SignInClientResponse> request_2;
+  auto request_future_2 = request_2.get_future();
+  now = std::time(nullptr);
+  client->SignInClient(
+      credentials,
+      [&](const AuthenticationClient::SignInClientResponse& response) {
+        request_2.set_value(response);
+      },
+      std::chrono::seconds(90000));
+  request_future_2.wait();
+
+  AuthenticationClient::SignInClientResponse response_2 =
+      request_future_2.get();
+  EXPECT_TRUE(response_2.IsSuccessful());
+  EXPECT_FALSE(response_2.GetResult().GetAccessToken().empty());
+  EXPECT_GE(now + kMaxLimitExpiry, response_2.GetResult().GetExpiryTime());
+  EXPECT_LT(now + kMinLimitExpiry, response_2.GetResult().GetExpiryTime());
+  EXPECT_FALSE(response_2.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response_2.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response_2.GetResult().GetUserIdentifier().empty());
+}
+
+TEST_F(AuthenticationProductionTest, InvalidCredentials) {
+  AuthenticationCredentials credentials(
+      CustomParameters::getArgument("production_service_id"),
+      CustomParameters::getArgument("production_service_id"));
+  std::promise<AuthenticationClient::SignInClientResponse> request;
+  auto request_future = request.get_future();
+  client->SignInClient(
+      credentials,
+      [&](const AuthenticationClient::SignInClientResponse& response) {
+        request.set_value(response);
+      });
+  request_future.wait();
+
+  AuthenticationClient::SignInClientResponse response = request_future.get();
+  EXPECT_TRUE(response.IsSuccessful());
+  EXPECT_EQ(kErrorUnauthorizedCode,
+            response.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorUnauthorizedMessage,
+            response.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response.GetResult().GetUserIdentifier().empty());
+}

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationTestUtils.h
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationTestUtils.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <memory>
+
+#include <olp/core/http/Network.h>
+
+struct AccessTokenOutcome {
+  std::string access_token;
+  int status;
+};
+
+struct FacebookUser {
+  AccessTokenOutcome token;
+  std::string id;
+};
+
+class AuthenticationTestUtils final {
+ public:
+  static bool CreateFacebookTestUser(
+      olp::http::Network& network,
+      const olp::http::NetworkSettings& network_settings,
+      const std::string& permissions, FacebookUser& user);
+  static bool DeleteFacebookTestUser(
+      olp::http::Network& network,
+      const olp::http::NetworkSettings& network_settings,
+      const std::string& user_id);
+
+  static bool GetGoogleAccessToken(
+      olp::http::Network& network,
+      const olp::http::NetworkSettings& network_settings,
+      AccessTokenOutcome& token);
+
+  static bool GetArcGisAccessToken(
+      olp::http::Network& network,
+      const olp::http::NetworkSettings& network_settings,
+      AccessTokenOutcome& token);
+
+ private:
+  static std::shared_ptr<std::vector<unsigned char>> GenerateArcGisClientBody();
+
+  static bool GetAccessTokenImpl(olp::http::Network& network,
+                                 const olp::http::NetworkRequest& request,
+                                 AccessTokenOutcome& token);
+  AuthenticationTestUtils() = delete;
+};

--- a/tests/functional/olp-cpp-sdk-authentication/ErrorCodes.h
+++ b/tests/functional/olp-cpp-sdk-authentication/ErrorCodes.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+constexpr auto kErrorAccountNotFoundCode = 401600;
+
+constexpr auto kErrorBlacklistedPasswordCode = 400205;
+
+constexpr auto kErrorFieldsCode = 400200;
+
+constexpr auto kErrorIllegalEmailCode = 400240;
+
+constexpr auto kErrorPreconditionCreatedCode = 412001;
+
+constexpr auto kErrorPreconditionFailedCode = 412001;
+
+constexpr auto kErrorRefreshFailedCode = 400601;
+
+constexpr auto kErrorUnauthorizedCode = 401300;

--- a/tests/functional/olp-cpp-sdk-authentication/ErrorMessages.h
+++ b/tests/functional/olp-cpp-sdk-authentication/ErrorMessages.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+
+static const std::string kErrorAccountNotFoundMessage =
+    "No account found for given account Id.";
+
+static const std::string kErrorBlacklistedPassword = "Black listed password.";
+
+static const std::string kErrorFieldsMessage = "Received invalid data.";
+
+static const std::string kErrorIllegalEmail = "Illegal email.";
+
+static const std::string kErrorNoContent = "No Content";
+
+static const std::string kErrorOk = "OK";
+
+static const std::string kErrorPreconditionCreatedMessage = "Created";
+
+static const std::string kErrorPreconditionFailedMessage = "Precondition Failed";
+
+static const std::string kErrorRefreshFailedMessage = "Invalid accessToken.";
+
+static const std::string kErrorSignUpCreated = "Created";
+
+static const std::string kErrorUnauthorizedMessage =
+    "Signature mismatch. Authorization signature or client credential is "
+    "wrong.";

--- a/tests/functional/olp-cpp-sdk-authentication/FacebookAuthenticationTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/FacebookAuthenticationTest.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <olp/core/http/HttpStatusCode.h>
+#include <olp/core/logging/Log.h>
+#include "AuthenticationCommonTestFixture.h"
+#include "AuthenticationTestUtils.h"
+#include "ErrorCodes.h"
+#include "ErrorMessages.h"
+#include "TestConstants.h"
+
+using namespace ::olp::authentication;
+
+namespace {
+
+static const int kErrorFacebookErrorCode = 400300;
+
+const std::string kErrorFacebookFailedMessage = "Unexpected Facebook error.";
+
+}  // namespace
+
+class FacebookAuthenticationTest : public AuthenticationCommonTestFixture {
+ protected:
+  void SetUp() override {
+    AuthenticationCommonTestFixture::SetUp();
+
+    ASSERT_TRUE(AuthenticationTestUtils::CreateFacebookTestUser(
+        *network_, olp::http::NetworkSettings(), "email", test_user_));
+  }
+
+  void TearDown() override {
+    DeleteFacebookTestUser(*network_, olp::http::NetworkSettings(),
+                           test_user_.id);
+
+    AuthenticationCommonTestFixture::TearDown();
+  }
+
+  AuthenticationClient::SignInUserResponse SignInFacebook(
+      std::string token = "") {
+    AuthenticationCredentials credentials(GetAppKey(), GetAppSecretKey());
+    std::promise<AuthenticationClient::SignInUserResponse> request;
+    auto request_future = request.get_future();
+    AuthenticationClient::FederatedProperties properties;
+    properties.access_token =
+        token.empty() ? test_user_.token.access_token : token;
+    properties.country_code = "usa";
+    properties.language = "en";
+    properties.email = kTestUserName + "@example.com";
+
+    client_->SignInFacebook(
+        credentials, properties,
+        [&](const AuthenticationClient::SignInUserResponse& response) {
+          request.set_value(response);
+        });
+    request_future.wait();
+    return request_future.get();
+  }
+
+  void DeleteFacebookTestUser(
+      olp::http::Network& network,
+      const olp::http::NetworkSettings& network_settings,
+      const std::string& id) {
+    for (int retry = 0; retry < 3; ++retry) {
+      if (AuthenticationTestUtils::DeleteFacebookTestUser(
+              network, network_settings, id)) {
+        return;
+      }
+
+      std::this_thread::sleep_for(std::chrono::seconds(retry));
+    }
+  }
+
+  std::string GetAppKey() const override { return kTestAppKeyId; }
+
+  std::string GetAppSecretKey() const override { return kTestAppKeySecret; }
+
+ private:
+  FacebookUser test_user_;
+};
+
+TEST_F(FacebookAuthenticationTest, SignInFacebook) {
+  AuthenticationClient::SignInUserResponse response = SignInFacebook();
+  EXPECT_EQ(olp::http::HttpStatusCode::CREATED,
+            response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorPreconditionCreatedCode,
+            response.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorPreconditionCreatedMessage,
+            response.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response.GetResult().GetUserIdentifier().empty());
+  EXPECT_FALSE(response.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_FALSE(response.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_FALSE(response.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_FALSE(response.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_FALSE(response.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::SignInUserResponse response2 = AcceptTerms(response);
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT,
+            response2.GetResult().GetStatus());
+  EXPECT_EQ(kErrorNoContent, response2.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response2.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response2.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response2.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response2.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::SignInUserResponse response3 = SignInFacebook();
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response3.GetResult().GetStatus());
+  EXPECT_EQ(kErrorOk, response3.GetResult().GetErrorResponse().message);
+  EXPECT_FALSE(response3.GetResult().GetAccessToken().empty());
+  EXPECT_FALSE(response3.GetResult().GetTokenType().empty());
+  EXPECT_FALSE(response3.GetResult().GetRefreshToken().empty());
+  EXPECT_FALSE(response3.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response3.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response3.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  DeleteUserResponse response4 =
+      DeleteUser(response3.GetResult().GetAccessToken());
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT, response4.status);
+  EXPECT_STREQ(kErrorNoContent.c_str(), response4.error.c_str());
+
+  // SignIn with invalid token
+  AuthenticationClient::SignInUserResponse response5 = SignInFacebook("12345");
+  EXPECT_EQ(olp::http::HttpStatusCode::UNAUTHORIZED,
+            response5.GetResult().GetStatus());
+  EXPECT_EQ(kErrorFacebookErrorCode,
+            response5.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorFacebookFailedMessage,
+            response5.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response5.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response5.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response5.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response5.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response5.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response5.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response5.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response5.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response5.GetResult().GetPrivatePolicyUrlJson().empty());
+}

--- a/tests/functional/olp-cpp-sdk-authentication/GoogleAuthenticationTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/GoogleAuthenticationTest.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <olp/core/http/HttpStatusCode.h>
+#include <olp/core/logging/Log.h>
+#include <olp/core/porting/make_unique.h>
+#include "AuthenticationCommonTestFixture.h"
+#include "AuthenticationTestUtils.h"
+#include "ErrorCodes.h"
+#include "ErrorMessages.h"
+#include "TestConstants.h"
+
+using namespace ::olp::authentication;
+
+class GoogleAuthenticationTest : public AuthenticationCommonTestFixture {
+ protected:
+  void SetUp() override {
+    AuthenticationCommonTestFixture::SetUp();
+
+    ASSERT_TRUE(AuthenticationTestUtils::GetGoogleAccessToken(
+        *network_, olp::http::NetworkSettings(), token_));
+  }
+
+  void TearDown() override {
+    token_ = AccessTokenOutcome{};
+    AuthenticationCommonTestFixture::TearDown();
+  }
+
+  AuthenticationClient::SignInUserResponse SignInGoogleUser(
+      const std::string& email, const std::string& access_token) {
+    AuthenticationCredentials credentials(GetAppKey(), GetAppSecretKey());
+    std::promise<AuthenticationClient::SignInUserResponse> request;
+    auto request_future = request.get_future();
+    AuthenticationClient::FederatedProperties properties;
+    properties.access_token = access_token;
+    properties.country_code = "USA";
+    properties.language = "en";
+    properties.email = email;
+    client_->SignInGoogle(
+        credentials, properties,
+        [&](const AuthenticationClient::SignInUserResponse& response) {
+          request.set_value(response);
+        });
+    request_future.wait();
+    return request_future.get();
+  }
+
+  std::string GetAppKey() const override { return kTestAppKeyId; }
+
+  std::string GetAppSecretKey() const override { return kTestAppKeySecret; }
+
+ protected:
+  AccessTokenOutcome token_;
+};
+
+TEST_F(GoogleAuthenticationTest, SignInGoogle) {
+  ASSERT_FALSE(token_.access_token.empty());
+
+  const std::string email = GetEmail();
+  OLP_SDK_LOG_TRACE("GoogleAuthenticationTest",
+                    "Running test with e-mail=" << email);
+
+  AuthenticationClient::SignInUserResponse response =
+      SignInGoogleUser(email, token_.access_token);
+  EXPECT_EQ(olp::http::HttpStatusCode::CREATED,
+            response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorPreconditionCreatedCode,
+            response.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorPreconditionCreatedMessage,
+            response.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response.GetResult().GetUserIdentifier().empty());
+  EXPECT_FALSE(response.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_FALSE(response.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_FALSE(response.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_FALSE(response.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_FALSE(response.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  OLP_SDK_LOG_TRACE(
+      "GoogleAuthenticationTest",
+      "termAcceptanceToken=" << response.GetResult().GetTermAcceptanceToken());
+
+  AuthenticationClient::SignInUserResponse response2 = AcceptTerms(response);
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT,
+            response2.GetResult().GetStatus());
+  EXPECT_STREQ(kErrorNoContent.c_str(),
+               response2.GetResult().GetErrorResponse().message.c_str());
+  EXPECT_TRUE(response2.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response2.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response2.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response2.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::SignInUserResponse response3 =
+      SignInGoogleUser(email, token_.access_token);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response3.GetResult().GetStatus());
+  EXPECT_STREQ(kErrorOk.c_str(),
+               response3.GetResult().GetErrorResponse().message.c_str());
+  EXPECT_FALSE(response3.GetResult().GetAccessToken().empty());
+  EXPECT_FALSE(response3.GetResult().GetTokenType().empty());
+  EXPECT_FALSE(response3.GetResult().GetRefreshToken().empty());
+  EXPECT_FALSE(response3.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response3.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response3.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::SignOutUserResponse signout_response =
+      SignOutUser(response3.GetResult().GetAccessToken());
+  EXPECT_TRUE(signout_response.IsSuccessful());
+  // EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT,
+  // signOutResponse.GetResult().GetStatus());
+  // EXPECT_EQ(kErrorNoContent.c_str(),
+  //          signOutResponse.GetResult().GetErrorResponse().message);
+
+  DeleteUserResponse response4 =
+      DeleteUser(response3.GetResult().GetAccessToken());
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT, response4.status);
+  EXPECT_STREQ(kErrorNoContent.c_str(), response4.error.c_str());
+
+  // SignIn with invalid token
+  AuthenticationClient::SignInUserResponse response5 =
+      SignInGoogleUser(email, "12345");
+  EXPECT_EQ(olp::http::HttpStatusCode::UNAUTHORIZED,
+            response5.GetResult().GetStatus());
+  EXPECT_TRUE(response5.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response5.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response5.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response5.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response5.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response5.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response5.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response5.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response5.GetResult().GetPrivatePolicyUrlJson().empty());
+}

--- a/tests/functional/olp-cpp-sdk-authentication/TestConstants.h
+++ b/tests/functional/olp-cpp-sdk-authentication/TestConstants.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+
+constexpr auto kMaxRetryCount = 3u;
+constexpr auto kRetryDelayInSecs = 2u;
+
+constexpr auto kLimitExpiry = 86400u;
+
+constexpr auto kExpiryTime = 3600u;
+constexpr auto kMaxExpiry = kExpiryTime + 30u;
+constexpr auto kMinExpiry = kExpiryTime - 10u;
+
+constexpr auto kCustomExpiryTime = 6000u;
+constexpr auto kMaxCustomExpiry = kCustomExpiryTime + 30u;
+constexpr auto kMinCustomExpiry = kCustomExpiryTime - 10u;
+
+constexpr auto kExtendedExpiryTime = 2 * kExpiryTime;
+constexpr auto kMaxExtendedExpiry = kExtendedExpiryTime + 30u;
+constexpr auto kMinExtendedExpiry = kExtendedExpiryTime - 10u;
+
+constexpr auto kMaxLimitExpiry = kLimitExpiry + 30u;
+constexpr auto kMinLimitExpiry = kLimitExpiry - 10u;
+
+static const std::string kHereAccountStagingURL =
+    "https://stg.account.api.here.com";
+
+static const std::string kTestUserName = "HA-UnitTestUser-Edge";
+static const std::string kTestAppKeyId = "Ha-Integration-Test-App";
+static const std::string kTestAppKeySecret = "ha-test-secret-1";

--- a/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -18,7 +18,6 @@
  */
 
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
 
 #include <future>
 #include <memory>
@@ -26,9 +25,7 @@
 #include <olp/core/porting/make_unique.h>
 #include <olp/core/http/HttpStatusCode.h>
 #include "olp/core/client/OlpClientSettingsFactory.h"
-
 #include <olp/authentication/AuthenticationClient.h>
-
 #include <mocks/NetworkMock.h>
 
 #include "AuthenticationMockedResponses.h"


### PR DESCRIPTION
- copy authentication functional tests to <root>/tests/ folder to meet the Pitchfork layout model;
- refactoring of original TestUtils structure to reduce code duplication in authentication tests;
- small fix regarding includes in auth integration tests

Relates to: OLPEDGE-718

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>