### PR TITLE
Adapt codestyle in IndexLayerClient test

### DIFF
--- a/olp-cpp-sdk-dataservice-write/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-write/tests/CMakeLists.txt
@@ -28,7 +28,7 @@ set(OLP_SDK_DATASERVICE_WRITE_TEST_SOURCES
     TestVersionedLayerClient.cpp
     TestVolatileLayerClient.cpp
     TestCancellationTokenList.cpp
-    TestIndexLayerClient.cpp
+    IndexLayerClientTest.cpp
     IndexLayerClientOnlineTest.cpp
     )
 


### PR DESCRIPTION
Rename test and source file. Remove dead code. Switch from parameterized
test to fixture.

Relates-to: OLPEDGE-720
Signed-off-by: Serhii Lysenko <ext-serhii.lysenko@here.com>