### PR TITLE
Inherit CatalogClientTestBase in CatalogClientTest

### DIFF
--- a/olp-cpp-sdk-dataservice-read/tests/CatalogClientCacheTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/CatalogClientCacheTest.cpp
@@ -16,19 +16,6 @@
 #include <olp/dataservice/read/PartitionsRequest.h>
 #include "HttpResponses.h"
 
-std::ostream& operator<<(std::ostream& os, const CacheType cache_type) {
-  switch (cache_type) {
-    case CacheType::IN_MEMORY:
-      return os << "In-memory cache";
-    case CacheType::DISK:
-      return os << "Disk cache";
-    case CacheType::BOTH:
-      return os << "In-memory & disk cache";
-    default:
-      return os << "Unknown cache type";
-  }
-}
-
 namespace {
 
 using namespace olp::dataservice::read;

--- a/olp-cpp-sdk-dataservice-read/tests/CatalogClientTestBase.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/CatalogClientTestBase.cpp
@@ -24,6 +24,19 @@
 
 using ::testing::_;
 
+std::ostream& operator<<(std::ostream& os, const CacheType cache_type) {
+  switch (cache_type) {
+    case CacheType::IN_MEMORY:
+      return os << "In-memory cache";
+    case CacheType::DISK:
+      return os << "Disk cache";
+    case CacheType::BOTH:
+      return os << "In-memory & disk cache";
+    default:
+      return os << "Unknown cache type";
+  }
+}
+
 CatalogClientTestBase::CatalogClientTestBase() = default;
 
 CatalogClientTestBase::~CatalogClientTestBase() = default;
@@ -53,6 +66,7 @@ void CatalogClientTestBase::SetUp() {
 void CatalogClientTestBase::TearDown() {
   client_.reset();
   settings_.reset();
+  ::testing::Mock::VerifyAndClearExpectations(network_mock_.get());
   network_mock_.reset();
 }
 

--- a/olp-cpp-sdk-dataservice-read/tests/CatalogClientTestBase.h
+++ b/olp-cpp-sdk-dataservice-read/tests/CatalogClientTestBase.h
@@ -27,6 +27,8 @@
 
 enum class CacheType { IN_MEMORY, DISK, BOTH };
 
+std::ostream& operator<<(std::ostream& os, const CacheType cache_type);
+
 class CatalogClientTestBase : public ::testing::TestWithParam<CacheType> {
  protected:
   CatalogClientTestBase();


### PR DESCRIPTION
 * inherit CatalogClientTestBase in CatalogClientTest
 * cleanup #includes in CatalogClientBase
 * move operator<<(ostream, CacheType) to CatalogClientTestBase source
 *  remove GetExecutionTime function, get CatalogClient response directly

Relates-to: OLPEDGE-719
Signed-off-by: Serhii Lysenko <ext-serhii.lysenko@here.com>