### PR TITLE
Add pragma once guard to the header

### DIFF
--- a/olp-cpp-sdk-dataservice-read/tests/CatalogClientTestBase.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/CatalogClientTestBase.cpp
@@ -20,7 +20,6 @@
 #include "CatalogClientTestBase.h"
 
 #include <matchers/NetworkUrlMatchers.h>
-
 #include "HttpResponses.h"
 
 using ::testing::_;

--- a/olp-cpp-sdk-dataservice-read/tests/CatalogClientTestBase.h
+++ b/olp-cpp-sdk-dataservice-read/tests/CatalogClientTestBase.h
@@ -17,24 +17,23 @@
  * License-Filename: LICENSE
  */
 
-#include <gmock/gmock.h>
+#pragma once
 
+#include <gmock/gmock.h>
+#include <mocks/NetworkMock.h>
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/OlpClient.h>
 #include <olp/core/client/OlpClientFactory.h>
 
-#include <mocks/NetworkMock.h>
-
 enum class CacheType { IN_MEMORY, DISK, BOTH };
 
 class CatalogClientTestBase : public ::testing::TestWithParam<CacheType> {
- public:
+ protected:
   CatalogClientTestBase();
   ~CatalogClientTestBase();
   std::string GetTestCatalog();
   static std::string ApiErrorToString(const olp::client::ApiError& error);
 
- protected:
   void SetUp() override;
   void TearDown() override;
 


### PR DESCRIPTION
 * #pragma once in CatalogClientTestBase.h
 * make all public methods of CatalogClientTestBase protected

Relates-to: OLPEDGE-719
Signed-off-by: Serhii Lysenko <ext-serhii.lysenko@here.com>