### PR TITLE
Copy ArcGis functional tests to <root>/tests

### DIFF
--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -27,6 +27,8 @@ set(OLP_SDK_FUNCTIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-authentication/AuthenticationUtils.cpp
     ./olp-cpp-sdk-authentication/FacebookAuthenticationTest.cpp
     ./olp-cpp-sdk-authentication/FacebookTestUtils.cpp
+    ./olp-cpp-sdk-authentication/ArcGisAuthenticationTest.cpp
+    ./olp-cpp-sdk-authentication/ArcGisTestUtils.cpp
 )
 
 set(OLP_SDK_FUNCTIONAL_TESTS_HEADERS
@@ -34,6 +36,7 @@ set(OLP_SDK_FUNCTIONAL_TESTS_HEADERS
     ./olp-cpp-sdk-authentication/AuthenticationUtils.h
     ./olp-cpp-sdk-authentication/TestConstants.h
     ./olp-cpp-sdk-authentication/FacebookTestUtils.h
+    ./olp-cpp-sdk-authentication/ArcGisTestUtils.h
 )
 
 if (ANDROID OR IOS)

--- a/tests/functional/olp-cpp-sdk-authentication/ArcGisAuthenticationTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/ArcGisAuthenticationTest.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <olp/core/http/HttpStatusCode.h>
+#include <olp/core/porting/make_unique.h>
+#include "AuthenticationCommonTestFixture.h"
+#include "ArcGisTestUtils.h"
+#include "TestConstants.h"
+
+namespace {
+constexpr auto kErrorArcGisFailedCode = 400300;
+
+const std::string kErrorArcGisFailedMessage = "Invalid token.";
+
+}  // namespace
+
+using namespace ::olp::authentication;
+
+class ArcGisAuthenticationTest : public AuthenticationCommonTestFixture {
+ protected:
+  void SetUp() override {
+    AuthenticationCommonTestFixture::SetUp();
+
+    arc_gis_utils_ = std::make_unique<ArcGisTestUtils>();
+    ASSERT_TRUE(arc_gis_utils_->GetAccessToken(
+        *network_, olp::http::NetworkSettings(), test_user_));
+
+    id_ = kTestAppKeyId;
+    secret_ = kTestAppKeySecret;
+  }
+
+  void TearDown() override {
+    test_user_ = ArcGisTestUtils::ArcGisUser{};
+    arc_gis_utils_.reset();
+
+    AuthenticationCommonTestFixture::TearDown();
+  }
+
+  AuthenticationClient::SignInUserResponse SignInArcGis(
+      const std::string& email, const std::string& token = "") {
+    AuthenticationCredentials credentials(id_, secret_);
+    std::promise<AuthenticationClient::SignInUserResponse> request;
+    auto request_future = request.get_future();
+    AuthenticationClient::FederatedProperties properties;
+    properties.access_token = token.empty() ? test_user_.access_token : token;
+    properties.country_code = "usa";
+    properties.language = "en";
+    properties.email = email;
+    client_->SignInArcGis(
+        credentials, properties,
+        [&](const AuthenticationClient::SignInUserResponse& response) {
+          request.set_value(response);
+        });
+    request_future.wait();
+    return request_future.get();
+  }
+
+ protected:
+  ArcGisTestUtils::ArcGisUser test_user_;
+  std::unique_ptr<ArcGisTestUtils> arc_gis_utils_;
+};
+
+// The ArcGIS refresh token will eventually expire. This requires a manual
+// update of ARCGIS_TEST_accessToken in ArcGisTestUtils.cpp
+TEST_F(ArcGisAuthenticationTest, SignInArcGis) {
+  const std::string email = GetEmail();
+  std::cout << "Creating account for: " << email << std::endl;
+
+  AuthenticationClient::SignInUserResponse response = SignInArcGis(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::CREATED,
+            response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorPreconditionCreatedCode,
+            response.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorPreconditionCreatedMessage,
+            response.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response.GetResult().GetUserIdentifier().empty());
+  EXPECT_FALSE(response.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_FALSE(response.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_FALSE(response.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_FALSE(response.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_FALSE(response.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::SignInUserResponse response2 = AcceptTerms(response);
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT,
+            response2.GetResult().GetStatus());
+  EXPECT_EQ(kErrorNoContent, response2.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response2.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response2.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response2.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response2.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::AuthenticationClient::SignInUserResponse response3 =
+      SignInArcGis(email);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response3.GetResult().GetStatus());
+  EXPECT_EQ(kErrorOk, response3.GetResult().GetErrorResponse().message);
+  EXPECT_FALSE(response3.GetResult().GetAccessToken().empty());
+  EXPECT_FALSE(response3.GetResult().GetTokenType().empty());
+  EXPECT_FALSE(response3.GetResult().GetRefreshToken().empty());
+  EXPECT_FALSE(response3.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response3.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response3.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationUtils::DeleteUserResponse response4 =
+      DeleteUser(response3.GetResult().GetAccessToken());
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT, response4.status);
+  EXPECT_STREQ(kErrorNoContent.c_str(), response4.error.c_str());
+
+  // SignIn with invalid token
+  AuthenticationClient::SignInUserResponse response5 =
+      SignInArcGis(email, "12345");
+  EXPECT_EQ(olp::http::HttpStatusCode::UNAUTHORIZED,
+            response5.GetResult().GetStatus());
+  EXPECT_EQ(kErrorArcGisFailedCode,
+            response5.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorArcGisFailedMessage,
+            response5.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response5.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response5.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response5.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response5.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response5.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response5.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response5.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response5.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response5.GetResult().GetPrivatePolicyUrlJson().empty());
+}

--- a/tests/functional/olp-cpp-sdk-authentication/ArcGisTestUtils.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/ArcGisTestUtils.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+#include "ArcGisTestUtils.h"
+
+#ifndef WIN32
+#include <unistd.h>
+#endif
+
+#include <future>
+#include <sstream>
+
+#include <rapidjson/document.h>
+#include <rapidjson/istreamwrapper.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+#include <olp/core/http/HttpStatusCode.h>
+#include <olp/core/http/Network.h>
+#include <olp/core/logging/Log.h>
+#include <olp/core/porting/make_unique.h>
+#include <testutils/CustomParameters.hpp>
+#include "TestConstants.h"
+
+namespace {
+constexpr auto kArcgisUrl = "https://www.arcgis.com/sharing/rest/oauth2/token";
+constexpr auto kGrantType = "grant_type";
+constexpr auto kClientId = "client_id";
+constexpr auto kRefreshToken = "refresh_token";
+}  // namespace
+
+namespace olp {
+namespace authentication {
+class ArcGisTestUtils::Impl {
+ public:
+  Impl() = default;
+
+  virtual ~Impl() = default;
+
+  bool GetAccessToken(http::Network& network,
+                      const olp::http::NetworkSettings& network_settings,
+                      ArcGisUser& user);
+
+ private:
+  std::shared_ptr<std::vector<unsigned char> > GenerateClientBody();
+};
+
+bool ArcGisTestUtils::Impl::GetAccessToken(
+    olp::http::Network& network,
+    const olp::http::NetworkSettings& network_settings, ArcGisUser& user) {
+  olp::http::NetworkRequest request(kArcgisUrl);
+  request.WithVerb(http::NetworkRequest::HttpVerb::POST);
+  request.WithSettings(network_settings);
+
+  request.WithBody(GenerateClientBody());
+  request.WithHeader("content-type", "application/x-www-form-urlencoded");
+  request.WithSettings(network_settings);
+
+  unsigned int retry = 0u;
+  do {
+    if (retry > 0u) {
+      OLP_SDK_LOG_WARNING(__func__, "Request retry attempted (" << retry
+                                                                << ")");
+      std::this_thread::sleep_for(
+          std::chrono::seconds(retry * kRetryDelayInSecs));
+    }
+
+    auto payload = std::make_shared<std::stringstream>();
+
+    std::promise<void> promise;
+    auto future = promise.get_future();
+    network.Send(request, payload,
+                 [payload, &promise,
+                  &user](const olp::http::NetworkResponse& network_response) {
+                   user.status = network_response.GetStatus();
+                   if (user.status == olp::http::HttpStatusCode::OK) {
+                     auto document = std::make_shared<rapidjson::Document>();
+                     rapidjson::IStreamWrapper stream(*payload.get());
+                     document->ParseStream(stream);
+                     bool is_valid = !document->HasParseError() &&
+                                     document->HasMember(kAccessToken.c_str());
+                     if (is_valid) {
+                       user.access_token =
+                           (*document)[kAccessToken.c_str()].GetString();
+                     }
+                   }
+                   promise.set_value();
+                 });
+    future.wait();
+  } while ((user.status < 0) && (++retry < kMaxRetryCount));
+
+  return !user.access_token.empty();
+}
+
+std::shared_ptr<std::vector<unsigned char> >
+ArcGisTestUtils::Impl::GenerateClientBody() {
+  std::string data;
+  data.append(kClientId)
+      .append(kEqualsParam)
+      .append(CustomParameters::getArgument("arcgis_app_id"))
+      .append(kAndParam);
+  data.append(kGrantType)
+      .append(kEqualsParam)
+      .append(kRefreshToken)
+      .append(kAndParam);
+  data.append(kRefreshToken)
+      .append(kEqualsParam)
+      .append(CustomParameters::getArgument("arcgis_access_token"));
+  return std::make_shared<std::vector<unsigned char> >(data.begin(),
+                                                       data.end());
+}
+
+ArcGisTestUtils::ArcGisTestUtils()
+    : d_(std::make_unique<ArcGisTestUtils::Impl>()) {}
+
+ArcGisTestUtils::~ArcGisTestUtils() = default;
+
+bool ArcGisTestUtils::GetAccessToken(
+    olp::http::Network& network,
+    const olp::http::NetworkSettings& network_settings, ArcGisUser& user) {
+  return d_->GetAccessToken(network, network_settings, user);
+}
+
+}  // namespace authentication
+}  // namespace olp

--- a/tests/functional/olp-cpp-sdk-authentication/ArcGisTestUtils.h
+++ b/tests/functional/olp-cpp-sdk-authentication/ArcGisTestUtils.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+#pragma once
+
+#include <memory>
+#include <string>
+
+namespace olp {
+
+namespace http {
+class Network;
+class NetworkSettings;
+}  // namespace http
+
+namespace authentication {
+class ArcGisTestUtils {
+ public:
+  struct ArcGisUser {
+    std::string access_token;
+    int status;
+  };
+
+  ArcGisTestUtils();
+  virtual ~ArcGisTestUtils();
+  bool GetAccessToken(http::Network& network,
+                      const olp::http::NetworkSettings& network_settings,
+                      ArcGisUser& user);
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> d_;
+};
+}  // namespace authentication
+}  // namespace olp
+


### PR DESCRIPTION
Copied the ArcGisAuthenticationOnlineTest from olp-sdk-authentication/tests to <root>/tests/functional folder with following changes:
 - renamed ArcGisAuthenticationOnlineTest to ArcGisAuthenticationTest;
 - moved ArcGisAuthenticationTest class fixture to cpp file;

Relates to: OLPEDGE-718

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>