### PR TITLE
Adopt code style in StreamLayerClient test

### DIFF
--- a/olp-cpp-sdk-dataservice-write/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-write/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ set(OLP_SDK_DATASERVICE_WRITE_TEST_SOURCES
     HttpResponses.h
     TestParser.cpp
     TestSerializer.cpp
-    TestStreamLayerClient.cpp
+    StreamLayerClientTest.cpp
     TestThreadSafeQueue.cpp
     TestTimeUtils.cpp
     TestVersionedLayerClient.cpp


### PR DESCRIPTION
Rename source file and test. Reorder #includes. Rename variables.
Replace parameterized test by fixture. Remove dead code.

Relates-to: OLPEDGE-720
Signed-off-by: Serhii Lysenko <ext-serhii.lysenko@here.com>