### PR TITLE
Adopt code style in VolatileLayerClient test

### DIFF
--- a/olp-cpp-sdk-dataservice-write/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-write/tests/CMakeLists.txt
@@ -26,8 +26,8 @@ set(OLP_SDK_DATASERVICE_WRITE_TEST_SOURCES
     ThreadSafeQueueTest.cpp
     TimeUtilsTest.cpp
     VersionedLayerClientOnlineTest.cpp
-    TestVolatileLayerClient.cpp
     CancellationTokenListTest.cpp
+    VolatileLayerClientTest.cpp
     IndexLayerClientTest.cpp
     IndexLayerClientOnlineTest.cpp
     StartBatchRequestTest.cpp


### PR DESCRIPTION
Rename test and source file. Put code into anonymous namespace. Replace
parameterized test by fixture. Reorder #includes.

Relates-to: OLPEDGE-720
Signed-off-by: Serhii Lysenko <ext-serhii.lysenko@here.com>