### PR TITLE
Add sync GetLatestVersion

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.cpp
@@ -21,6 +21,7 @@
 #include <iostream>
 
 #include <olp/core/client/CancellationContext.h>
+#include <olp/core/client/Condition.h>
 #include <olp/core/logging/Log.h>
 
 #include "ApiRepository.h"
@@ -236,6 +237,92 @@ client::CancellationToken CatalogRepository::getLatestCatalogVersion(
   OLP_SDK_LOG_INFO_F(kLogTag, "ExecuteOrAssociate '%s'", requestKey.c_str());
   return client::CancellationToken(
       [cancel_context]() { cancel_context->CancelOperation(); });
+}
+
+MetadataApi::CatalogVersionResponse CatalogRepository::GetLatestVersion(
+    const client::HRN& catalog,
+    client::CancellationContext cancellation_context,
+    const DataRequest& data_request, client::OlpClientSettings settings) {
+  using namespace client;
+
+  repository::CatalogCacheRepository repository(catalog, settings.cache);
+
+  auto fetch_option = data_request.GetFetchOption();
+  if (fetch_option != OnlineOnly) {
+    auto cached_version = repository.GetVersion();
+    if (cached_version) {
+      OLP_SDK_LOG_INFO_F(kLogTag, "cache catalog '%s' found!",
+                         data_request.CreateKey().c_str());
+      return cached_version.value();
+    } else if (fetch_option == CacheOnly) {
+      OLP_SDK_LOG_INFO_F(kLogTag, "cache catalog '%s' not found!",
+                         data_request.CreateKey().c_str());
+      return ApiError(
+          ErrorCode::NotFound,
+          "Cache only resource not found in cache (catalog version).");
+    }
+  }
+
+  const auto timeout = settings.retry_settings.timeout;
+
+  auto metadata_api =
+      ApiClientLookup::LookupApi(catalog, cancellation_context, "metadata",
+                                 "v1", fetch_option, std::move(settings));
+
+  if (!metadata_api.IsSuccessful()) {
+    return metadata_api.GetError();
+  }
+
+  const client::OlpClient& client = metadata_api.GetResult();
+
+  Condition condition{std::chrono::seconds{timeout}};
+
+  // when the network operation took too much time we cancel it and exit
+  // execution, to make sure that network callback will not access dangling
+  // references we protect them with atomic bool flag.
+  auto interest_flag = std::make_shared<std::atomic_bool>(true);
+
+  MetadataApi::CatalogVersionResponse version_response;
+  cancellation_context.ExecuteOrCancelled(
+      [&]() {
+        auto token = MetadataApi::GetLatestCatalogVersion(
+            client, -1, data_request.GetBillingTag(),
+            [&, interest_flag](MetadataApi::CatalogVersionResponse response) {
+              if (interest_flag->exchange(false)) {
+                version_response = std::move(response);
+                condition.Notify();
+              }
+            });
+
+        return client::CancellationToken([&, interest_flag, token]() {
+          if (interest_flag->exchange(false)) {
+            token.cancel();
+            condition.Notify();
+          }
+        });
+      },
+      [&condition]() { condition.Notify(); });
+
+  if (!condition.Wait()) {
+    cancellation_context.CancelOperation();
+    return ApiError(ErrorCode::RequestTimeout, "Network request timed out.");
+  }
+  interest_flag->store(false);
+
+  if (cancellation_context.IsCancelled()) {
+    return ApiError(ErrorCode::Cancelled, "Operation cancelled.");
+  }
+
+  if (version_response.IsSuccessful()) {
+    repository.PutVersion(version_response.GetResult());
+  } else {
+    const auto& error = version_response.GetError();
+    if (error.GetHttpStatusCode() == http::HttpStatusCode::FORBIDDEN) {
+      repository.Clear();
+    }
+  }
+
+  return version_response;
 }
 
 }  // namespace repository

--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.h
@@ -19,10 +19,13 @@
 
 #pragma once
 
+#include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/HRN.h>
+#include "generated/api/MetadataApi.h"
 #include "MultiRequestContext.h"
 #include "olp/dataservice/read/CatalogClient.h"
+#include "olp/dataservice/read/DataRequest.h"
 
 namespace olp {
 namespace dataservice {
@@ -47,12 +50,17 @@ class CatalogRepository final {
       const read::CatalogVersionRequest& request,
       const read::CatalogVersionCallback& callback);
 
+  static MetadataApi::CatalogVersionResponse GetLatestVersion(
+      const client::HRN& catalog,
+      client::CancellationContext cancellation_context,
+      const DataRequest& data_request,
+      client::OlpClientSettings settings);
+
  private:
   client::HRN hrn_;
   std::shared_ptr<ApiRepository> apiRepo_;
   std::shared_ptr<CatalogCacheRepository> cache_;
-  std::shared_ptr<
-      MultiRequestContext<read::CatalogResponse>>
+  std::shared_ptr<MultiRequestContext<read::CatalogResponse>>
       multiRequestContext_;
 };
 }  // namespace repository

--- a/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ cmake_minimum_required(VERSION 3.5)
 
 set(OLP_SDK_DATASERVICE_READ_TEST_SOURCES
     ApiClientLookupTest.cpp
+    CatalogRepositoryTest.cpp
     MultiRequestContextTest.cpp
     ParserTest.cpp
     PendingRequestsTest.cpp

--- a/olp-cpp-sdk-dataservice-read/tests/CatalogRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/CatalogRepositoryTest.cpp
@@ -1,0 +1,325 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "repositories/CatalogRepository.h"
+
+#include <gtest/gtest.h>
+#include <mocks/CacheMock.h>
+#include <mocks/NetworkMock.h>
+#include <matchers/NetworkUrlMatchers.h>
+#include <olp/core/client/OlpClientFactory.h>
+#include "ApiClientLookup.h"
+
+#define OLP_SDK_URL_LOOKUP_METADATA \
+  R"(https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data:::hereos-internal-test-v2/apis/metadata/v1)"
+#define OLP_SDK_HTTP_RESPONSE_LOOKUP_METADATA \
+  R"jsonString([{"api":"metadata","version":"v1","baseURL":"https://metadata.data.api.platform.here.com/metadata/v1/catalogs/hereos-internal-test-v2","parameters":{}}])jsonString"
+
+#define OLP_SDK_URL_LATEST_CATALOG_VERSION \
+  R"(https://metadata.data.api.platform.here.com/metadata/v1/catalogs/hereos-internal-test-v2/versions/latest?startVersion=-1)"
+
+#define OLP_SDK_HTTP_RESPONSE_LATEST_CATALOG_VERSION \
+  R"jsonString({"version":4})jsonString"
+
+namespace {
+
+using namespace olp::dataservice::read;
+using namespace ::testing;
+
+const std::string kCatalog = "hrn:here:data:::hereos-internal-test-v2";
+const std::string kCacheKey = kCatalog + "::latestVersion";
+const std::string kServiceName = "metadata";
+const std::string kServiceVersion = "v1";
+const std::string kCacheKeyMetadata =
+    kCatalog + "::" + kServiceName + "::" + kServiceVersion + "::api";
+const std::string kLookupUrl =
+    "https://api-lookup.data.api.platform.here.com/lookup/v1/resources/" +
+    kCatalog + "/apis/" + kServiceName + "/" + kServiceVersion;
+const auto kHRN = olp::client::HRN::FromString(kCatalog);
+
+class CatalogRepositoryTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    cache_ = std::make_shared<NiceMock<CacheMock>>();
+    network_ = std::make_shared<NiceMock<NetworkMock>>();
+
+    settings_.network_request_handler = network_;
+    settings_.cache = cache_;
+  }
+
+  void TearDown() override {
+    settings_.network_request_handler.reset();
+    settings_.cache.reset();
+
+    network_.reset();
+    cache_.reset();
+  }
+
+  std::shared_ptr<CacheMock> cache_;
+  std::shared_ptr<NetworkMock> network_;
+  olp::client::OlpClientSettings settings_;
+};
+
+TEST_F(CatalogRepositoryTest, GetLatestVersionCacheOnlyFound) {
+  olp::client::CancellationContext context;
+
+  auto request = DataRequest();
+
+  request.WithFetchOption(CacheOnly);
+
+  model::VersionResponse cached_vesrion;
+  cached_vesrion.SetVersion(10);
+
+  EXPECT_CALL(*cache_, Get(kCacheKey, _))
+      .Times(1)
+      .WillOnce(Return(cached_vesrion));
+
+  auto response = repository::CatalogRepository::GetLatestVersion(
+      kHRN, context, request, settings_);
+
+  ASSERT_TRUE(response.IsSuccessful());
+  EXPECT_EQ(10, response.GetResult().GetVersion());
+}
+
+TEST_F(CatalogRepositoryTest, GetLatestVersionCacheOnlyNotFound) {
+  olp::client::CancellationContext context;
+
+  auto request = olp::dataservice::read::DataRequest();
+
+  request.WithFetchOption(CacheOnly);
+
+  EXPECT_CALL(*cache_, Get(_, _)).Times(1).WillOnce(Return(boost::any{}));
+
+  ON_CALL(*network_, Send(_, _, _, _, _))
+      .WillByDefault([](olp::http::NetworkRequest, olp::http::Network::Payload,
+                        olp::http::Network::Callback,
+                        olp::http::Network::HeaderCallback,
+                        olp::http::Network::DataCallback) {
+        ADD_FAILURE() << "Should not be called with CacheOnly";
+        return olp::http::SendOutcome(olp::http::ErrorCode::UNKNOWN_ERROR);
+      });
+
+  auto response =
+      olp::dataservice::read::repository::CatalogRepository::GetLatestVersion(
+          kHRN, context, request, settings_);
+
+  EXPECT_FALSE(response.IsSuccessful());
+}
+
+TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyNotFound) {
+  olp::client::CancellationContext context;
+
+  auto request = olp::dataservice::read::DataRequest();
+
+  request.WithFetchOption(OnlineOnly);
+
+  ON_CALL(*cache_, Get(_, _))
+      .WillByDefault([](const std::string&, const olp::cache::Decoder&) {
+        ADD_FAILURE() << "Cache should not be used in OnlineOnly request";
+        return boost::any{};
+      });
+
+  EXPECT_CALL(*network_,
+              Send(IsGetRequest(OLP_SDK_URL_LOOKUP_METADATA), _, _, _, _))
+      .Times(1)
+      .WillOnce(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::NOT_FOUND),
+          ""));
+
+  auto response =
+      olp::dataservice::read::repository::CatalogRepository::GetLatestVersion(
+          kHRN, context, request, settings_);
+
+  EXPECT_FALSE(response.IsSuccessful());
+}
+
+TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyFoundAndCacheWritten) {
+  olp::client::CancellationContext context;
+
+  auto request = olp::dataservice::read::DataRequest();
+
+  request.WithFetchOption(OnlineOnly);
+
+  ON_CALL(*cache_, Get(_, _))
+      .WillByDefault([](const std::string&, const olp::cache::Decoder&) {
+        ADD_FAILURE() << "Cache should not be used in OnlineOnly request";
+        return boost::any{};
+      });
+
+  EXPECT_CALL(*cache_, Put(Eq(kCacheKey), _, _, _)).Times(1);
+
+  EXPECT_CALL(*cache_, Put(Eq(kCacheKeyMetadata), _, _, _)).Times(1);
+
+  EXPECT_CALL(*network_,
+              Send(IsGetRequest(OLP_SDK_URL_LOOKUP_METADATA), _, _, _, _))
+      .WillOnce(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::OK),
+          OLP_SDK_HTTP_RESPONSE_LOOKUP_METADATA));
+
+  EXPECT_CALL(*network_, Send(IsGetRequest(OLP_SDK_URL_LATEST_CATALOG_VERSION),
+                              _, _, _, _))
+      .WillOnce(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::OK),
+          OLP_SDK_HTTP_RESPONSE_LATEST_CATALOG_VERSION));
+
+  auto response =
+      olp::dataservice::read::repository::CatalogRepository::GetLatestVersion(
+          kHRN, context, request, settings_);
+
+  ASSERT_TRUE(response.IsSuccessful());
+  ASSERT_EQ(4, response.GetResult().GetVersion());
+}
+
+TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyUserCancelled1) {
+  olp::client::CancellationContext context;
+
+  auto request = olp::dataservice::read::DataRequest();
+
+  std::promise<bool> cancelled;
+
+  ON_CALL(*network_,
+          Send(IsGetRequest(OLP_SDK_URL_LOOKUP_METADATA), _, _, _, _))
+      .WillByDefault([&context](olp::http::NetworkRequest,
+                                olp::http::Network::Payload,
+                                olp::http::Network::Callback,
+                                olp::http::Network::HeaderCallback,
+                                olp::http::Network::DataCallback) {
+        std::thread([&context]() { context.CancelOperation(); }).detach();
+
+        constexpr auto unused_request_id = 5;
+        return olp::http::SendOutcome(unused_request_id);
+      });
+
+  ON_CALL(*network_,
+          Send(IsGetRequest(OLP_SDK_URL_LATEST_CATALOG_VERSION), _, _, _, _))
+      .WillByDefault([](olp::http::NetworkRequest, olp::http::Network::Payload,
+                        olp::http::Network::Callback,
+                        olp::http::Network::HeaderCallback,
+                        olp::http::Network::DataCallback) {
+        ADD_FAILURE()
+            << "Should not be called. Previous request was cancelled.";
+        constexpr auto unused_request_id = 5;
+        return olp::http::SendOutcome(unused_request_id);
+      });
+
+  auto response =
+      olp::dataservice::read::repository::CatalogRepository::GetLatestVersion(
+          kHRN, context, request, settings_);
+
+  ASSERT_FALSE(response.IsSuccessful());
+  EXPECT_EQ(olp::client::ErrorCode::Cancelled,
+            response.GetError().GetErrorCode());
+}
+
+TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyUserCancelled2) {
+  olp::client::CancellationContext context;
+
+  auto request = olp::dataservice::read::DataRequest();
+
+  ON_CALL(*network_,
+          Send(IsGetRequest(OLP_SDK_URL_LOOKUP_METADATA), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::OK),
+          OLP_SDK_HTTP_RESPONSE_LOOKUP_METADATA));
+
+  ON_CALL(*network_,
+          Send(IsGetRequest(OLP_SDK_URL_LATEST_CATALOG_VERSION), _, _, _, _))
+      .WillByDefault([&](olp::http::NetworkRequest, olp::http::Network::Payload,
+                         olp::http::Network::Callback,
+                         olp::http::Network::HeaderCallback,
+                         olp::http::Network::DataCallback) {
+        std::thread([&]() { context.CancelOperation(); }).detach();
+
+        constexpr auto unused_request_id = 10;
+        return olp::http::SendOutcome(unused_request_id);
+      });
+
+  auto response =
+      olp::dataservice::read::repository::CatalogRepository::GetLatestVersion(
+          kHRN, context, request, settings_);
+
+  ASSERT_FALSE(response.IsSuccessful());
+  EXPECT_EQ(olp::client::ErrorCode::Cancelled,
+            response.GetError().GetErrorCode());
+}
+
+TEST_F(CatalogRepositoryTest, GetLatestVersionCancelledBeforeExecution) {
+  settings_.retry_settings.timeout = 0;
+  olp::client::CancellationContext context;
+
+  auto request = olp::dataservice::read::DataRequest();
+
+  ON_CALL(*network_, Send(_, _, _, _, _))
+      .WillByDefault([&](olp::http::NetworkRequest, olp::http::Network::Payload,
+                         olp::http::Network::Callback,
+                         olp::http::Network::HeaderCallback,
+                         olp::http::Network::DataCallback) {
+        ADD_FAILURE() << "Should not be called on cancelled operation";
+        constexpr auto unused_request_id = 10;
+        return olp::http::SendOutcome(unused_request_id);
+      });
+
+  context.CancelOperation();
+  auto response =
+      olp::dataservice::read::repository::CatalogRepository::GetLatestVersion(
+          kHRN, context, request, settings_);
+
+  ASSERT_FALSE(response.IsSuccessful());
+  EXPECT_EQ(olp::client::ErrorCode::Cancelled,
+            response.GetError().GetErrorCode());
+}
+
+TEST_F(CatalogRepositoryTest, GetLatestVersionTimeouted) {
+  olp::client::CancellationContext context;
+
+  auto request = olp::dataservice::read::DataRequest();
+
+  ON_CALL(*network_,
+          Send(IsGetRequest(OLP_SDK_URL_LOOKUP_METADATA), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::OK),
+          OLP_SDK_HTTP_RESPONSE_LOOKUP_METADATA));
+
+  ON_CALL(*network_,
+          Send(IsGetRequest(OLP_SDK_URL_LATEST_CATALOG_VERSION), _, _, _, _))
+      .WillByDefault([&](olp::http::NetworkRequest, olp::http::Network::Payload,
+                         olp::http::Network::Callback,
+                         olp::http::Network::HeaderCallback,
+                         olp::http::Network::DataCallback) {
+        constexpr auto unused_request_id = 10;
+        return olp::http::SendOutcome(unused_request_id);
+      });
+
+  settings_.retry_settings.timeout = 0;
+
+  auto response =
+      olp::dataservice::read::repository::CatalogRepository::GetLatestVersion(
+          kHRN, context, request, settings_);
+
+  ASSERT_FALSE(response.IsSuccessful());
+  EXPECT_EQ(olp::client::ErrorCode::RequestTimeout,
+            response.GetError().GetErrorCode());
+}
+
+}  // namespace


### PR DESCRIPTION
Add sync version of GetLatestVersion to CatalogRepository, based
on sync LookupApi and adaptation of async MetadataApi. Cover
implementation with tests.

Relates-to: OLPEDGE-834
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>