### PR TITLE
Copy CatalogClient Fixture to the base class

### DIFF
--- a/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ cmake_minimum_required(VERSION 3.5)
 set(OLP_SDK_DATASERVICE_READ_TEST_SOURCES
     ApiClientLookupTest.cpp
     CatalogClientTest.cpp
+    CatalogClientTestBase.cpp
     HttpResponses.h
     MultiRequestContextTest.cpp
     ParserTest.cpp

--- a/olp-cpp-sdk-dataservice-read/tests/CatalogClientTestBase.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/CatalogClientTestBase.cpp
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "CatalogClientTestBase.h"
+
+#include <matchers/NetworkUrlMatchers.h>
+
+#include "HttpResponses.h"
+
+using ::testing::_;
+
+CatalogClientTestBase::CatalogClientTestBase() = default;
+
+CatalogClientTestBase::~CatalogClientTestBase() = default;
+
+std::string CatalogClientTestBase::GetTestCatalog() {
+  return "hrn:here:data:::hereos-internal-test-v2";
+}
+
+std::string CatalogClientTestBase::ApiErrorToString(
+    const olp::client::ApiError& error) {
+  std::ostringstream result_stream;
+  result_stream << "ERROR: code: " << static_cast<int>(error.GetErrorCode())
+                << ", status: " << error.GetHttpStatusCode()
+                << ", message: " << error.GetMessage();
+  return result_stream.str();
+}
+
+void CatalogClientTestBase::SetUp() {
+  network_mock_ = std::make_shared<NetworkMock>();
+  settings_ = std::make_shared<olp::client::OlpClientSettings>();
+  settings_->network_request_handler = network_mock_;
+  client_ = olp::client::OlpClientFactory::Create(*settings_);
+
+  SetUpCommonNetworkMockCalls();
+}
+
+void CatalogClientTestBase::TearDown() {
+  client_.reset();
+  settings_.reset();
+  network_mock_.reset();
+}
+
+void CatalogClientTestBase::SetUpCommonNetworkMockCalls() {
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_LOOKUP_CONFIG));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_CONFIG), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200), HTTP_RESPONSE_CONFIG));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_METADATA), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_LOOKUP_METADATA));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_LATEST_CATALOG_VERSION), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_LATEST_CATALOG_VERSION));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_LAYER_VERSIONS), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_LAYER_VERSIONS));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_PARTITIONS));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_QUERY), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_LOOKUP_QUERY));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_QUERY_PARTITION_269), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_PARTITION_269));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_LOOKUP_BLOB));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_BLOB_DATA_269));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITION_3), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_PARTITION_3));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_LOOKUP_VOLATILE_BLOB), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_LOOKUP_VOLATILE_BLOB));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_LAYER_VERSIONS_V2), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_LAYER_VERSIONS_V2));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS_V2), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_PARTITIONS_V2));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_QUERY_PARTITION_269_V2), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_PARTITION_269_V2));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269_V2), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_BLOB_DATA_269_V2));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_QUERY_PARTITION_269_V10), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(400),
+          HTTP_RESPONSE_INVALID_VERSION_V10));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_QUERY_PARTITION_269_VN1), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(400),
+          HTTP_RESPONSE_INVALID_VERSION_VN1));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_LAYER_VERSIONS_V10), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(400),
+          HTTP_RESPONSE_INVALID_VERSION_V10));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_LAYER_VERSIONS_VN1), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(400),
+          HTTP_RESPONSE_INVALID_VERSION_VN1));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_CONFIG_V2), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_CONFIG_V2));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_QUADKEYS_23618364), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_QUADKEYS_23618364));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_QUADKEYS_1476147), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_QUADKEYS_1476147));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_QUADKEYS_5904591), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_QUADKEYS_5904591));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_QUADKEYS_369036), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_QUADKEYS_369036));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_1), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_BLOB_DATA_PREFETCH_1));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_2), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_BLOB_DATA_PREFETCH_2));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_3), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_BLOB_DATA_PREFETCH_3));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_4), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_BLOB_DATA_PREFETCH_4));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_5), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_BLOB_DATA_PREFETCH_5));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_6), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_BLOB_DATA_PREFETCH_6));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_7), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200),
+          HTTP_RESPONSE_BLOB_DATA_PREFETCH_7));
+
+  // Catch any non-interesting network calls that don't need to be verified
+  EXPECT_CALL(*network_mock_, Send(_, _, _, _, _)).Times(testing::AtLeast(0));
+}

--- a/olp-cpp-sdk-dataservice-read/tests/CatalogClientTestBase.h
+++ b/olp-cpp-sdk-dataservice-read/tests/CatalogClientTestBase.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gmock/gmock.h>
+
+#include <olp/core/client/ApiError.h>
+#include <olp/core/client/OlpClient.h>
+#include <olp/core/client/OlpClientFactory.h>
+
+#include <mocks/NetworkMock.h>
+
+enum class CacheType { IN_MEMORY, DISK, BOTH };
+
+class CatalogClientTestBase : public ::testing::TestWithParam<CacheType> {
+ public:
+  CatalogClientTestBase();
+  ~CatalogClientTestBase();
+  std::string GetTestCatalog();
+  static std::string ApiErrorToString(const olp::client::ApiError& error);
+
+ protected:
+  void SetUp() override;
+  void TearDown() override;
+
+ private:
+  void SetUpCommonNetworkMockCalls();
+
+ protected:
+  std::shared_ptr<olp::client::OlpClientSettings> settings_;
+  std::shared_ptr<olp::client::OlpClient> client_;
+  std::shared_ptr<NetworkMock> network_mock_;
+};


### PR DESCRIPTION
This will ease separation of CatalogClientTest and
CatalogClientCacheTest.

Relates-to: OLPEDGE-719
Signed-off-by: Serhii Lysenko <ext-serhii.lysenko@here.com>