### PR TITLE
Exclude non-unit tests from coverage report

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -25,4 +25,5 @@ ignore:
   - olp-cpp-sdk-core/tests
   - olp-cpp-sdk-dataservice-read/tests
   - olp-cpp-sdk-dataservice-write/tests
+  - tests
   - testutils


### PR DESCRIPTION
Exclude mocks and matchers from coverage reports.

Relates-to: OLPEDGE-768
Signed-off-by: Serhii Lysenko <ext-serhii.lysenko@here.com>