### PR TITLE
Copy GenerateNetworkMocks function to tests-common

### DIFF
--- a/tests/common/mocks/NetworkMock.h
+++ b/tests/common/mocks/NetworkMock.h
@@ -19,8 +19,17 @@
 
 #pragma once
 
+#include <future>
+
 #include <gmock/gmock.h>
 #include <olp/core/http/Network.h>
+
+using NetworkCallback = std::function<olp::http::SendOutcome(
+    olp::http::NetworkRequest, olp::http::Network::Payload,
+    olp::http::Network::Callback, olp::http::Network::HeaderCallback,
+    olp::http::Network::DataCallback)>;
+
+using CancelCallback = std::function<void(olp::http::RequestId)>;
 
 class NetworkMock : public olp::http::Network {
  public:
@@ -38,11 +47,39 @@ class NetworkMock : public olp::http::Network {
 
   MOCK_METHOD(void, Cancel, (olp::http::RequestId id), (override));
 
-  static std::function<olp::http::SendOutcome(
-      olp::http::NetworkRequest request, olp::http::Network::Payload payload,
-      olp::http::Network::Callback callback,
-      olp::http::Network::HeaderCallback header_callback,
-      olp::http::Network::DataCallback data_callback)>
-  ReturnHttpResponse(olp::http::NetworkResponse response,
-                     const std::string& response_body);
+  static NetworkCallback ReturnHttpResponse(olp::http::NetworkResponse response,
+                                            const std::string& response_body);
 };
+
+/**
+ * @brief Data Structure which is used by network mock to fill response's body
+ * on network request.
+ */
+struct MockedResponseInformation {
+  int status;        /// HTTP status code for response.
+  const char* data;  /// Body of HTTP response.
+};
+
+/**
+ * @brief Helper function creates actions that can be provided to the
+ * NetworkMock instance.
+ *
+ * @param pre_signal - promise that will notify the test that it has reached
+ * network code.
+ * @param wait_for_signal - promise that test should set to let network mock
+ * know that it is time to check requets for cancellation. Test needs to cancel
+ * request before setting this promise.
+ * @param response_information - Data that network mock should return in
+ * response if request wasn't cancelled.
+ * @param post_signal - optional promise that network mock will set after
+ * request is finished.
+ *
+ * @return Triple: RequestId; Action for method Send(); Action for method
+ * Cancel();
+ */
+std::tuple<olp::http::RequestId, NetworkCallback, CancelCallback>
+GenerateNetworkMockActions(std::shared_ptr<std::promise<void>> pre_signal,
+                           std::shared_ptr<std::promise<void>> wait_for_signal,
+                           MockedResponseInformation response_information,
+                           std::shared_ptr<std::promise<void>> post_signal =
+                               std::make_shared<std::promise<void>>());


### PR DESCRIPTION
GenerateNetworkMocks is now called GenerateNetworkMockActions and
defined in NetworkMock source file.

Relates-to: OLPEDGE-768
Signed-off-by: Serhii Lysenko <ext-serhii.lysenko@here.com>