### PR TITLE
Copied AuthenticationOnlineTest to <root>/tests/functional folder

### DIFF
--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -22,10 +22,21 @@ set(OLP_SDK_FUNCTIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-core/OlpClientDefaultAsyncHttpTest.cpp
     ./olp-cpp-sdk-dataservice-read/ApiTest.cpp
     ./olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
+    ./olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.cpp
+    ./olp-cpp-sdk-authentication/AuthenticationFunctionalTest.cpp
+    ./olp-cpp-sdk-authentication/AuthenticationUtils.cpp
+)
+
+set(OLP_SDK_FUNCTIONAL_TESTS_HEADERS
+    ./olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.h
+    ./olp-cpp-sdk-authentication/AuthenticationUtils.h
+    ./olp-cpp-sdk-authentication/TestConstants.h
 )
 
 if (ANDROID OR IOS)
-    add_library(olp-cpp-sdk-functional-tests-lib ${OLP_SDK_FUNCTIONAL_TESTS_SOURCES})
+    add_library(olp-cpp-sdk-functional-tests-lib
+        ${OLP_SDK_FUNCTIONAL_TESTS_SOURCES}
+        ${OLP_SDK_FUNCTIONAL_TESTS_HEADERS})
     target_include_directories(olp-cpp-sdk-functional-lib
         PRIVATE
             ${PROJECT_SOURCE_DIR}/olp-cpp-sdk-dataservice-read/src
@@ -55,7 +66,9 @@ if (ANDROID OR IOS)
     endif()
 
 else()
-    add_executable(olp-cpp-sdk-functional-tests ${OLP_SDK_FUNCTIONAL_TESTS_SOURCES})
+    add_executable(olp-cpp-sdk-functional-tests
+        ${OLP_SDK_FUNCTIONAL_TESTS_SOURCES}
+        ${OLP_SDK_FUNCTIONAL_TESTS_HEADERS})
     target_include_directories(olp-cpp-sdk-functional-tests
     PRIVATE
         ${PROJECT_SOURCE_DIR}/olp-cpp-sdk-dataservice-read/src

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.cpp
@@ -1,0 +1,311 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "AuthenticationCommonTestFixture.h"
+
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <olp/core/logging/Log.h>
+#include <olp/core/porting/make_unique.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include <testutils/CustomParameters.hpp>
+
+std::shared_ptr<olp::http::Network> AuthenticationCommonTestFixture::s_network_;
+
+void AuthenticationCommonTestFixture::SetUpTestSuite() {
+  s_network_ =
+      olp::client::OlpClientSettingsFactory::CreateDefaultNetworkRequestHandler(
+          1);
+}
+
+void AuthenticationCommonTestFixture::TearDownTestSuite() {
+  s_network_.reset();
+}
+
+void AuthenticationCommonTestFixture::SetUp() {
+  utils_ = std::make_unique<AuthenticationUtils>();
+  network_ = s_network_;
+  task_scheduler_ =
+      olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler();
+
+  client_ = std::make_unique<AuthenticationClient>(kHereAccountStagingURL);
+  client_->SetNetwork(network_);
+  client_->SetTaskScheduler(task_scheduler_);
+
+  id_ = CustomParameters::getArgument("service_id");
+  secret_ = CustomParameters::getArgument("service_secret");
+}
+
+void AuthenticationCommonTestFixture::TearDown() {
+  client_.reset();
+  network_.reset();
+  utils_.reset();
+
+  // TODO - what is the reason behind this sleep?
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+}
+
+AuthenticationClient::SignInUserResponse
+AuthenticationCommonTestFixture::AcceptTerms(
+    const AuthenticationClient::SignInUserResponse& precond_failed_response,
+    bool do_cancel) {
+  AuthenticationCredentials credentials(id_, secret_);
+
+  std::shared_ptr<AuthenticationClient::SignInUserResponse> response;
+  unsigned int retry = 0u;
+  do {
+    if (retry > 0u) {
+      OLP_SDK_LOG_WARNING(__func__, "Request retry attempted (" << retry
+                                                                << ")");
+      std::this_thread::sleep_for(
+          std::chrono::seconds(retry * kRetryDelayInSecs));
+    }
+
+    std::promise<AuthenticationClient::SignInUserResponse> request;
+    auto request_future = request.get_future();
+    auto cancel_token = client_->AcceptTerms(
+        credentials,
+        precond_failed_response.GetResult().GetTermAcceptanceToken(),
+        [&request](const AuthenticationClient::SignInUserResponse& resp) {
+          request.set_value(resp);
+        });
+
+    if (do_cancel) {
+      cancel_token.cancel();
+    }
+
+    request_future.wait();
+    response = std::make_shared<AuthenticationClient::SignInUserResponse>(
+        request_future.get());
+  } while ((!response->IsSuccessful()) && (++retry < kMaxRetryCount) &&
+           !do_cancel);
+
+  return *response;
+}
+
+AuthenticationUtils::DeleteUserResponse
+AuthenticationCommonTestFixture::DeleteUser(
+    const std::string& user_bearer_token) {
+  std::shared_ptr<AuthenticationUtils::DeleteUserResponse> response;
+  unsigned int retry = 0u;
+  do {
+    if (retry > 0u) {
+      OLP_SDK_LOG_WARNING(__func__, "Request retry attempted (" << retry
+                                                                << ")");
+      std::this_thread::sleep_for(
+          std::chrono::seconds(retry * kRetryDelayInSecs));
+    }
+
+    std::promise<AuthenticationUtils::DeleteUserResponse> request;
+    auto request_future = request.get_future();
+    utils_->DeleteHereUser(
+        *network_, olp::http::NetworkSettings(), user_bearer_token,
+        [&request](const AuthenticationUtils::DeleteUserResponse& resp) {
+          request.set_value(resp);
+        });
+    request_future.wait();
+    response = std::make_shared<AuthenticationUtils::DeleteUserResponse>(
+        request_future.get());
+  } while ((response->status < 0) && (++retry < kMaxRetryCount));
+
+  return *response;
+}
+
+AuthenticationClient::SignOutUserResponse
+AuthenticationCommonTestFixture::SignOutUser(const std::string& access_token,
+                                             bool do_cancel) {
+  AuthenticationCredentials credentials(id_, secret_);
+  std::promise<AuthenticationClient::SignOutUserResponse> request;
+  auto request_future = request.get_future();
+  auto cancel_token = client_->SignOut(
+      credentials, access_token,
+      [&](const AuthenticationClient::SignOutUserResponse& response) {
+        request.set_value(response);
+      });
+
+  if (do_cancel) {
+    cancel_token.cancel();
+  }
+
+  request_future.wait();
+  return request_future.get();
+}
+
+std::string AuthenticationCommonTestFixture::GetEmail() const {
+  return kTestUserName + "-" + GenerateRandomSequence() + "@example.com";
+}
+
+std::string AuthenticationCommonTestFixture::GenerateBearerHeader(
+    const std::string& user_bearer_token) {
+  std::string authorization = "Bearer ";
+  authorization += user_bearer_token;
+  return authorization;
+}
+
+std::string AuthenticationCommonTestFixture::GenerateRandomSequence() const {
+  static boost::uuids::random_generator gen;
+  return boost::uuids::to_string(gen());
+}
+
+AuthenticationClient::SignInClientResponse
+AuthenticationCommonTestFixture::SignInClient(
+    const AuthenticationCredentials& credentials, std::time_t& now,
+    unsigned int expires_in, bool do_cancel) {
+  std::shared_ptr<AuthenticationClient::SignInClientResponse> response;
+  unsigned int retry = 0u;
+  do {
+    if (retry > 0u) {
+      OLP_SDK_LOG_WARNING(__func__, "Request retry attempted (" << retry
+                                                                << ")");
+      std::this_thread::sleep_for(
+          std::chrono::seconds(retry * kRetryDelayInSecs));
+    }
+
+    std::promise<AuthenticationClient::SignInClientResponse> request;
+    auto request_future = request.get_future();
+
+    now = std::time(nullptr);
+    auto cancel_token = client_->SignInClient(
+        credentials,
+        [&](const AuthenticationClient::SignInClientResponse& resp) {
+          request.set_value(resp);
+        },
+        std::chrono::seconds(expires_in));
+
+    if (do_cancel) {
+      cancel_token.cancel();
+    }
+    request_future.wait();
+    response = std::make_shared<AuthenticationClient::SignInClientResponse>(
+        request_future.get());
+  } while ((!response->IsSuccessful()) && (++retry < kMaxRetryCount) &&
+           !do_cancel);
+
+  return *response;
+}
+
+AuthenticationClient::SignInUserResponse
+AuthenticationCommonTestFixture::SignInUser(const std::string& email,
+                                            bool do_cancel) {
+  AuthenticationCredentials credentials(id_, secret_);
+  AuthenticationClient::UserProperties properties;
+  properties.email = email;
+  properties.password = "password123";
+
+  std::shared_ptr<AuthenticationClient::SignInUserResponse> response;
+  unsigned int retry = 0u;
+  do {
+    if (retry > 0u) {
+      OLP_SDK_LOG_WARNING(__func__, "Request retry attempted (" << retry
+                                                                << ")");
+      std::this_thread::sleep_for(
+          std::chrono::seconds(retry * kRetryDelayInSecs));
+    }
+
+    std::promise<AuthenticationClient::SignInUserResponse> request;
+    auto request_future = request.get_future();
+    auto cancel_token = client_->SignInHereUser(
+        credentials, properties,
+        [&request](const AuthenticationClient::SignInUserResponse& resp) {
+          request.set_value(resp);
+        });
+
+    if (do_cancel) {
+      cancel_token.cancel();
+    }
+
+    request_future.wait();
+    response = std::make_shared<AuthenticationClient::SignInUserResponse>(
+        request_future.get());
+  } while ((!response->IsSuccessful()) && (++retry < kMaxRetryCount) &&
+           !do_cancel);
+
+  return *response;
+}
+
+AuthenticationClient::SignInUserResponse
+AuthenticationCommonTestFixture::SignInRefesh(const std::string& access_token,
+                                              const std::string& refresh_token,
+                                              bool do_cancel) {
+  AuthenticationCredentials credentials(id_, secret_);
+  AuthenticationClient::RefreshProperties properties;
+  properties.access_token = access_token;
+  properties.refresh_token = refresh_token;
+
+  std::shared_ptr<AuthenticationClient::SignInUserResponse> response;
+  unsigned int retry = 0u;
+  do {
+    if (retry > 0u) {
+      OLP_SDK_LOG_WARNING(__func__, "Request retry attempted (" << retry
+                                                                << ")");
+      std::this_thread::sleep_for(
+          std::chrono::seconds(retry * kRetryDelayInSecs));
+    }
+
+    std::promise<AuthenticationClient::SignInUserResponse> request;
+    auto request_future = request.get_future();
+    auto cancel_token = client_->SignInRefresh(
+        credentials, properties,
+        [&request](const AuthenticationClient::SignInUserResponse& resp) {
+          request.set_value(resp);
+        });
+
+    if (do_cancel) {
+      cancel_token.cancel();
+    }
+
+    request_future.wait();
+    response = std::make_shared<AuthenticationClient::SignInUserResponse>(
+        request_future.get());
+  } while ((!response->IsSuccessful()) && (++retry < kMaxRetryCount) &&
+           !do_cancel);
+
+  return *response;
+}
+
+AuthenticationClient::SignUpResponse
+AuthenticationCommonTestFixture::SignUpUser(const std::string& email,
+                                            const std::string& password,
+                                            bool do_cancel) {
+  AuthenticationCredentials credentials(id_, secret_);
+  std::promise<AuthenticationClient::SignUpResponse> request;
+  auto request_future = request.get_future();
+  AuthenticationClient::SignUpProperties properties;
+  properties.email = email;
+  properties.password = password;
+  properties.date_of_birth = "31/01/1980";
+  properties.first_name = "AUTH_TESTER";
+  properties.last_name = "HEREOS";
+  properties.country_code = "USA";
+  properties.language = "en";
+  properties.phone_number = "+1234567890";
+  auto cancel_token = client_->SignUpHereUser(
+      credentials, properties,
+      [&](const AuthenticationClient::SignUpResponse& response) {
+        request.set_value(response);
+      });
+
+  if (do_cancel) {
+    cancel_token.cancel();
+  }
+
+  request_future.wait();
+  return request_future.get();
+}

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.h
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <gtest/gtest.h>
+#include <olp/core/http/Network.h>
+#include <olp/authentication/AuthenticationClient.h>
+#include "AuthenticationUtils.h"
+#include "TestConstants.h"
+
+using namespace ::olp::authentication;
+
+class AuthenticationCommonTestFixture : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite();
+
+  static void TearDownTestSuite();
+
+  void SetUp() override;
+
+  void TearDown() override;
+
+  AuthenticationClient::SignInUserResponse AcceptTerms(
+      const AuthenticationClient::SignInUserResponse& precond_failed_response,
+      bool do_cancel = false);
+
+  AuthenticationUtils::DeleteUserResponse DeleteUser(
+      const std::string& user_bearer_token);
+
+  AuthenticationClient::SignOutUserResponse SignOutUser(
+      const std::string& access_token, bool do_cancel = false);
+
+  std::string GetEmail() const;
+
+  AuthenticationClient::SignInClientResponse SignInClient(
+      const AuthenticationCredentials& credentials, std::time_t& now,
+      unsigned int expires_in = kLimitExpiry, bool do_cancel = false);
+
+  AuthenticationClient::SignInUserResponse SignInUser(const std::string& email,
+                                                      bool do_cancel = false);
+
+  AuthenticationClient::SignInUserResponse SignInRefesh(
+      const std::string& access_token, const std::string& refresh_token,
+      bool do_cancel = false);
+
+  AuthenticationClient::SignUpResponse SignUpUser(
+      const std::string& email, const std::string& password = "password123",
+      bool do_cancel = false);
+
+ protected:
+  std::string id_;
+  std::string secret_;
+  std::shared_ptr<olp::authentication::AuthenticationClient> client_;
+  std::shared_ptr<olp::http::Network> network_;
+  std::shared_ptr<olp::thread::TaskScheduler> task_scheduler_;
+  std::unique_ptr<AuthenticationUtils> utils_;
+
+  static std::shared_ptr<olp::http::Network> s_network_;
+
+ private:
+  std::string GenerateBearerHeader(const std::string& user_bearer_token);
+
+  std::string GenerateRandomSequence() const;
+};

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationFunctionalTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationFunctionalTest.cpp
@@ -1,0 +1,456 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "AuthenticationCommonTestFixture.h"
+
+class AuthenticationFunctionalTest : public AuthenticationCommonTestFixture {};
+
+TEST_F(AuthenticationFunctionalTest, SignInClient) {
+  AuthenticationCredentials credentials(id_, secret_);
+  std::time_t now;
+  AuthenticationClient::SignInClientResponse response =
+      SignInClient(credentials, now, kExpiryTime);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response.GetResult().GetStatus());
+  EXPECT_STREQ(kErrorOk.c_str(),
+               response.GetResult().GetErrorResponse().message.c_str());
+  EXPECT_FALSE(response.GetResult().GetAccessToken().empty());
+  EXPECT_GE(now + kMaxExpiry, response.GetResult().GetExpiryTime());
+  EXPECT_LT(now + kMinExpiry, response.GetResult().GetExpiryTime());
+  EXPECT_FALSE(response.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response.GetResult().GetUserIdentifier().empty());
+
+  now = std::time(nullptr);
+  AuthenticationClient::SignInClientResponse response_2 =
+      SignInClient(credentials, now, kExtendedExpiryTime);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response_2.GetResult().GetStatus());
+  EXPECT_FALSE(response_2.GetResult().GetAccessToken().empty());
+  EXPECT_GE(now + kMaxExtendedExpiry, response_2.GetResult().GetExpiryTime());
+  EXPECT_LT(now + kMinExtendedExpiry, response_2.GetResult().GetExpiryTime());
+  EXPECT_FALSE(response_2.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response_2.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response_2.GetResult().GetUserIdentifier().empty());
+
+  now = std::time(nullptr);
+  AuthenticationClient::SignInClientResponse response_3 =
+      SignInClient(credentials, now, kCustomExpiryTime);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response_3.GetResult().GetStatus());
+  EXPECT_FALSE(response_3.GetResult().GetAccessToken().empty());
+  EXPECT_GE(now + kMaxCustomExpiry, response_3.GetResult().GetExpiryTime());
+  EXPECT_LT(now + kMinCustomExpiry, response_3.GetResult().GetExpiryTime());
+  EXPECT_FALSE(response_3.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response_3.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response_3.GetResult().GetUserIdentifier().empty());
+}
+
+TEST_F(AuthenticationFunctionalTest, SignInClientMaxExpiration) {
+  // Test maximum token expiration 24 h
+  AuthenticationCredentials credentials(id_, secret_);
+
+  std::time_t now;
+  AuthenticationClient::SignInClientResponse response =
+      SignInClient(credentials, now);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response.GetResult().GetStatus());
+  EXPECT_FALSE(response.GetResult().GetAccessToken().empty());
+  EXPECT_STREQ(kErrorOk.c_str(),
+               response.GetResult().GetErrorResponse().message.c_str());
+  EXPECT_GE(now + kMaxLimitExpiry, response.GetResult().GetExpiryTime());
+  EXPECT_LT(now + kMinLimitExpiry, response.GetResult().GetExpiryTime());
+
+  // Test token expiration greater than 24h
+  AuthenticationClient::SignInClientResponse response_2 =
+      SignInClient(credentials, now, 90000);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response_2.GetResult().GetStatus());
+  EXPECT_FALSE(response_2.GetResult().GetAccessToken().empty());
+  EXPECT_GE(now + kMaxLimitExpiry, response_2.GetResult().GetExpiryTime());
+  EXPECT_LT(now + kMinLimitExpiry, response_2.GetResult().GetExpiryTime());
+  EXPECT_FALSE(response_2.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response_2.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response_2.GetResult().GetUserIdentifier().empty());
+}
+
+TEST_F(AuthenticationFunctionalTest, InvalidCredentials) {
+  AuthenticationCredentials credentials(id_, id_);
+
+  std::time_t now;
+  AuthenticationClient::SignInClientResponse response =
+      SignInClient(credentials, now);
+  EXPECT_EQ(olp::http::HttpStatusCode::UNAUTHORIZED,
+            response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorUnauthorizedCode,
+            response.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorUnauthorizedMessage,
+            response.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response.GetResult().GetUserIdentifier().empty());
+}
+
+TEST_F(AuthenticationFunctionalTest, SignInClientCancel) {
+  AuthenticationCredentials credentials(id_, secret_);
+
+  std::time_t now;
+  AuthenticationClient::SignInClientResponse response =
+      SignInClient(credentials, now, kLimitExpiry, true);
+
+  EXPECT_FALSE(response.IsSuccessful());
+  EXPECT_EQ(olp::client::ErrorCode::Cancelled,
+            response.GetError().GetErrorCode());
+}
+
+TEST_F(AuthenticationFunctionalTest, SignUpInUser) {
+  const std::string email = GetEmail();
+  std::cout << "Creating account for: " << email << std::endl;
+
+  AuthenticationClient::SignUpResponse signup_response = SignUpUser(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::CREATED,
+            signup_response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorSignUpCreated,
+            signup_response.GetResult().GetErrorResponse().message);
+  EXPECT_FALSE(signup_response.GetResult().GetUserIdentifier().empty());
+
+  AuthenticationClient::SignInUserResponse response = SignInUser(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::PRECONDITION_FAILED,
+            response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorPreconditionFailedCode,
+            response.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorPreconditionFailedMessage,
+            response.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response.GetResult().GetUserIdentifier().empty());
+  EXPECT_FALSE(response.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_FALSE(response.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_FALSE(response.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_FALSE(response.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_FALSE(response.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::SignInUserResponse response2 = AcceptTerms(response);
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT,
+            response2.GetResult().GetStatus());
+  EXPECT_EQ(kErrorNoContent, response2.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response2.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response2.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response2.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response2.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::SignInUserResponse response3 = SignInUser(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response3.GetResult().GetStatus());
+  EXPECT_STREQ(kErrorOk.c_str(),
+               response3.GetResult().GetErrorResponse().message.c_str());
+  EXPECT_FALSE(response3.GetResult().GetAccessToken().empty());
+  EXPECT_FALSE(response3.GetResult().GetTokenType().empty());
+  EXPECT_FALSE(response3.GetResult().GetRefreshToken().empty());
+  EXPECT_FALSE(response3.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response3.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response3.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationUtils::DeleteUserResponse response4 =
+      DeleteUser(response3.GetResult().GetAccessToken());
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT, response4.status);
+  EXPECT_STREQ(kErrorNoContent.c_str(), response4.error.c_str());
+
+  AuthenticationClient::SignInUserResponse response5 = SignInUser(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::UNAUTHORIZED,
+            response5.GetResult().GetStatus());
+  EXPECT_EQ(kErrorAccountNotFoundCode,
+            response5.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorAccountNotFoundMessage,
+            response5.GetResult().GetErrorResponse().message);
+}
+
+TEST_F(AuthenticationFunctionalTest, SignUpUserCancel) {
+  const std::string email = GetEmail();
+  std::cout << "Creating account for: " << email << std::endl;
+
+  AuthenticationClient::SignUpResponse response =
+      SignUpUser(email, "password123", true);
+  EXPECT_FALSE(response.IsSuccessful());
+  EXPECT_EQ(olp::client::ErrorCode::Cancelled,
+            response.GetError().GetErrorCode());
+}
+
+TEST_F(AuthenticationFunctionalTest, SignInUserCancel) {
+  const std::string email = GetEmail();
+  std::cout << "Creating account for: " << email << std::endl;
+
+  AuthenticationClient::SignUpResponse signup_response = SignUpUser(email);
+  EXPECT_TRUE(signup_response.IsSuccessful());
+
+  AuthenticationClient::SignInUserResponse response = SignInUser(email, true);
+  EXPECT_FALSE(response.IsSuccessful());
+  EXPECT_EQ(olp::client::ErrorCode::Cancelled,
+            response.GetError().GetErrorCode());
+}
+
+TEST_F(AuthenticationFunctionalTest, AcceptTermCancel) {
+  const std::string email = GetEmail();
+  std::cout << "Creating account for: " << email << std::endl;
+
+  AuthenticationClient::SignUpResponse signup_response = SignUpUser(email);
+  EXPECT_TRUE(signup_response.IsSuccessful());
+
+  AuthenticationClient::SignInUserResponse response = SignInUser(email);
+  EXPECT_TRUE(response.IsSuccessful());
+
+  AuthenticationClient::SignInUserResponse response2 =
+      AcceptTerms(response, true);
+  EXPECT_FALSE(response2.IsSuccessful());
+  EXPECT_EQ(olp::client::ErrorCode::Cancelled,
+            response2.GetError().GetErrorCode());
+
+  AuthenticationClient::SignInUserResponse response3 = SignInUser(email);
+  EXPECT_TRUE(response.IsSuccessful());
+
+  AuthenticationClient::SignOutUserResponse signOutResponse =
+      SignOutUser(response3.GetResult().GetAccessToken());
+  EXPECT_FALSE(response2.IsSuccessful());
+  EXPECT_EQ(olp::client::ErrorCode::Cancelled,
+            response2.GetError().GetErrorCode());
+
+  AuthenticationUtils::DeleteUserResponse response4 =
+      DeleteUser(response3.GetResult().GetAccessToken());
+}
+
+TEST_F(AuthenticationFunctionalTest, SignInRefresh) {
+  const std::string email = GetEmail();
+  std::cout << "Creating account for: " << email << std::endl;
+
+  AuthenticationClient::SignUpResponse signup_response = SignUpUser(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::CREATED,
+            signup_response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorSignUpCreated,
+            signup_response.GetResult().GetErrorResponse().message);
+  EXPECT_FALSE(signup_response.GetResult().GetUserIdentifier().empty());
+
+  AuthenticationClient::SignInUserResponse response = SignInUser(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::PRECONDITION_FAILED,
+            response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorPreconditionFailedCode,
+            response.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorPreconditionFailedMessage,
+            response.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response.GetResult().GetUserIdentifier().empty());
+  EXPECT_FALSE(response.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_FALSE(response.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_FALSE(response.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_FALSE(response.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_FALSE(response.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::SignInUserResponse response2 = AcceptTerms(response);
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT,
+            response2.GetResult().GetStatus());
+  EXPECT_EQ(kErrorNoContent, response2.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response2.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response2.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response2.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response2.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::SignInUserResponse response3 = SignInUser(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response3.GetResult().GetStatus());
+  EXPECT_EQ(kErrorOk, response3.GetResult().GetErrorResponse().message);
+  EXPECT_FALSE(response3.GetResult().GetAccessToken().empty());
+  EXPECT_FALSE(response3.GetResult().GetTokenType().empty());
+  EXPECT_FALSE(response3.GetResult().GetRefreshToken().empty());
+  EXPECT_FALSE(response3.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response3.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response3.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::SignInUserResponse response4 =
+      SignInRefesh(response3.GetResult().GetAccessToken(),
+                   response3.GetResult().GetRefreshToken());
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response4.GetResult().GetStatus());
+  EXPECT_EQ(kErrorOk, response4.GetResult().GetErrorResponse().message);
+  EXPECT_FALSE(response4.GetResult().GetAccessToken().empty());
+  EXPECT_FALSE(response4.GetResult().GetTokenType().empty());
+  EXPECT_FALSE(response4.GetResult().GetRefreshToken().empty());
+  EXPECT_FALSE(response4.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response4.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response4.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response4.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response4.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response4.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::SignInUserResponse response5 =
+      SignInRefesh("12345", response3.GetResult().GetRefreshToken());
+  EXPECT_EQ(olp::http::HttpStatusCode::UNAUTHORIZED,
+            response5.GetResult().GetStatus());
+  EXPECT_EQ(kErrorRefreshFailedCode,
+            response5.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorRefreshFailedMessage,
+            response5.GetResult().GetErrorResponse().message);
+
+  AuthenticationUtils::DeleteUserResponse response6 =
+      DeleteUser(response4.GetResult().GetAccessToken());
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT, response6.status);
+  EXPECT_STREQ(kErrorNoContent.c_str(), response6.error.c_str());
+
+  AuthenticationClient::SignInUserResponse response7 = SignInUser(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::UNAUTHORIZED,
+            response7.GetResult().GetStatus());
+  EXPECT_EQ(kErrorAccountNotFoundCode,
+            response7.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorAccountNotFoundMessage,
+            response7.GetResult().GetErrorResponse().message);
+}
+
+TEST_F(AuthenticationFunctionalTest, SignInRefreshCancel) {
+  const std::string email = GetEmail();
+  std::cout << "Creating account for: " << email << std::endl;
+
+  AuthenticationClient::SignUpResponse signup_response = SignUpUser(email);
+  EXPECT_TRUE(signup_response.IsSuccessful());
+
+  AuthenticationClient::SignInUserResponse response = SignInUser(email);
+  EXPECT_TRUE(response.IsSuccessful());
+  EXPECT_EQ(olp::http::HttpStatusCode::PRECONDITION_FAILED,
+            response.GetResult().GetStatus());
+
+  AuthenticationClient::SignInUserResponse response2 = AcceptTerms(response);
+  EXPECT_TRUE(response2.IsSuccessful());
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT,
+            response2.GetResult().GetStatus());
+
+  AuthenticationClient::SignInUserResponse response3 = SignInUser(email);
+  EXPECT_TRUE(response3.IsSuccessful());
+
+  AuthenticationClient::SignInUserResponse response4 =
+      SignInRefesh(response3.GetResult().GetAccessToken(),
+                   response3.GetResult().GetRefreshToken(), true);
+  EXPECT_FALSE(response4.IsSuccessful());
+  EXPECT_EQ(olp::client::ErrorCode::Cancelled,
+            response4.GetError().GetErrorCode());
+
+  AuthenticationUtils::DeleteUserResponse response5 =
+      DeleteUser(response3.GetResult().GetAccessToken());
+}
+
+TEST_F(AuthenticationFunctionalTest, SignOutUser) {
+  const std::string email = GetEmail();
+  std::cout << "Creating account for: " << email << std::endl;
+
+  AuthenticationClient::SignUpResponse signup_response = SignUpUser(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::CREATED,
+            signup_response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorSignUpCreated,
+            signup_response.GetResult().GetErrorResponse().message);
+  EXPECT_FALSE(signup_response.GetResult().GetUserIdentifier().empty());
+
+  AuthenticationClient::SignInUserResponse response = SignInUser(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::PRECONDITION_FAILED,
+            response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorPreconditionFailedCode,
+            response.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorPreconditionFailedMessage,
+            response.GetResult().GetErrorResponse().message);
+
+  AuthenticationClient::SignInUserResponse response2 = AcceptTerms(response);
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT,
+            response2.GetResult().GetStatus());
+  EXPECT_STREQ(kErrorNoContent.c_str(),
+               response2.GetResult().GetErrorResponse().message.c_str());
+
+  AuthenticationClient::SignInUserResponse response3 = SignInUser(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response3.GetResult().GetStatus());
+  EXPECT_STREQ(kErrorOk.c_str(),
+               response3.GetResult().GetErrorResponse().message.c_str());
+
+  AuthenticationClient::SignOutUserResponse signOutResponse =
+      SignOutUser(response3.GetResult().GetAccessToken());
+  EXPECT_TRUE(signOutResponse.IsSuccessful());
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT,
+            signOutResponse.GetResult().GetStatus());
+  EXPECT_EQ(kErrorNoContent,
+            signOutResponse.GetResult().GetErrorResponse().message);
+
+  AuthenticationUtils::DeleteUserResponse response4 =
+      DeleteUser(response3.GetResult().GetAccessToken());
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT, response4.status);
+  EXPECT_STREQ(kErrorNoContent.c_str(), response4.error.c_str());
+}
+
+TEST_F(AuthenticationFunctionalTest, NetworkProxySettings) {
+  AuthenticationCredentials credentials(id_, secret_);
+
+  auto proxy_settings = olp::http::NetworkProxySettings();
+  client_->SetNetworkProxySettings(proxy_settings);
+  proxy_settings.WithHostname("$.?");
+  proxy_settings.WithPort(42);
+  proxy_settings.WithType(olp::http::NetworkProxySettings::Type::SOCKS4);
+
+  client_->SetNetworkProxySettings(proxy_settings);
+  std::time_t now;
+  auto response = SignInClient(credentials, now, kExpiryTime);
+  // Bad proxy error code and message varies by platform
+  EXPECT_FALSE(response.IsSuccessful());
+  EXPECT_TRUE(response.GetError().GetErrorCode() ==
+              olp::client::ErrorCode::ServiceUnavailable);
+  EXPECT_STRNE(response.GetError().GetMessage().c_str(), kErrorOk.c_str());
+}
+
+TEST_F(AuthenticationFunctionalTest, ErrorFields) {
+  static const std::string PASSWORD = "password";
+  static const std::string EMAIL = "email";
+
+  AuthenticationClient::SignUpResponse signup_response =
+      SignUpUser("a/*<@test.com", "password");
+  EXPECT_TRUE(signup_response.IsSuccessful());
+  EXPECT_EQ(olp::http::HttpStatusCode::BAD_REQUEST,
+            signup_response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorFieldsCode,
+            signup_response.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorFieldsMessage,
+            signup_response.GetResult().GetErrorResponse().message);
+  EXPECT_EQ(2, signup_response.GetResult().GetErrorFields().size());
+  int count = 0;
+  for (ErrorFields::const_iterator it =
+           signup_response.GetResult().GetErrorFields().begin();
+       it != signup_response.GetResult().GetErrorFields().end(); it++) {
+    const std::string name = count == 0 ? EMAIL : PASSWORD;
+    const std::string message =
+        count == 0 ? kErrorIllegalEmail : kErrorBlacklistedPassword;
+    unsigned int code =
+        count == 0 ? kErrorIllegalEmailCode : kErrorBlacklistedPasswordCode;
+    count++;
+    EXPECT_EQ(name, it->name);
+    EXPECT_EQ(message, it->message);
+    EXPECT_EQ(code, it->code);
+  }
+}

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationUtils.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationUtils.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "AuthenticationUtils.h"
+
+#include <chrono>
+#include <sstream>
+
+#include <olp/core/http/Network.h>
+#include <olp/core/http/NetworkRequest.h>
+#include <olp/core/http/NetworkResponse.h>
+#include <olp/core/porting/make_unique.h>
+#include <olp/core/utils/Url.h>
+
+namespace {
+constexpr auto kHypeDevEnvPartitionHrn = "here-dev";
+constexpr auto kHypeProdEnvPartitionHrn = "here";
+
+const std::map<std::string, std::string> authentication_server_url = {
+    {kHypeDevEnvPartitionHrn, "https://stg.account.api.here.com"},
+    {kHypeProdEnvPartitionHrn, "https://account.api.here.com"}};
+
+// Tags
+constexpr auto kAuthorization = "Authorization";
+constexpr auto kContentType = "Content-Type";
+constexpr auto kApplicationJson = "application/json";
+constexpr auto kDeleteUserEndpoint = "/user/me";
+
+}  // namespace
+
+namespace olp {
+namespace authentication {
+class AuthenticationUtils::Impl {
+ public:
+  /**
+   * @brief Constructor
+   * @param token_cache_limit Maximum number of tokens that will be cached.
+   */
+  Impl();
+
+  virtual ~Impl() = default;
+
+  void DeleteHereUser(olp::http::Network& network,
+                      const olp::http::NetworkSettings& network_settings,
+                      const std::string& user_bearer_token,
+                      const DeleteHereUserCallback& callback);
+
+ private:
+  std::string Base64Encode(const std::vector<uint8_t>& vector);
+
+  std::string GenerateBearerHeader(const std::string& user_bearer_token);
+
+  std::string GenerateUid(size_t length = 32u, size_t groupLength = 8u);
+};
+
+AuthenticationUtils::Impl::Impl() {
+  srand(static_cast<unsigned int>(
+      std::chrono::system_clock::now().time_since_epoch().count()));
+}
+
+void AuthenticationUtils::Impl::DeleteHereUser(
+    olp::http::Network& network,
+    const olp::http::NetworkSettings& network_settings,
+    const std::string& user_bearer_token,
+    const DeleteHereUserCallback& callback) {
+  std::string url = authentication_server_url.at(kHypeDevEnvPartitionHrn);
+  url.append(kDeleteUserEndpoint);
+
+  olp::http::NetworkRequest request(url);
+  request.WithVerb(http::NetworkRequest::HttpVerb::DEL);
+  request.WithHeader(kAuthorization, GenerateBearerHeader(user_bearer_token));
+  request.WithHeader(kContentType, kApplicationJson);
+  request.WithSettings(network_settings);
+
+  std::shared_ptr<std::stringstream> payload =
+      std::make_shared<std::stringstream>();
+  network.Send(
+      request, payload,
+      [callback, payload](const olp::http::NetworkResponse& network_response) {
+        DeleteUserResponse response;
+        response.status = network_response.GetStatus();
+        response.error = network_response.GetError();
+        callback(response);
+      });
+}
+
+std::string AuthenticationUtils::Impl::GenerateBearerHeader(
+    const std::string& user_bearer_token) {
+  std::string authorization = "Bearer ";
+  authorization += user_bearer_token;
+  return authorization;
+}
+
+AuthenticationUtils::AuthenticationUtils() : d_(std::make_unique<Impl>()) {}
+
+AuthenticationUtils::~AuthenticationUtils() = default;
+
+void AuthenticationUtils::DeleteHereUser(
+    olp::http::Network& network,
+    const olp::http::NetworkSettings& network_settings,
+    const std::string& user_bearer_token,
+    const DeleteHereUserCallback& callback) {
+  d_->DeleteHereUser(network, network_settings, user_bearer_token, callback);
+}
+
+}  // namespace authentication
+}  // namespace olp
+

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationUtils.h
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationUtils.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace olp {
+
+namespace http {
+class Network;
+class NetworkSettings;
+}  // namespace http
+
+namespace authentication {
+/**
+ * @brief Authetication Utils
+ */
+class AuthenticationUtils {
+ public:
+  struct DeleteUserResponse {
+    int status;
+    std::string error;
+  };
+
+  AuthenticationUtils();
+  virtual ~AuthenticationUtils();
+
+  using DeleteHereUserCallback =
+      std::function<void(const DeleteUserResponse& response)>;
+
+  void DeleteHereUser(olp::http::Network& network,
+                      const olp::http::NetworkSettings& network_settings,
+                      const std::string& user_bearer_token,
+                      const DeleteHereUserCallback& callback);
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> d_;
+};
+
+}  // namespace authentication
+}  // namespace olp

--- a/tests/functional/olp-cpp-sdk-authentication/TestConstants.h
+++ b/tests/functional/olp-cpp-sdk-authentication/TestConstants.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+
+namespace olp {
+namespace authentication {
+static const std::string kHereAccountStagingURL =
+    "https://stg.account.api.here.com";
+static const std::string kHereAccountOauth2Endpoint = "/oauth2/token";
+
+constexpr auto kMaxRetryCount = 3u;
+constexpr auto kRetryDelayInSecs = 2u;
+
+constexpr auto kLimitExpiry = 86400u;
+
+constexpr auto kExpiryTime = 3600u;
+constexpr auto kMaxExpiry = kExpiryTime + 30u;
+constexpr auto kMinExpiry = kExpiryTime - 10u;
+
+constexpr auto kCustomExpiryTime = 6000u;
+constexpr auto kMaxCustomExpiry = kCustomExpiryTime + 30u;
+constexpr auto kMinCustomExpiry = kCustomExpiryTime - 10u;
+
+constexpr auto kExtendedExpiryTime = 2 * kExpiryTime;
+constexpr auto kMaxExtendedExpiry = kExtendedExpiryTime + 30u;
+constexpr auto kMinExtendedExpiry = kExtendedExpiryTime - 10u;
+
+constexpr auto kMaxLimitExpiry = kLimitExpiry + 30u;
+constexpr auto kMinLimitExpiry = kLimitExpiry - 10u;
+
+static const std::string kTestUserName = "HA-UnitTestUser-Edge";
+static const std::string kTestAppKeyId = "Ha-Integration-Test-App";
+static const std::string kTestAppKeySecret = "ha-test-secret-1";
+
+const static std::string kAccessToken = "access_token";
+
+const static std::string kQuestionParam = "?";
+const static std::string kEqualsParam = "=";
+const static std::string kAndParam = "&";
+
+// HTTP errors codes
+constexpr auto kErrorAccountNotFoundCode = 401600;
+constexpr auto kErrorBlacklistedPasswordCode = 400205;
+constexpr auto kErrorFieldsCode = 400200;
+constexpr auto kErrorIllegalEmailCode = 400240;
+constexpr auto kErrorPreconditionCreatedCode = 412001;
+constexpr auto kErrorPreconditionFailedCode = 412001;
+constexpr auto kErrorRefreshFailedCode = 400601;
+constexpr auto kErrorUnauthorizedCode = 401300;
+
+// HTTP response messages
+static const std::string kErrorAccountNotFoundMessage =
+    "No account found for given account Id.";
+static const std::string kErrorBlacklistedPassword = "Black listed password.";
+static const std::string kErrorFieldsMessage = "Received invalid data.";
+static const std::string kErrorIllegalEmail = "Illegal email.";
+static const std::string kErrorNoContent = "No Content";
+static const std::string kErrorOk = "OK";
+static const std::string kErrorPreconditionCreatedMessage = "Created";
+static const std::string kErrorPreconditionFailedMessage =
+    "Precondition Failed";
+static const std::string kErrorRefreshFailedMessage = "Invalid accessToken.";
+static const std::string kErrorSignUpCreated = "Created";
+static const std::string kErrorUnauthorizedMessage =
+    "Signature mismatch. Authorization signature or client credential is "
+    "wrong.";
+
+
+}  // namespace authentication
+}  // namespace olp

--- a/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -18,7 +18,6 @@
  */
 
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
 
 #include <future>
 #include <memory>
@@ -26,9 +25,7 @@
 #include <olp/core/porting/make_unique.h>
 #include <olp/core/http/HttpStatusCode.h>
 #include "olp/core/client/OlpClientSettingsFactory.h"
-
 #include <olp/authentication/AuthenticationClient.h>
-
 #include <mocks/NetworkMock.h>
 
 #include "AuthenticationMockedResponses.h"


### PR DESCRIPTION
Copied AuthenticationOnlineTest from olp-sdk-cpp-authentication/tests folder to <root>/tests/functional folder in order to meet the Pitchfork layout model.

Also, following changes were applied:
 - renamed AuthenticationOnlineTest.h -> AuthenticationCommonTestFixture.h
 - added AuthenticationCommonTestFixture.cpp to reduce compilation times between other test suites;
 - renamed AuthenticationOnlineTest.cpp -> AuthenticationFunctionalTest.cpp
 - renamed CommonTestUtils.h -> TestConstants.h
 - applied Google C++ Code Style guidelines

Realtes to: OLPEDGE-718

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>