### PR TITLE
Fixed review comments in authentication tests

### DIFF
--- a/tests/functional/olp-cpp-sdk-authentication/ArcGisAuthenticationTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/ArcGisAuthenticationTest.cpp
@@ -28,8 +28,6 @@ constexpr auto kErrorArcGisFailedCode = 400300;
 
 const std::string kErrorArcGisFailedMessage = "Invalid token.";
 
-}  // namespace
-
 using namespace ::olp::authentication;
 
 class ArcGisAuthenticationTest : public AuthenticationCommonTestFixture {
@@ -65,7 +63,6 @@ class ArcGisAuthenticationTest : public AuthenticationCommonTestFixture {
         [&](const AuthenticationClient::SignInUserResponse& response) {
           request.set_value(response);
         });
-    request_future.wait();
     return request_future.get();
   }
 
@@ -148,3 +145,5 @@ TEST_F(ArcGisAuthenticationTest, SignInArcGis) {
   EXPECT_TRUE(response5.GetResult().GetPrivatePolicyUrl().empty());
   EXPECT_TRUE(response5.GetResult().GetPrivatePolicyUrlJson().empty());
 }
+
+}  // namespace

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.cpp
@@ -26,6 +26,7 @@
 #include <olp/core/porting/make_unique.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
 #include "AuthenticationTestUtils.h"
+#include "TestConstants.h"
 
 std::shared_ptr<olp::http::Network> AuthenticationCommonTestFixture::s_network_;
 
@@ -86,7 +87,6 @@ AuthenticationCommonTestFixture::AcceptTerms(
       cancel_token.cancel();
     }
 
-    request_future.wait();
     response = std::make_shared<AuthenticationClient::SignInUserResponse>(
         request_future.get());
   } while ((!response->IsSuccessful()) && (++retry < kMaxRetryCount) &&
@@ -115,7 +115,6 @@ AuthenticationCommonTestFixture::DeleteUser(
         [&request](const AuthenticationTestUtils::DeleteUserResponse& resp) {
           request.set_value(resp);
         });
-    request_future.wait();
     response = std::make_shared<AuthenticationTestUtils::DeleteUserResponse>(
         request_future.get());
   } while ((response->status < 0) && (++retry < kMaxRetryCount));
@@ -139,7 +138,6 @@ AuthenticationCommonTestFixture::SignOutUser(const std::string& access_token,
     cancel_token.cancel();
   }
 
-  request_future.wait();
   return request_future.get();
 }
 

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.h
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.h
@@ -25,7 +25,6 @@
 #include <olp/core/http/Network.h>
 #include <olp/authentication/AuthenticationClient.h>
 #include "AuthenticationTestUtils.h"
-#include "TestConstants.h"
 
 using namespace ::olp::authentication;
 

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationFunctionalTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationFunctionalTest.cpp
@@ -23,6 +23,7 @@
 #include <olp/core/porting/make_unique.h>
 #include <testutils/CustomParameters.hpp>
 #include "AuthenticationTestUtils.h"
+#include "TestConstants.h"
 
 namespace {
 
@@ -62,7 +63,6 @@ class AuthenticationFunctionalTest : public AuthenticationCommonTestFixture {
       if (do_cancel) {
         cancel_token.cancel();
       }
-      request_future.wait();
       response = std::make_shared<AuthenticationClient::SignInClientResponse>(
           request_future.get());
     } while ((!response->IsSuccessful()) && (++retry < kMaxRetryCount) &&
@@ -100,7 +100,6 @@ class AuthenticationFunctionalTest : public AuthenticationCommonTestFixture {
         cancel_token.cancel();
       }
 
-      request_future.wait();
       response = std::make_shared<AuthenticationClient::SignInUserResponse>(
           request_future.get());
     } while ((!response->IsSuccessful()) && (++retry < kMaxRetryCount) &&
@@ -139,7 +138,6 @@ class AuthenticationFunctionalTest : public AuthenticationCommonTestFixture {
         cancel_token.cancel();
       }
 
-      request_future.wait();
       response = std::make_shared<AuthenticationClient::SignInUserResponse>(
           request_future.get());
     } while ((!response->IsSuccessful()) && (++retry < kMaxRetryCount) &&
@@ -173,7 +171,6 @@ class AuthenticationFunctionalTest : public AuthenticationCommonTestFixture {
       cancel_token.cancel();
     }
 
-    request_future.wait();
     return request_future.get();
   }
 };

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationProductionTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationProductionTest.cpp
@@ -75,7 +75,6 @@ TEST_F(AuthenticationProductionTest, SignInClient) {
         request.set_value(response);
       },
       std::chrono::seconds(kExpiryTime));
-  request_future.wait();
 
   AuthenticationClient::SignInClientResponse response = request_future.get();
   std::time_t now = std::time(nullptr);
@@ -99,7 +98,6 @@ TEST_F(AuthenticationProductionTest, SignInClient) {
         request_2.set_value(response);
       },
       std::chrono::seconds(kExtendedExpiryTime));
-  request_future_2.wait();
 
   AuthenticationClient::SignInClientResponse response_2 =
       request_future_2.get();
@@ -120,7 +118,6 @@ TEST_F(AuthenticationProductionTest, SignInClient) {
         request_3.set_value(response);
       },
       std::chrono::seconds(kCustomExpiryTime));
-  request_future_3.wait();
 
   AuthenticationClient::SignInClientResponse response_3 =
       request_future_3.get();
@@ -146,7 +143,6 @@ TEST_F(AuthenticationProductionTest, SignInClientMaxExpiration) {
       [&](const AuthenticationClient::SignInClientResponse& response) {
         request.set_value(response);
       });
-  request_future.wait();
 
   AuthenticationClient::SignInClientResponse response = request_future.get();
   EXPECT_TRUE(response.IsSuccessful());
@@ -164,7 +160,6 @@ TEST_F(AuthenticationProductionTest, SignInClientMaxExpiration) {
         request_2.set_value(response);
       },
       std::chrono::seconds(90000));
-  request_future_2.wait();
 
   AuthenticationClient::SignInClientResponse response_2 =
       request_future_2.get();
@@ -188,7 +183,6 @@ TEST_F(AuthenticationProductionTest, InvalidCredentials) {
       [&](const AuthenticationClient::SignInClientResponse& response) {
         request.set_value(response);
       });
-  request_future.wait();
 
   AuthenticationClient::SignInClientResponse response = request_future.get();
   EXPECT_TRUE(response.IsSuccessful());

--- a/tests/functional/olp-cpp-sdk-authentication/FacebookAuthenticationTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/FacebookAuthenticationTest.cpp
@@ -32,8 +32,6 @@ static const int kErrorFacebookErrorCode = 400300;
 
 const std::string kErrorFacebookFailedMessage = "Unexpected Facebook error.";
 
-}  // namespace
-
 class FacebookAuthenticationTest : public AuthenticationCommonTestFixture {
  protected:
   void SetUp() override {
@@ -160,3 +158,5 @@ TEST_F(FacebookAuthenticationTest, SignInFacebook) {
   EXPECT_TRUE(response5.GetResult().GetPrivatePolicyUrl().empty());
   EXPECT_TRUE(response5.GetResult().GetPrivatePolicyUrlJson().empty());
 }
+
+}  // namespace

--- a/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -17,17 +17,15 @@
  * License-Filename: LICENSE
  */
 
-#include <gmock/gmock.h>
-
 #include <future>
 #include <memory>
 
+#include <gmock/gmock.h>
 #include <olp/core/porting/make_unique.h>
 #include <olp/core/http/HttpStatusCode.h>
 #include "olp/core/client/OlpClientSettingsFactory.h"
 #include <olp/authentication/AuthenticationClient.h>
 #include <mocks/NetworkMock.h>
-
 #include "AuthenticationMockedResponses.h"
 
 using namespace olp::authentication;


### PR DESCRIPTION
Fixed the review comments in authentication functional and integration tests:
 - moved tests into anonymous namespace to adhere to Google C++ code style;
 - removed future.wait() method because of request.get() is already present;
 - includes reordering and improvement;

Relates to: OLPEDGE-718

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>