### PR TITLE
Disable dataservice-write cache offline tests

### DIFF
--- a/scripts/linux/psv/travis_test_psv.sh
+++ b/scripts/linux/psv/travis_test_psv.sh
@@ -17,7 +17,7 @@ $CPP_TEST_SOURCE_DARASERVICE_READ/olp-cpp-sdk-dataservice-read-tests \
 echo ">>> Dataservice write Test ... >>>"
 $CPP_TEST_SOURCE_DARASERVICE_WRITE/olp-cpp-sdk-dataservice-write-tests \
     --gtest_output="xml:olp-cpp-sdk-dataservice-write-tests-report.xml" \
-    --gtest_filter=-"*Online*":"TestCacheMock*"
+    --gtest_filter=-"*Online*":"StreamLayerClientCacheMockTest*"
 echo ">>> Integration Test ... >>>"
 $CPP_TEST_SOURCE_INTEGRATION/olp-cpp-sdk-integration-tests \
     --gtest_output="xml:olp-cpp-sdk-integration-tests-report.xml"


### PR DESCRIPTION
Disable dataservice-write cache offline tests.

Relates-to: OLPEDGE-857
Signed-off-by: Serhii Lysenko <ext-serhii.lysenko@here.com>