### PR TITLE
Adopt codestyle in dataservice-read tests

### DIFF
--- a/olp-cpp-sdk-dataservice-read/tests/PendingRequestsTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PendingRequestsTest.cpp
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+namespace {
+
 TEST(PendingRequests, InsertNeedsGeneratedPlaceholderInAdvancePositive) {
   olp::dataservice::read::PendingRequests pending_request;
   auto key = pending_request.GenerateRequestPlaceholder();
@@ -41,3 +43,5 @@ TEST(PendingRequests, CancellAllPendingRequest) {
   EXPECT_TRUE(pending_request.CancelPendingRequests());
   EXPECT_TRUE(cancelled);
 }
+
+}  // namespace

--- a/olp-cpp-sdk-dataservice-read/tests/SerializerTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/SerializerTest.cpp
@@ -41,7 +41,6 @@ void RemoveWhitespaceAndNewlines(std::string& s) {
   std::regex r("\\s+");
   s = std::regex_replace(s, r, "");
 }
-}  // namespace
 
 TEST(DataServiceReadSerializerTest, Api) {
   std::string expectedOutput =
@@ -426,3 +425,5 @@ TEST(DataserviceReadSerializerTest, VersionResponse) {
   RemoveWhitespaceAndNewlines(json);
   ASSERT_EQ(expectedOutput, json);
 }
+
+}  // namespace


### PR DESCRIPTION
Put PendingRequestsTest and SerializerTest into anonymous namespace.

Relates-to: OLPEDGE-719
Signed-off-by: Serhii Lysenko <ext-serhii.lysenko@here.com>