### PR TITLE
Removed auto_flush_time_period from FlushSettings

### DIFF
--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/FlushSettings.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/FlushSettings.h
@@ -31,13 +31,6 @@ namespace write {
 
 struct DATASERVICE_WRITE_API FlushSettings {
   /**
-    Time Period for AutoFlush mechanism, allows flush events to occur at
-    specified times. Hourly - each hour at 00:00 Daily - each day at 00:00:00
-    Weekly, each Monday at 00:00:00
-   */
-  enum class TimePeriod { Hourly, Daily, Weekly };
-
-  /**
    * How many requests can be cached before an auto flush event is triggered.
    */
   int auto_flush_num_events = 20;
@@ -47,11 +40,6 @@ struct DATASERVICE_WRITE_API FlushSettings {
    * interval based auto-flush. Setting 0 indicates this feature is disabled.
    */
   int auto_flush_interval = 0;
-
-  /**
-   * The TimePeriod between auto flush events.
-   */
-  boost::optional<TimePeriod> auto_flush_time_period = boost::none;
 
   /**
    * Queue time of oldest queued partition that will trigger an auto-flush event

--- a/olp-cpp-sdk-dataservice-write/src/TimeUtils.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/TimeUtils.cpp
@@ -62,33 +62,6 @@ std::chrono::seconds getSecondsToNextWeek(int tm_wday, int tm_hour, int tm_min,
       getSecondsToNextWeek_internal(tm_wday, tm_hour, tm_min, tm_sec)};
 }
 
-template <class Clock, class Duration>
-std::chrono::milliseconds getDelayTillPeriod(
-    FlushSettings::TimePeriod period,
-    std::chrono::time_point<Clock, Duration> atime_point) {
-  auto atime_t = Clock::to_time_t(atime_point);
-  std::tm currentTimePoint;
-  currentTimePoint = *localtime(&atime_t);
-
-  if (period == FlushSettings::TimePeriod::Weekly) {
-    return std::chrono::duration_cast<std::chrono::milliseconds>(
-        getSecondsToNextWeek(currentTimePoint.tm_wday, currentTimePoint.tm_hour,
-                             currentTimePoint.tm_min, currentTimePoint.tm_sec));
-  } else if (period == FlushSettings::TimePeriod::Daily) {
-    return std::chrono::duration_cast<std::chrono::milliseconds>(
-        getSecondsToNextDay(currentTimePoint.tm_hour, currentTimePoint.tm_min,
-                            currentTimePoint.tm_sec));
-  } else {
-    return std::chrono::duration_cast<std::chrono::milliseconds>(
-        getSecondsToNextHour(currentTimePoint.tm_min, currentTimePoint.tm_sec));
-  }
-}
-
-template std::chrono::milliseconds getDelayTillPeriod(
-    FlushSettings::TimePeriod period,
-    std::chrono::time_point<std::chrono::system_clock,
-                            std::chrono::system_clock::duration>
-        atime_point);
 }  // namespace write
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/TimeUtils.h
+++ b/olp-cpp-sdk-dataservice-write/src/TimeUtils.h
@@ -19,10 +19,7 @@
 
 #pragma once
 
-#include <olp/dataservice/write/FlushSettings.h>
-#include <time.h>
 #include <chrono>
-#include <ctime>
 
 namespace olp {
 namespace dataservice {
@@ -31,12 +28,6 @@ std::chrono::seconds getSecondsToNextHour(int tm_min, int tm_sec);
 std::chrono::seconds getSecondsToNextDay(int tm_hour, int tm_min, int tm_sec);
 std::chrono::seconds getSecondsToNextWeek(int tm_wday, int tm_hour, int tm_min,
                                           int tm_sec);
-
-template <class Clock, class Duration = typename Clock::duration>
-std::chrono::milliseconds getDelayTillPeriod(
-    FlushSettings::TimePeriod period,
-    std::chrono::time_point<Clock, Duration> atime_point =
-        std::chrono::system_clock::now());
 
 }  // namespace write
 }  // namespace dataservice


### PR DESCRIPTION
1. Removed auto_flush_time_period property from FlushSettings.
2. Removed TimePeriod enum class.
3. Removed corresponding methods which used the auto_flush_time_period in AutoFlushController
4. Removed unused TimeUtils methods and updated TestTimeUtils's tests.

Resolves: OLPEDGE-814

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>