### PR TITLE
Copied FacebookAuthenticationOnlineTest to <root>/tests/functional

### DIFF
--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -25,12 +25,15 @@ set(OLP_SDK_FUNCTIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.cpp
     ./olp-cpp-sdk-authentication/AuthenticationFunctionalTest.cpp
     ./olp-cpp-sdk-authentication/AuthenticationUtils.cpp
+    ./olp-cpp-sdk-authentication/FacebookAuthenticationTest.cpp
+    ./olp-cpp-sdk-authentication/FacebookTestUtils.cpp
 )
 
 set(OLP_SDK_FUNCTIONAL_TESTS_HEADERS
     ./olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.h
     ./olp-cpp-sdk-authentication/AuthenticationUtils.h
     ./olp-cpp-sdk-authentication/TestConstants.h
+    ./olp-cpp-sdk-authentication/FacebookTestUtils.h
 )
 
 if (ANDROID OR IOS)

--- a/tests/functional/olp-cpp-sdk-authentication/FacebookAuthenticationTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/FacebookAuthenticationTest.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <olp/core/http/HttpStatusCode.h>
+#include <olp/core/logging/Log.h>
+#include <olp/core/porting/make_unique.h>
+#include "AuthenticationCommonTestFixture.h"
+#include "FacebookTestUtils.h"
+#include "TestConstants.h"
+
+using namespace ::olp::authentication;
+
+namespace {
+
+static const int kErrorFacebookErrorCode = 400300;
+
+const std::string kErrorFacebookFailedMessage = "Unexpected Facebook error.";
+
+}  // namespace
+
+class FacebookAuthenticationTest : public AuthenticationCommonTestFixture {
+ protected:
+  void SetUp() override {
+    AuthenticationCommonTestFixture::SetUp();
+
+    facebook_utils_ = std::make_unique<FacebookTestUtils>();
+    ASSERT_TRUE(facebook_utils_->CreateFacebookTestUser(
+        *network_, olp::http::NetworkSettings(), test_user_, "email"));
+
+    id_ = kTestAppKeyId;
+    secret_ = kTestAppKeySecret;
+  }
+
+  void TearDown() override {
+    DeleteFacebookTestUser(*network_, olp::http::NetworkSettings(),
+                           test_user_.id);
+
+    test_user_ = FacebookTestUtils::FacebookUser{};
+    AuthenticationCommonTestFixture::TearDown();
+  }
+
+  AuthenticationClient::SignInUserResponse SignInFacebook(
+      std::string token = "") {
+    AuthenticationCredentials credentials(id_, secret_);
+    std::promise<AuthenticationClient::SignInUserResponse> request;
+    auto request_future = request.get_future();
+    AuthenticationClient::FederatedProperties properties;
+    properties.access_token = token.empty() ? test_user_.access_token : token;
+    properties.country_code = "usa";
+    properties.language = "en";
+    properties.email = kTestUserName + "@example.com";
+
+    client_->SignInFacebook(
+        credentials, properties,
+        [&](const AuthenticationClient::SignInUserResponse& response) {
+          request.set_value(response);
+        });
+    return request_future.get();
+  }
+
+  void DeleteFacebookTestUser(
+      olp::http::Network& network,
+      const olp::http::NetworkSettings& network_settings,
+      const std::string& id) {
+    for (int retry = 0; retry < 3; ++retry) {
+      if (facebook_utils_->DeleteFacebookTestUser(network, network_settings,
+                                                  id)) {
+        return;
+      }
+
+      std::this_thread::sleep_for(std::chrono::seconds(retry));
+    }
+  }
+
+ private:
+  FacebookTestUtils::FacebookUser test_user_;
+  std::unique_ptr<FacebookTestUtils> facebook_utils_;
+};
+
+TEST_F(FacebookAuthenticationTest, SignInFacebook) {
+  AuthenticationClient::SignInUserResponse response = SignInFacebook();
+  EXPECT_EQ(olp::http::HttpStatusCode::CREATED,
+            response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorPreconditionCreatedCode,
+            response.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorPreconditionCreatedMessage,
+            response.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response.GetResult().GetUserIdentifier().empty());
+  EXPECT_FALSE(response.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_FALSE(response.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_FALSE(response.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_FALSE(response.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_FALSE(response.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::SignInUserResponse response2 = AcceptTerms(response);
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT,
+            response2.GetResult().GetStatus());
+  EXPECT_EQ(kErrorNoContent, response2.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response2.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response2.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response2.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response2.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::SignInUserResponse response3 = SignInFacebook();
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response3.GetResult().GetStatus());
+  EXPECT_EQ(kErrorOk, response3.GetResult().GetErrorResponse().message);
+  EXPECT_FALSE(response3.GetResult().GetAccessToken().empty());
+  EXPECT_FALSE(response3.GetResult().GetTokenType().empty());
+  EXPECT_FALSE(response3.GetResult().GetRefreshToken().empty());
+  EXPECT_FALSE(response3.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response3.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response3.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationUtils::DeleteUserResponse response4 =
+      DeleteUser(response3.GetResult().GetAccessToken());
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT, response4.status);
+  EXPECT_STREQ(kErrorNoContent.c_str(), response4.error.c_str());
+
+  // SignIn with invalid token
+  AuthenticationClient::SignInUserResponse response5 = SignInFacebook("12345");
+  EXPECT_EQ(olp::http::HttpStatusCode::UNAUTHORIZED,
+            response5.GetResult().GetStatus());
+  EXPECT_EQ(kErrorFacebookErrorCode,
+            response5.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorFacebookFailedMessage,
+            response5.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response5.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response5.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response5.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response5.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response5.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response5.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response5.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response5.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response5.GetResult().GetPrivatePolicyUrlJson().empty());
+}

--- a/tests/functional/olp-cpp-sdk-authentication/FacebookTestUtils.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/FacebookTestUtils.cpp
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+#include "FacebookTestUtils.h"
+
+#ifndef WIN32
+#include <unistd.h>
+#endif
+
+#include <future>
+#include <sstream>
+
+#include <rapidjson/document.h>
+#include <rapidjson/istreamwrapper.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+#include <olp/core/http/HttpStatusCode.h>
+#include <olp/core/http/Network.h>
+#include <olp/core/logging/Log.h>
+#include <olp/core/porting/make_unique.h>
+#include <testutils/CustomParameters.hpp>
+#include "TestConstants.h"
+
+namespace {
+constexpr auto kInstalledStatus = "true";
+
+constexpr auto kTestUserPath = "/accounts/test-users";
+constexpr auto kFacebookUrl = "https://graph.facebook.com/v2.12";
+
+constexpr auto kInstalled = "installed";
+constexpr auto kName = "name";
+constexpr auto kPermissions = "permissions";
+constexpr auto kId = "id";
+
+const std::string kAccessToken = "access_token";
+}  // namespace
+
+namespace olp {
+namespace authentication {
+class FacebookTestUtils::Impl {
+ public:
+  Impl() = default;
+
+  virtual ~Impl() = default;
+
+  bool CreateFacebookTestUser(
+      http::Network& network,
+      const olp::http::NetworkSettings& network_settings, FacebookUser& user,
+      std::string permissions);
+  bool DeleteFacebookTestUser(
+      olp::http::Network& network,
+      const olp::http::NetworkSettings& network_settings,
+      const std::string& user_id);
+};
+
+bool FacebookTestUtils::Impl::CreateFacebookTestUser(
+    olp::http::Network& network,
+    const olp::http::NetworkSettings& network_settings, FacebookUser& user,
+    std::string permissions) {
+  std::string url = std::string() + kFacebookUrl + "/" +
+                    CustomParameters::getArgument("facebook_app_id") +
+                    kTestUserPath;
+  ;
+  url.append(kQuestionParam);
+  url.append(kAccessToken + kEqualsParam +
+             CustomParameters::getArgument("facebook_access_token"));
+  url.append(kAndParam);
+  url.append(kInstalled + kEqualsParam + kInstalledStatus);
+  url.append(kAndParam);
+  url.append(kName + kEqualsParam + kTestUserName);
+  if (!permissions.empty()) {
+    url.append(kAndParam);
+    url.append(kPermissions + kEqualsParam + permissions);
+  }
+  olp::http::NetworkRequest request(url);
+  request.WithVerb(http::NetworkRequest::HttpVerb::POST);
+  request.WithSettings(network_settings);
+
+  unsigned int retry = 0u;
+  do {
+    if (retry > 0u) {
+      OLP_SDK_LOG_WARNING(__func__, "Request retry attempted (" << retry
+                                                                << ")");
+      std::this_thread::sleep_for(
+          std::chrono::seconds(retry * kRetryDelayInSecs));
+    }
+
+    auto payload = std::make_shared<std::stringstream>();
+
+    std::promise<void> promise;
+    auto future = promise.get_future();
+    network.Send(
+        request, payload,
+        [payload, &promise,
+         &user](const olp::http::NetworkResponse& network_response) {
+          user.status = network_response.GetStatus();
+          if (user.status == olp::http::HttpStatusCode::OK) {
+            auto document = std::make_shared<rapidjson::Document>();
+            rapidjson::IStreamWrapper stream(*payload.get());
+            document->ParseStream(stream);
+            bool is_valid = !document->HasParseError() &&
+                            document->HasMember(kAccessToken.c_str()) &&
+                            document->HasMember(kId);
+
+            if (is_valid) {
+              user.access_token = (*document)[kAccessToken.c_str()].GetString();
+              user.id = (*document)[kId].GetString();
+            }
+          }
+          promise.set_value();
+        });
+    future.wait();
+  } while ((user.status < 0) && (++retry < kMaxRetryCount));
+
+  return !user.id.empty() && !user.access_token.empty();
+}
+
+bool FacebookTestUtils::Impl::DeleteFacebookTestUser(
+    http::Network& network, const olp::http::NetworkSettings& network_settings,
+    const std::string& user_id) {
+  std::string url = std::string() + kFacebookUrl + "/" + user_id;
+  url.append(kQuestionParam);
+  url.append(kAccessToken + kEqualsParam +
+             CustomParameters::getArgument("facebook_access_token"));
+  olp::http::NetworkRequest request(url);
+  request.WithVerb(http::NetworkRequest::HttpVerb::DEL);
+  request.WithSettings(network_settings);
+
+  int status = 0;
+  unsigned int retry = 0u;
+  do {
+    if (retry > 0u) {
+      OLP_SDK_LOG_WARNING(__func__, "Request retry attempted (" << retry
+                                                                << ")");
+      std::this_thread::sleep_for(
+          std::chrono::seconds(retry * kRetryDelayInSecs));
+    }
+
+    auto payload = std::make_shared<std::stringstream>();
+
+    std::promise<void> promise;
+    auto future = promise.get_future();
+    network.Send(request, payload,
+                 [payload, &promise,
+                  &status](const olp::http::NetworkResponse& network_response) {
+                   status = network_response.GetStatus();
+                   promise.set_value();
+                 });
+    future.wait();
+  } while ((status < 0) && (++retry < kMaxRetryCount));
+
+  return (status == olp::http::HttpStatusCode::OK);
+}
+
+FacebookTestUtils::FacebookTestUtils()
+    : impl_(std::make_unique<FacebookTestUtils::Impl>()) {}
+
+FacebookTestUtils::~FacebookTestUtils() = default;
+
+bool FacebookTestUtils::CreateFacebookTestUser(
+    http::Network& network, const olp::http::NetworkSettings& network_settings,
+    FacebookUser& user, const std::string& permissions) {
+  return impl_->CreateFacebookTestUser(network, network_settings, user,
+                                       permissions);
+}
+
+bool FacebookTestUtils::DeleteFacebookTestUser(
+    olp::http::Network& network,
+    const olp::http::NetworkSettings& network_settings, std::string user_id) {
+  return impl_->DeleteFacebookTestUser(network, network_settings, user_id);
+}
+
+}  // namespace authentication
+}  // namespace olp

--- a/tests/functional/olp-cpp-sdk-authentication/FacebookTestUtils.h
+++ b/tests/functional/olp-cpp-sdk-authentication/FacebookTestUtils.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+#pragma once
+
+#include <memory>
+#include <string>
+
+namespace olp {
+
+namespace http {
+class Network;
+class NetworkSettings;
+}  // namespace http
+
+namespace authentication {
+class FacebookTestUtils {
+ public:
+  struct FacebookUser {
+    std::string access_token;
+    std::string id;
+    int status;
+  };
+
+  FacebookTestUtils();
+  virtual ~FacebookTestUtils();
+  bool CreateFacebookTestUser(
+      olp::http::Network& network,
+      const olp::http::NetworkSettings& network_settings, FacebookUser& user,
+      const std::string& permissions);
+  bool DeleteFacebookTestUser(
+      http::Network& network,
+      const olp::http::NetworkSettings& network_settings, std::string user_id);
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+}  // namespace authentication
+}  // namespace olp


### PR DESCRIPTION
Copied functional test FacebookAuthenticationOnlineTest to <root>/tests/functional folder with following changes:
 - FacebookAuthenticationOnlineTest fixture class moved to cpp side;
 - FacebookAuthenticationOnlineTest renamed to FacebookAuthenticationTest;

Relates To: OLPEDGE-718

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>