### PR TITLE
Copy Google functional tests to <root>/tests

### DIFF
--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -28,7 +28,9 @@ set(OLP_SDK_FUNCTIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-authentication/FacebookAuthenticationTest.cpp
     ./olp-cpp-sdk-authentication/FacebookTestUtils.cpp
     ./olp-cpp-sdk-authentication/ArcGisAuthenticationTest.cpp
-    ./olp-cpp-sdk-authentication/ArcGisTestUtils.cpp
+    ./olp-cpp-sdk-authentication/ArcGisTestUtils.cpp 
+    ./olp-cpp-sdk-authentication/GoogleAuthenticationTest.cpp
+    ./olp-cpp-sdk-authentication/GoogleTestUtils.cpp
 )
 
 set(OLP_SDK_FUNCTIONAL_TESTS_HEADERS
@@ -37,6 +39,7 @@ set(OLP_SDK_FUNCTIONAL_TESTS_HEADERS
     ./olp-cpp-sdk-authentication/TestConstants.h
     ./olp-cpp-sdk-authentication/FacebookTestUtils.h
     ./olp-cpp-sdk-authentication/ArcGisTestUtils.h
+    ./olp-cpp-sdk-authentication/GoogleTestUtils.h
 )
 
 if (ANDROID OR IOS)

--- a/tests/functional/olp-cpp-sdk-authentication/GoogleAuthenticationTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/GoogleAuthenticationTest.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <olp/core/http/HttpStatusCode.h>
+#include <olp/core/porting/make_unique.h>
+#include "AuthenticationCommonTestFixture.h"
+#include "GoogleTestUtils.h"
+#include "TestConstants.h"
+
+using namespace ::olp::authentication;
+
+namespace {
+
+class GoogleAuthenticationTest : public AuthenticationCommonTestFixture {
+ protected:
+  void SetUp() override {
+    AuthenticationCommonTestFixture::SetUp();
+
+    google_utils_ = std::make_unique<GoogleTestUtils>();
+    ASSERT_TRUE(google_utils_->GetAccessToken(
+        *network_, olp::http::NetworkSettings(), test_user_));
+
+    id_ = kTestAppKeyId;
+    secret_ = kTestAppKeySecret;
+  }
+
+  void TearDown() override {
+    test_user_ = GoogleTestUtils::GoogleUser{};
+    google_utils_.reset();
+
+    AuthenticationCommonTestFixture::TearDown();
+  }
+
+  AuthenticationClient::SignInUserResponse SignInGoogleUser(
+      const std::string& email, const std::string& access_token) {
+    AuthenticationCredentials credentials(id_, secret_);
+    std::promise<AuthenticationClient::SignInUserResponse> request;
+    auto request_future = request.get_future();
+    AuthenticationClient::FederatedProperties properties;
+    properties.access_token = access_token;
+    properties.country_code = "USA";
+    properties.language = "en";
+    properties.email = email;
+    client_->SignInGoogle(
+        credentials, properties,
+        [&](const AuthenticationClient::SignInUserResponse& response) {
+          request.set_value(response);
+        });
+    return request_future.get();
+  }
+
+ protected:
+  GoogleTestUtils::GoogleUser test_user_;
+  std::unique_ptr<GoogleTestUtils> google_utils_;
+};
+
+TEST_F(GoogleAuthenticationTest, SignInGoogle) {
+  ASSERT_FALSE(test_user_.access_token.empty());
+
+  const std::string email = GetEmail();
+  std::cout << "Creating account for: " << email << std::endl;
+
+  AuthenticationClient::SignInUserResponse response =
+      SignInGoogleUser(email, test_user_.access_token);
+  EXPECT_EQ(olp::http::HttpStatusCode::CREATED,
+            response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorPreconditionCreatedCode,
+            response.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorPreconditionCreatedMessage,
+            response.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response.GetResult().GetUserIdentifier().empty());
+  EXPECT_FALSE(response.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_FALSE(response.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_FALSE(response.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_FALSE(response.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_FALSE(response.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  std::cout << "termAcceptanceToken="
+            << response.GetResult().GetTermAcceptanceToken() << std::endl;
+
+  AuthenticationClient::SignInUserResponse response2 = AcceptTerms(response);
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT,
+            response2.GetResult().GetStatus());
+  EXPECT_STREQ(kErrorNoContent.c_str(),
+               response2.GetResult().GetErrorResponse().message.c_str());
+  EXPECT_TRUE(response2.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response2.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response2.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response2.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response2.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::SignInUserResponse response3 =
+      SignInGoogleUser(email, test_user_.access_token);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response3.GetResult().GetStatus());
+  EXPECT_STREQ(kErrorOk.c_str(),
+               response3.GetResult().GetErrorResponse().message.c_str());
+  EXPECT_FALSE(response3.GetResult().GetAccessToken().empty());
+  EXPECT_FALSE(response3.GetResult().GetTokenType().empty());
+  EXPECT_FALSE(response3.GetResult().GetRefreshToken().empty());
+  EXPECT_FALSE(response3.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response3.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response3.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response3.GetResult().GetPrivatePolicyUrlJson().empty());
+
+  AuthenticationClient::SignOutUserResponse signout_response =
+      SignOutUser(response3.GetResult().GetAccessToken());
+  EXPECT_TRUE(signout_response.IsSuccessful());
+  // EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT,
+  // signOutResponse.GetResult().GetStatus());
+  // EXPECT_EQ(kErrorNoContent.c_str(),
+  //          signOutResponse.GetResult().GetErrorResponse().message);
+
+  AuthenticationUtils::DeleteUserResponse response4 =
+      DeleteUser(response3.GetResult().GetAccessToken());
+  EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT, response4.status);
+  EXPECT_STREQ(kErrorNoContent.c_str(), response4.error.c_str());
+
+  // SignIn with invalid token
+  AuthenticationClient::SignInUserResponse response5 =
+      SignInGoogleUser(email, "12345");
+  EXPECT_EQ(olp::http::HttpStatusCode::UNAUTHORIZED,
+            response5.GetResult().GetStatus());
+  EXPECT_TRUE(response5.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response5.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response5.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response5.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response5.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response5.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response5.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response5.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response5.GetResult().GetPrivatePolicyUrlJson().empty());
+}
+}  // namespace

--- a/tests/functional/olp-cpp-sdk-authentication/GoogleTestUtils.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/GoogleTestUtils.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "GoogleTestUtils.h"
+
+#ifndef WIN32
+#include <unistd.h>
+#endif
+
+#include <future>
+#include <iostream>
+#include <sstream>
+
+#include <rapidjson/document.h>
+#include <rapidjson/istreamwrapper.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+#include <olp/core/http/HttpStatusCode.h>
+#include <olp/core/http/Network.h>
+#include <olp/core/logging/Log.h>
+#include <olp/core/porting/make_unique.h>
+#include <testutils/CustomParameters.hpp>
+#include "TestConstants.h"
+
+namespace olp {
+namespace authentication {
+constexpr auto kGoogleApiUrl = "https://www.googleapis.com/";
+constexpr auto kGoogleOauth2Endpoint = "oauth2/v3/token";
+constexpr auto kGoogleClientIdParam = "client_id";
+constexpr auto kGoogleClientSecretParam = "client_secret";
+constexpr auto kGoogleRefreshTokenParam = "refresh_token";
+constexpr auto kGoogleRefreshTokenGrantType = "grant_type=refresh_token";
+
+class GoogleTestUtils::Impl {
+ public:
+  Impl();
+
+  virtual ~Impl();
+
+  bool GetAccessToken(olp::http::Network& network,
+                      const olp::http::NetworkSettings& network_settings,
+                      GoogleTestUtils::GoogleUser& user);
+};
+
+GoogleTestUtils::Impl::Impl() = default;
+
+GoogleTestUtils::Impl::~Impl() = default;
+
+bool GoogleTestUtils::Impl::GetAccessToken(
+    http::Network& network, const olp::http::NetworkSettings& network_settings,
+    GoogleTestUtils::GoogleUser& user) {
+  std::string url = std::string() + kGoogleApiUrl + kGoogleOauth2Endpoint;
+  url.append(kQuestionParam);
+  url.append(kGoogleClientIdParam + kEqualsParam +
+             CustomParameters::getArgument("google_client_id"));
+  url.append(kAndParam);
+  url.append(kGoogleClientSecretParam + kEqualsParam +
+             CustomParameters::getArgument("google_client_secret"));
+  url.append(kAndParam);
+  url.append(kGoogleRefreshTokenParam + kEqualsParam +
+             CustomParameters::getArgument("google_client_token"));
+  url.append(kAndParam);
+  url.append(kGoogleRefreshTokenGrantType);
+
+  olp::http::NetworkRequest request(url);
+  request.WithVerb(http::NetworkRequest::HttpVerb::POST);
+  request.WithSettings(network_settings);
+
+  unsigned int retry = 0u;
+  do {
+    if (retry > 0u) {
+      OLP_SDK_LOG_WARNING(__func__, "Request retry attempted (" << retry
+                                                                << ")");
+      std::this_thread::sleep_for(
+          std::chrono::seconds(retry * kRetryDelayInSecs));
+    }
+
+    auto payload = std::make_shared<std::stringstream>();
+
+    std::promise<void> promise;
+    auto future = promise.get_future();
+    network.Send(
+        request, payload,
+        [payload, &promise,
+         &user](const olp::http::NetworkResponse& network_response) {
+          user.status = network_response.GetStatus();
+          if (user.status == olp::http::HttpStatusCode::OK) {
+            auto document = std::make_shared<rapidjson::Document>();
+            rapidjson::IStreamWrapper stream(*payload.get());
+            document->ParseStream(stream);
+            bool is_valid = !document->HasParseError() &&
+                            document->HasMember(kAccessToken.c_str());
+
+            if (is_valid) {
+              user.access_token = (*document)[kAccessToken.c_str()].GetString();
+            }
+          } else {
+            std::cout << "GetAccessToken: status=" << user.status
+                      << ", error=" << network_response.GetError() << std::endl;
+          }
+          promise.set_value();
+        });
+    future.wait();
+  } while ((user.status < 0) && (++retry < kMaxRetryCount));
+
+  return !user.access_token.empty();
+}
+
+GoogleTestUtils::GoogleTestUtils()
+    : d_(std::make_unique<GoogleTestUtils::Impl>()) {}
+
+GoogleTestUtils::~GoogleTestUtils() = default;
+
+bool GoogleTestUtils::GetAccessToken(
+    olp::http::Network& network,
+    const olp::http::NetworkSettings& network_settings,
+    GoogleTestUtils::GoogleUser& user) {
+  return d_->GetAccessToken(network, network_settings, user);
+}
+
+}  // namespace authentication
+}  // namespace olp

--- a/tests/functional/olp-cpp-sdk-authentication/GoogleTestUtils.h
+++ b/tests/functional/olp-cpp-sdk-authentication/GoogleTestUtils.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+namespace olp {
+
+namespace http {
+class Network;
+class NetworkSettings;
+}  // namespace http
+
+namespace authentication {
+class GoogleTestUtils {
+ public:
+  struct GoogleUser {
+    std::string access_token;
+    int status;
+  };
+
+  GoogleTestUtils();
+  virtual ~GoogleTestUtils();
+
+  bool GetAccessToken(http::Network& network,
+                      const olp::http::NetworkSettings& network_settings,
+                      GoogleUser& user);
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> d_;
+};
+
+}  // namespace authentication
+}  // namespace olp


### PR DESCRIPTION
Copied the GoogleAuthenticationOnlineTest from olp-sdk-authentication/tests to <root>tests/functional folder with following changes:
- renamed GoogleAuthenticationOnlineTest to GoogleAuthenticationTest;
- moved GoogleAuthenticationTest class fixture to cpp file;

Relates to: OLPEDGE-718

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>