### PR TITLE
Added DataRepository::GetBlobData() sync method

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/MultiRequestContext.h
+++ b/olp-cpp-sdk-dataservice-read/src/MultiRequestContext.h
@@ -21,6 +21,7 @@
 
 #include <iostream>
 #include <map>
+#include <memory>
 #include <mutex>
 
 #include <boost/uuid/random_generator.hpp>

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
@@ -24,6 +24,7 @@
 #include <olp/core/client/HRN.h>
 #include "MultiRequestContext.h"
 #include "olp/dataservice/read/CatalogClient.h"
+#include "generated/api/BlobApi.h"
 
 namespace olp {
 namespace dataservice {
@@ -50,6 +51,13 @@ class DataRepository final {
   void GetData(std::shared_ptr<client::CancellationContext> cancellationContext,
                const std::string& layerType, const read::DataRequest& request,
                const read::DataResponseCallback& callback);
+
+  static BlobApi::DataResponse GetBlobData(
+      const client::HRN& catalog, const std::string& layer,
+      const DataRequest& data_request,
+      client::CancellationContext cancellation_context,
+      client::OlpClientSettings settings);
+
   static bool IsInlineData(const std::string& dataHandle);
 
  private:
@@ -59,9 +67,7 @@ class DataRepository final {
   std::shared_ptr<PartitionsRepository> partitionsRepo_;
   std::shared_ptr<DataCacheRepository> cache_;
   std::shared_ptr<PartitionsCacheRepository> partitionsCache_;
-  std::shared_ptr<
-      MultiRequestContext<read::DataResponse>>
-      multiRequestContext_;
+  std::shared_ptr<MultiRequestContext<read::DataResponse>> multiRequestContext_;
 };
 }  // namespace repository
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ cmake_minimum_required(VERSION 3.5)
 set(OLP_SDK_DATASERVICE_READ_TEST_SOURCES
     ApiClientLookupTest.cpp
     CatalogRepositoryTest.cpp
+    DataRepositoryTest.cpp
     MultiRequestContextTest.cpp
     ParserTest.cpp
     PendingRequestsTest.cpp

--- a/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
@@ -1,0 +1,256 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gtest/gtest.h>
+
+#include <matchers/NetworkUrlMatchers.h>
+#include <mocks/NetworkMock.h>
+#include <olp/core/client/OlpClientFactory.h>
+#include <olp/core/client/OlpClientSettings.h>
+#include <olp/dataservice/read/DataRequest.h>
+#include <repositories/DataRepository.h>
+
+#define URL_LOOKUP_BLOB \
+  R"(https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data:::hereos-internal-test-v2/apis/blob/v1)"
+
+#define URL_BLOB_DATA_269 \
+  R"(https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2/layers/testlayer/data/4eed6ed1-0d32-43b9-ae79-043cb4256432)"
+
+#define HTTP_RESPONSE_LOOKUP_BLOB \
+  R"jsonString([{"api":"blob","version":"v1","baseURL":"https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2","parameters":{}}])jsonString"
+
+#define HTTP_RESPONSE_403 \
+  R"jsonString("Forbidden - A catalog with the specified HRN doesn't exist or access to this catalog is forbidden)jsonString"
+
+#define BLOB_DATA_HANDLE R"(4eed6ed1-0d32-43b9-ae79-043cb4256432)"
+
+namespace {
+
+using testing::_;
+
+class DataRepositoryTest : public ::testing::Test {
+ protected:
+  void SetUp() override;
+  void TearDown() override;
+
+  std::string GetTestCatalog();
+
+  std::shared_ptr<olp::client::OlpClientSettings> settings_;
+  std::shared_ptr<NetworkMock> network_mock_;
+};
+
+void DataRepositoryTest::SetUp() {
+  network_mock_ = std::make_shared<NetworkMock>();
+  settings_ = std::make_shared<olp::client::OlpClientSettings>();
+  settings_->cache = olp::dataservice::read::CreateDefaultCache();
+  settings_->network_request_handler = network_mock_;
+}
+
+void DataRepositoryTest::TearDown() {
+  settings_.reset();
+  network_mock_.reset();
+}
+
+std::string DataRepositoryTest::GetTestCatalog() {
+  return "hrn:here:data:::hereos-internal-test-v2";
+}
+
+TEST_F(DataRepositoryTest, GetBlobData) {
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
+      .WillOnce(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::OK),
+          HTTP_RESPONSE_LOOKUP_BLOB));
+
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
+      .WillOnce(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::OK),
+          "someData"));
+
+  olp::client::CancellationContext context;
+
+  olp::dataservice::read::DataRequest request;
+  request.WithDataHandle(BLOB_DATA_HANDLE);
+
+  olp::client::HRN hrn(GetTestCatalog());
+
+  auto response =
+      olp::dataservice::read::repository::DataRepository::GetBlobData(
+          hrn, "testlayer", request, context, *settings_);
+
+  ASSERT_TRUE(response.IsSuccessful());
+}
+
+TEST_F(DataRepositoryTest, GetBlobDataApiLookupFailed403) {
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
+      .WillOnce(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::FORBIDDEN),
+          HTTP_RESPONSE_403));
+
+  olp::client::CancellationContext context;
+
+  olp::dataservice::read::DataRequest request;
+  request.WithDataHandle(BLOB_DATA_HANDLE);
+
+  olp::client::HRN hrn(GetTestCatalog());
+
+  auto response =
+      olp::dataservice::read::repository::DataRepository::GetBlobData(
+          hrn, "testlayer", request, context, *settings_);
+
+  ASSERT_FALSE(response.IsSuccessful());
+}
+
+TEST_F(DataRepositoryTest, GetBlobDataNoDataHandle) {
+  olp::client::CancellationContext context;
+  olp::dataservice::read::DataRequest request;
+  olp::client::HRN hrn(GetTestCatalog());
+  auto response =
+      olp::dataservice::read::repository::DataRepository::GetBlobData(
+          hrn, "testlayer", request, context, *settings_);
+  ASSERT_FALSE(response.IsSuccessful());
+}
+
+TEST_F(DataRepositoryTest, GetBlobDataFailedDataFetch403) {
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
+      .WillOnce(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::OK),
+          HTTP_RESPONSE_LOOKUP_BLOB));
+
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
+      .WillOnce(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::FORBIDDEN),
+          HTTP_RESPONSE_403));
+
+  olp::client::CancellationContext context;
+
+  olp::dataservice::read::DataRequest request;
+  request.WithDataHandle(BLOB_DATA_HANDLE);
+
+  olp::client::HRN hrn(GetTestCatalog());
+
+  auto response =
+      olp::dataservice::read::repository::DataRepository::GetBlobData(
+          hrn, "testlayer", request, context, *settings_);
+
+  ASSERT_FALSE(response.IsSuccessful());
+}
+
+TEST_F(DataRepositoryTest, GetBlobDataCache) {
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
+      .WillOnce(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::OK),
+          HTTP_RESPONSE_LOOKUP_BLOB));
+
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
+      .WillOnce(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::OK),
+          "someData"));
+
+  olp::client::CancellationContext context;
+
+  olp::dataservice::read::DataRequest request;
+  request.WithDataHandle(BLOB_DATA_HANDLE);
+
+  olp::client::HRN hrn(GetTestCatalog());
+
+  // This should download data from network and cache it
+  auto response =
+      olp::dataservice::read::repository::DataRepository::GetBlobData(
+          hrn, "testlayer", request, context, *settings_);
+
+  ASSERT_TRUE(response.IsSuccessful());
+
+  // This call should not do any network calls and use already cached values
+  // instead
+  response = olp::dataservice::read::repository::DataRepository::GetBlobData(
+      hrn, "testlayer", request, context, *settings_);
+
+  ASSERT_TRUE(response.IsSuccessful());
+}
+
+TEST_F(DataRepositoryTest, GetBlobDataImmediateCancel) {
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::OK),
+          HTTP_RESPONSE_LOOKUP_BLOB));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
+      .WillByDefault(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::OK),
+          "someData"));
+
+  olp::client::CancellationContext context;
+
+  olp::dataservice::read::DataRequest request;
+  request.WithDataHandle(BLOB_DATA_HANDLE);
+
+  olp::client::HRN hrn(GetTestCatalog());
+
+  context.CancelOperation();
+  ASSERT_TRUE(context.IsCancelled());
+
+  auto response =
+      olp::dataservice::read::repository::DataRepository::GetBlobData(
+          hrn, "testlayer", request, context, *settings_);
+  ASSERT_EQ(response.GetError().GetErrorCode(),
+            olp::client::ErrorCode::Cancelled);
+}
+
+TEST_F(DataRepositoryTest, GetBlobDataInProgressCancel) {
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
+      .WillOnce(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::OK),
+          HTTP_RESPONSE_LOOKUP_BLOB));
+
+  olp::client::CancellationContext context;
+
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
+      .WillOnce(
+          [&](olp::http::NetworkRequest, olp::http::Network::Payload,
+              olp::http::Network::Callback, olp::http::Network::HeaderCallback,
+              olp::http::Network::DataCallback) -> olp::http::SendOutcome {
+            std::thread([&]() { context.CancelOperation(); }).detach();
+            constexpr auto unused_request_id = 12;
+            return olp::http::SendOutcome(unused_request_id);
+          });
+  EXPECT_CALL(*network_mock_, Cancel(_)).WillOnce(testing::Return());
+
+  olp::dataservice::read::DataRequest request;
+  request.WithDataHandle(BLOB_DATA_HANDLE);
+
+  olp::client::HRN hrn(GetTestCatalog());
+
+  auto response =
+      olp::dataservice::read::repository::DataRepository::GetBlobData(
+          hrn, "testlayer", request, context, *settings_);
+  ASSERT_EQ(response.GetError().GetErrorCode(),
+            olp::client::ErrorCode::Cancelled);
+}
+
+}  // namespace


### PR DESCRIPTION
Added sync version of DataRepository::GetData in olp::dataservice::read module
Added tests that cover DataRepository::GetBlobData method
Added #include<memory> to MultiRequestContext.h to fix tests compilation

Resolves: OLPEDGE-835

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>