### PR TITLE
ApiClientLookup cancel-before-execution case

### DIFF
--- a/olp-cpp-sdk-dataservice-read/tests/ApiClientLookupTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/ApiClientLookupTest.cpp
@@ -209,4 +209,17 @@ TEST(ApiClientLookupTest, LookupApi) {
               olp::client::ErrorCode::Cancelled);
     Mock::VerifyAndClearExpectations(network.get());
   }
-}
+  {
+    SCOPED_TRACE("Network request cancelled before execution setup");
+    client::CancellationContext context;
+
+    context.CancelOperation();
+    auto response = ApiClientLookup::LookupApi(
+        catalog_hrn, context, service_name, service_version,
+        FetchOptions::OnlineOnly, settings);
+
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(),
+              olp::client::ErrorCode::Cancelled);
+    Mock::VerifyAndClearExpectations(network.get());
+  }}


### PR DESCRIPTION
Added the condition's unblock on cancel event to cover a case when user
cancelled the operation before it actually was set up.

Relates-to: OLPEDGE-832

Signed-off-by: Sergii Vostrikov <ext-sergii.vostrikov@here.com>