### PR TITLE
Move online tests to tests/functional/

### DIFF
--- a/olp-cpp-sdk-dataservice-write/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-write/tests/CMakeLists.txt
@@ -25,14 +25,10 @@ set(OLP_SDK_DATASERVICE_WRITE_TEST_SOURCES
     StreamLayerClientTest.cpp
     ThreadSafeQueueTest.cpp
     TimeUtilsTest.cpp
-    VersionedLayerClientOnlineTest.cpp
     TestVolatileLayerClient.cpp
     CancellationTokenListTest.cpp
     IndexLayerClientTest.cpp
-    IndexLayerClientOnlineTest.cpp
     StartBatchRequestTest.cpp
-    VolatileLayerClientOnlineTest.cpp
-    StreamLayerClientOnlineTest.cpp
     )
 
 

--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -22,6 +22,10 @@ set(OLP_SDK_FUNCTIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-core/OlpClientDefaultAsyncHttpTest.cpp
     ./olp-cpp-sdk-dataservice-read/ApiTest.cpp
     ./olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
+    ./olp-cpp-sdk-dataservice-write/DataserviceWriteIndexLayerClientTest.cpp
+    ./olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientTest.cpp
+    ./olp-cpp-sdk-dataservice-write/DataserviceWriteVersionedLayerClientTest.cpp
+    ./olp-cpp-sdk-dataservice-write/DataserviceWriteVolatileLayerClientTest.cpp
     ./olp-cpp-sdk-authentication/ArcGisAuthenticationTest.cpp
     ./olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.cpp
     ./olp-cpp-sdk-authentication/AuthenticationFunctionalTest.cpp

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteIndexLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteIndexLayerClientTest.cpp
@@ -55,7 +55,7 @@ void PublishFailureAssertions(
   EXPECT_FALSE(result.GetError().GetMessage().empty());
 }
 
-class IndexLayerClientOnlineTest : public ::testing::Test {
+class DataserviceWriteIndexLayerClientTest : public ::testing::Test {
  protected:
   static void SetUpTestSuite() {
     s_network = olp::client::OlpClientSettingsFactory::
@@ -143,9 +143,10 @@ class IndexLayerClientOnlineTest : public ::testing::Test {
 // Static network instance is necessary as it needs to outlive any created
 // clients. This is a known limitation as triggered send requests capture the
 // network instance inside the callbacks.
-std::shared_ptr<olp::http::Network> IndexLayerClientOnlineTest::s_network;
+std::shared_ptr<olp::http::Network>
+    DataserviceWriteIndexLayerClientTest::s_network;
 
-TEST_F(IndexLayerClientOnlineTest, PublishData) {
+TEST_F(DataserviceWriteIndexLayerClientTest, PublishData) {
   auto response = client_
                       ->PublishIndex(PublishIndexRequest()
                                          .WithIndex(GetTestIndex())
@@ -157,7 +158,7 @@ TEST_F(IndexLayerClientOnlineTest, PublishData) {
   ASSERT_NO_FATAL_FAILURE(PublishDataSuccessAssertions(response));
 }
 
-TEST_F(IndexLayerClientOnlineTest, DeleteData) {
+TEST_F(DataserviceWriteIndexLayerClientTest, DeleteData) {
   auto response = client_
                       ->PublishIndex(PublishIndexRequest()
                                          .WithIndex(GetTestIndex())
@@ -180,7 +181,7 @@ TEST_F(IndexLayerClientOnlineTest, DeleteData) {
   ASSERT_TRUE(delete_index_response.IsSuccessful());
 }
 
-TEST_F(IndexLayerClientOnlineTest, PublishDataAsync) {
+TEST_F(DataserviceWriteIndexLayerClientTest, PublishDataAsync) {
   std::promise<PublishIndexResponse> response_promise;
   bool call_is_async = true;
 
@@ -205,7 +206,7 @@ TEST_F(IndexLayerClientOnlineTest, PublishDataAsync) {
   ASSERT_NO_FATAL_FAILURE(PublishDataSuccessAssertions(response));
 }
 
-TEST_F(IndexLayerClientOnlineTest, UpdateIndex) {
+TEST_F(DataserviceWriteIndexLayerClientTest, UpdateIndex) {
   Index index = GetTestIndex();
   index.SetId("2f269191-5ef7-42a4-a445-fdfe53f95d92");
 
@@ -223,7 +224,7 @@ TEST_F(IndexLayerClientOnlineTest, UpdateIndex) {
   EXPECT_EQ("", response.GetError().GetMessage());
 }
 
-TEST_F(IndexLayerClientOnlineTest, PublishNoData) {
+TEST_F(DataserviceWriteIndexLayerClientTest, PublishNoData) {
   auto response = client_
                       ->PublishIndex(PublishIndexRequest()
                                          .WithIndex(GetTestIndex())
@@ -237,7 +238,7 @@ TEST_F(IndexLayerClientOnlineTest, PublishNoData) {
   ASSERT_EQ("Request data empty.", response.GetError().GetMessage());
 }
 
-TEST_F(IndexLayerClientOnlineTest, PublishNoLayer) {
+TEST_F(DataserviceWriteIndexLayerClientTest, PublishNoLayer) {
   auto response = client_
                       ->PublishIndex(PublishIndexRequest()
                                          .WithIndex(GetTestIndex())

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientTest.cpp
@@ -117,9 +117,9 @@ void PublishFailureAssertions(
   // EXPECT_FALSE(result.GetError().GetMessage().empty());
 }
 
-class StreamLayerClientOnlineTest : public ::testing::Test {
+class DataserviceWriteStreamLayerClientTest : public ::testing::Test {
  protected:
-  StreamLayerClientOnlineTest() {
+  DataserviceWriteStreamLayerClientTest() {
     sdii_data_ = std::make_shared<std::vector<unsigned char>>(
         kSDIITestData, kSDIITestData + kSDIITestDataLength);
   }
@@ -209,9 +209,10 @@ class StreamLayerClientOnlineTest : public ::testing::Test {
 // Static network instance is necessary as it needs to outlive any created
 // clients. This is a known limitation as triggered send requests capture the
 // network instance inside the callbacks.
-std::shared_ptr<olp::http::Network> StreamLayerClientOnlineTest::s_network;
+std::shared_ptr<olp::http::Network>
+    DataserviceWriteStreamLayerClientTest::s_network;
 
-TEST_F(StreamLayerClientOnlineTest, PublishData) {
+TEST_F(DataserviceWriteStreamLayerClientTest, PublishData) {
   auto response =
       client_
           ->PublishData(
@@ -222,7 +223,7 @@ TEST_F(StreamLayerClientOnlineTest, PublishData) {
   ASSERT_NO_FATAL_FAILURE(PublishDataSuccessAssertions(response));
 }
 
-TEST_F(StreamLayerClientOnlineTest, PublishDataGreaterThanTwentyMib) {
+TEST_F(DataserviceWriteStreamLayerClientTest, PublishDataGreaterThanTwentyMib) {
   auto large_data =
       std::make_shared<std::vector<unsigned char>>(kTwentyMib + 1, 'z');
 
@@ -236,7 +237,7 @@ TEST_F(StreamLayerClientOnlineTest, PublishDataGreaterThanTwentyMib) {
   ASSERT_NO_FATAL_FAILURE(PublishDataSuccessAssertions(response));
 }
 
-TEST_F(StreamLayerClientOnlineTest, PublishDataAsync) {
+TEST_F(DataserviceWriteStreamLayerClientTest, PublishDataAsync) {
   std::promise<PublishDataResponse> response_promise;
   bool call_is_async = true;
 
@@ -258,7 +259,7 @@ TEST_F(StreamLayerClientOnlineTest, PublishDataAsync) {
   ASSERT_NO_FATAL_FAILURE(PublishDataSuccessAssertions(response));
 }
 
-TEST_F(StreamLayerClientOnlineTest, PublishDataCancel) {
+TEST_F(DataserviceWriteStreamLayerClientTest, PublishDataCancel) {
   auto cancel_future = client_->PublishData(
       PublishDataRequest().WithData(data_).WithLayerId(GetTestLayer()));
 
@@ -283,7 +284,7 @@ TEST_F(StreamLayerClientOnlineTest, PublishDataCancel) {
   //  response.GetError().GetErrorCode());
 }
 
-TEST_F(StreamLayerClientOnlineTest, PublishDataCancelLongDelay) {
+TEST_F(DataserviceWriteStreamLayerClientTest, PublishDataCancelLongDelay) {
   auto cancel_future = client_->PublishData(
       PublishDataRequest().WithData(data_).WithLayerId(GetTestLayer()));
 
@@ -308,7 +309,7 @@ TEST_F(StreamLayerClientOnlineTest, PublishDataCancelLongDelay) {
   //  response.GetError().GetErrorCode());
 }
 
-TEST_F(StreamLayerClientOnlineTest,
+TEST_F(DataserviceWriteStreamLayerClientTest,
        PublishDataCancelGetFutureAfterRequestCancelled) {
   auto cancel_future = client_->PublishData(
       PublishDataRequest().WithData(data_).WithLayerId(GetTestLayer()));
@@ -335,7 +336,8 @@ TEST_F(StreamLayerClientOnlineTest,
   //  response.GetError().GetErrorCode());
 }
 
-TEST_F(StreamLayerClientOnlineTest, PublishDataGreaterThanTwentyMibCancel) {
+TEST_F(DataserviceWriteStreamLayerClientTest,
+       PublishDataGreaterThanTwentyMibCancel) {
   auto large_data =
       std::make_shared<std::vector<unsigned char>>(kTwentyMib + 1, 'z');
 
@@ -360,7 +362,7 @@ TEST_F(StreamLayerClientOnlineTest, PublishDataGreaterThanTwentyMibCancel) {
   ASSERT_NO_FATAL_FAILURE(PublishFailureAssertions(response));
 }
 
-TEST_F(StreamLayerClientOnlineTest, IncorrectLayer) {
+TEST_F(DataserviceWriteStreamLayerClientTest, IncorrectLayer) {
   auto response =
       client_
           ->PublishData(
@@ -371,7 +373,7 @@ TEST_F(StreamLayerClientOnlineTest, IncorrectLayer) {
   ASSERT_NO_FATAL_FAILURE(PublishFailureAssertions(response));
 }
 
-TEST_F(StreamLayerClientOnlineTest, NullData) {
+TEST_F(DataserviceWriteStreamLayerClientTest, NullData) {
   auto response =
       client_
           ->PublishData(PublishDataRequest().WithData(nullptr).WithLayerId(
@@ -382,7 +384,7 @@ TEST_F(StreamLayerClientOnlineTest, NullData) {
   ASSERT_NO_FATAL_FAILURE(PublishFailureAssertions(response));
 }
 
-TEST_F(StreamLayerClientOnlineTest, CustomTraceId) {
+TEST_F(DataserviceWriteStreamLayerClientTest, CustomTraceId) {
   const auto uuid = GenerateRandomUUID();
 
   auto response = client_
@@ -398,7 +400,7 @@ TEST_F(StreamLayerClientOnlineTest, CustomTraceId) {
   EXPECT_STREQ(response.GetResult().GetTraceID().c_str(), uuid.c_str());
 }
 
-TEST_F(StreamLayerClientOnlineTest, BillingTag) {
+TEST_F(DataserviceWriteStreamLayerClientTest, BillingTag) {
   auto response = client_
                       ->PublishData(PublishDataRequest()
                                         .WithData(data_)
@@ -411,7 +413,7 @@ TEST_F(StreamLayerClientOnlineTest, BillingTag) {
 }
 
 #ifdef DATASERVICE_WRITE_HAS_OPENSSL
-TEST_F(StreamLayerClientOnlineTest, ChecksumValid) {
+TEST_F(DataserviceWriteStreamLayerClientTest, ChecksumValid) {
   const std::string data_string(data_->begin(), data_->end());
   auto checksum = sha256(data_string);
 
@@ -427,7 +429,7 @@ TEST_F(StreamLayerClientOnlineTest, ChecksumValid) {
 }
 #endif
 
-TEST_F(StreamLayerClientOnlineTest, ChecksumGarbageString) {
+TEST_F(DataserviceWriteStreamLayerClientTest, ChecksumGarbageString) {
   auto response = client_
                       ->PublishData(PublishDataRequest()
                                         .WithData(data_)
@@ -439,7 +441,7 @@ TEST_F(StreamLayerClientOnlineTest, ChecksumGarbageString) {
   ASSERT_NO_FATAL_FAILURE(PublishFailureAssertions(response));
 }
 
-TEST_F(StreamLayerClientOnlineTest, SequentialPublishSameLayer) {
+TEST_F(DataserviceWriteStreamLayerClientTest, SequentialPublishSameLayer) {
   auto response =
       client_
           ->PublishData(
@@ -458,7 +460,7 @@ TEST_F(StreamLayerClientOnlineTest, SequentialPublishSameLayer) {
   ASSERT_NO_FATAL_FAILURE(PublishDataSuccessAssertions(response));
 }
 
-TEST_F(StreamLayerClientOnlineTest, SequentialPublishDifferentLayer) {
+TEST_F(DataserviceWriteStreamLayerClientTest, SequentialPublishDifferentLayer) {
   auto response =
       client_
           ->PublishData(
@@ -477,7 +479,7 @@ TEST_F(StreamLayerClientOnlineTest, SequentialPublishDifferentLayer) {
   ASSERT_NO_FATAL_FAILURE(PublishDataSuccessAssertions(response));
 }
 
-TEST_F(StreamLayerClientOnlineTest, ConcurrentPublishSameIngestApi) {
+TEST_F(DataserviceWriteStreamLayerClientTest, ConcurrentPublishSameIngestApi) {
   auto publish_data = [&]() {
     auto response =
         client_
@@ -501,7 +503,8 @@ TEST_F(StreamLayerClientOnlineTest, ConcurrentPublishSameIngestApi) {
   async5.get();
 }
 
-TEST_F(StreamLayerClientOnlineTest, ConcurrentPublishDifferentIngestApi) {
+TEST_F(DataserviceWriteStreamLayerClientTest,
+       ConcurrentPublishDifferentIngestApi) {
   auto publishData = [&]() {
     auto client = CreateStreamLayerClient();
 
@@ -528,7 +531,7 @@ TEST_F(StreamLayerClientOnlineTest, ConcurrentPublishDifferentIngestApi) {
   async5.get();
 }
 
-TEST_F(StreamLayerClientOnlineTest, PublishSdii) {
+TEST_F(DataserviceWriteStreamLayerClientTest, PublishSdii) {
   auto response = client_
                       ->PublishSdii(PublishSdiiRequest()
                                         .WithSdiiMessageList(sdii_data_)
@@ -539,7 +542,7 @@ TEST_F(StreamLayerClientOnlineTest, PublishSdii) {
   ASSERT_NO_FATAL_FAILURE(PublishSdiiSuccessAssertions(response));
 }
 
-TEST_F(StreamLayerClientOnlineTest, PublishSdiiAsync) {
+TEST_F(DataserviceWriteStreamLayerClientTest, PublishSdiiAsync) {
   std::promise<PublishSdiiResponse> response_promise;
   bool call_is_async = true;
   auto cancel_token =
@@ -562,7 +565,7 @@ TEST_F(StreamLayerClientOnlineTest, PublishSdiiAsync) {
   ASSERT_NO_FATAL_FAILURE(PublishSdiiSuccessAssertions(response));
 }
 
-TEST_F(StreamLayerClientOnlineTest, PublishSdiiCancel) {
+TEST_F(DataserviceWriteStreamLayerClientTest, PublishSdiiCancel) {
   auto cancel_future =
       client_->PublishSdii(PublishSdiiRequest()
                                .WithSdiiMessageList(sdii_data_)
@@ -589,7 +592,7 @@ TEST_F(StreamLayerClientOnlineTest, PublishSdiiCancel) {
   //  response.GetError().GetErrorCode());
 }
 
-TEST_F(StreamLayerClientOnlineTest, PublishSdiiCancelLongDelay) {
+TEST_F(DataserviceWriteStreamLayerClientTest, PublishSdiiCancelLongDelay) {
   auto cancel_future =
       client_->PublishSdii(PublishSdiiRequest()
                                .WithSdiiMessageList(sdii_data_)
@@ -616,7 +619,7 @@ TEST_F(StreamLayerClientOnlineTest, PublishSdiiCancelLongDelay) {
   //  response.GetError().GetErrorCode());
 }
 
-TEST_F(StreamLayerClientOnlineTest, PublishSDIINonSDIIData) {
+TEST_F(DataserviceWriteStreamLayerClientTest, PublishSDIINonSDIIData) {
   auto response =
       client_
           ->PublishSdii(
@@ -628,7 +631,7 @@ TEST_F(StreamLayerClientOnlineTest, PublishSDIINonSDIIData) {
   ASSERT_NO_FATAL_FAILURE(PublishFailureAssertions(response));
 }
 
-TEST_F(StreamLayerClientOnlineTest, PublishSDIIIncorrectLayer) {
+TEST_F(DataserviceWriteStreamLayerClientTest, PublishSDIIIncorrectLayer) {
   auto response = client_
                       ->PublishSdii(PublishSdiiRequest()
                                         .WithSdiiMessageList(sdii_data_)
@@ -639,7 +642,7 @@ TEST_F(StreamLayerClientOnlineTest, PublishSDIIIncorrectLayer) {
   ASSERT_NO_FATAL_FAILURE(PublishFailureAssertions(response));
 }
 
-TEST_F(StreamLayerClientOnlineTest, PublishSDIICustomTraceId) {
+TEST_F(DataserviceWriteStreamLayerClientTest, PublishSDIICustomTraceId) {
   const auto uuid = GenerateRandomUUID();
 
   auto response = client_
@@ -656,7 +659,7 @@ TEST_F(StreamLayerClientOnlineTest, PublishSDIICustomTraceId) {
                uuid.c_str());
 }
 
-TEST_F(StreamLayerClientOnlineTest, PublishSDIIBillingTag) {
+TEST_F(DataserviceWriteStreamLayerClientTest, PublishSDIIBillingTag) {
   auto response = client_
                       ->PublishSdii(PublishSdiiRequest()
                                         .WithSdiiMessageList(sdii_data_)
@@ -669,7 +672,7 @@ TEST_F(StreamLayerClientOnlineTest, PublishSDIIBillingTag) {
 }
 
 #ifdef DATASERVICE_WRITE_HAS_OPENSSL
-TEST_F(StreamLayerClientOnlineTest, SDIIChecksumValid) {
+TEST_F(DataserviceWriteStreamLayerClientTest, SDIIChecksumValid) {
   const std::string data_string(sdii_data_->begin(), sdii_data_->end());
   auto checksum = sha256(data_string);
 
@@ -685,7 +688,7 @@ TEST_F(StreamLayerClientOnlineTest, SDIIChecksumValid) {
 }
 #endif
 
-TEST_F(StreamLayerClientOnlineTest, SDIIChecksumGarbageString) {
+TEST_F(DataserviceWriteStreamLayerClientTest, SDIIChecksumGarbageString) {
   auto response = client_
                       ->PublishSdii(PublishSdiiRequest()
                                         .WithSdiiMessageList(sdii_data_)
@@ -697,7 +700,8 @@ TEST_F(StreamLayerClientOnlineTest, SDIIChecksumGarbageString) {
   ASSERT_NO_FATAL_FAILURE(PublishFailureAssertions(response));
 }
 
-TEST_F(StreamLayerClientOnlineTest, SDIIConcurrentPublishSameIngestApi) {
+TEST_F(DataserviceWriteStreamLayerClientTest,
+       SDIIConcurrentPublishSameIngestApi) {
   auto publish_data = [&]() {
     auto response = client_
                         ->PublishSdii(PublishSdiiRequest()
@@ -721,7 +725,8 @@ TEST_F(StreamLayerClientOnlineTest, SDIIConcurrentPublishSameIngestApi) {
   async5.get();
 }
 
-class StreamLayerClientCacheOnlineTest : public StreamLayerClientOnlineTest {
+class StreamLayerClientCacheOnlineTest
+    : public DataserviceWriteStreamLayerClientTest {
  protected:
   static std::shared_ptr<olp::http::Network> s_network;
 
@@ -762,7 +767,7 @@ class StreamLayerClientCacheOnlineTest : public StreamLayerClientOnlineTest {
   }
 
   virtual void TearDown() override {
-    StreamLayerClientOnlineTest::TearDown();
+    DataserviceWriteStreamLayerClientTest::TearDown();
     if (disk_cache_) {
       disk_cache_->Close();
     }

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVersionedLayerClientTest.cpp
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 #include <olp/authentication/TokenProvider.h>
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/HRN.h>
@@ -40,7 +40,7 @@ const std::string kLayer2 = "layer2";
 const std::string kLayerSdii = "layer_sdii";
 const std::string kVersionedLayer = "versioned_layer";
 
-class VersionedLayerClientOnlineTest : public ::testing::Test {
+class DataserviceWriteVersionedLayerClientTest : public ::testing::Test {
  protected:
   static std::shared_ptr<olp::http::Network> s_network;
 
@@ -81,9 +81,10 @@ class VersionedLayerClientOnlineTest : public ::testing::Test {
 // Static network instance is necessary as it needs to outlive any created
 // clients. This is a known limitation as triggered send requests capture the
 // network instance inside the callbacks.
-std::shared_ptr<olp::http::Network> VersionedLayerClientOnlineTest::s_network;
+std::shared_ptr<olp::http::Network>
+    DataserviceWriteVersionedLayerClientTest::s_network;
 
-TEST_F(VersionedLayerClientOnlineTest, StartBatchInvalid) {
+TEST_F(DataserviceWriteVersionedLayerClientTest, StartBatchInvalid) {
   auto versioned_client = CreateVersionedLayerClient();
   auto response =
       versioned_client->StartBatch(StartBatchRequest()).GetFuture().get();
@@ -111,7 +112,7 @@ TEST_F(VersionedLayerClientOnlineTest, StartBatchInvalid) {
   ASSERT_FALSE(cancel_batch_response.IsSuccessful());
 }
 
-TEST_F(VersionedLayerClientOnlineTest, StartBatch) {
+TEST_F(DataserviceWriteVersionedLayerClientTest, StartBatch) {
   auto versioned_client = CreateVersionedLayerClient();
   auto response = versioned_client
                       ->StartBatch(StartBatchRequest().WithLayers(
@@ -171,7 +172,7 @@ TEST_F(VersionedLayerClientOnlineTest, StartBatch) {
   // get_batch_response.GetResult().GetDetails()->GetState());
 }
 
-TEST_F(VersionedLayerClientOnlineTest, DeleteClient) {
+TEST_F(DataserviceWriteVersionedLayerClientTest, DeleteClient) {
   auto versioned_client = CreateVersionedLayerClient();
   auto fut = versioned_client
                  ->StartBatch(StartBatchRequest().WithLayers(
@@ -199,7 +200,7 @@ TEST_F(VersionedLayerClientOnlineTest, DeleteClient) {
             get_batch_response.GetResult().GetDetails()->GetState());
 }
 
-TEST_F(VersionedLayerClientOnlineTest, GetBaseVersion) {
+TEST_F(DataserviceWriteVersionedLayerClientTest, GetBaseVersion) {
   auto versioned_client = CreateVersionedLayerClient();
   auto response = versioned_client->GetBaseVersion().GetFuture().get();
 
@@ -208,7 +209,7 @@ TEST_F(VersionedLayerClientOnlineTest, GetBaseVersion) {
   ASSERT_GE(version_response.GetVersion(), 0);
 }
 
-TEST_F(VersionedLayerClientOnlineTest, CancelBatch) {
+TEST_F(DataserviceWriteVersionedLayerClientTest, CancelBatch) {
   auto versioned_client = CreateVersionedLayerClient();
   auto response = versioned_client
                       ->StartBatch(StartBatchRequest().WithLayers(
@@ -245,7 +246,7 @@ TEST_F(VersionedLayerClientOnlineTest, CancelBatch) {
             get_batch_response.GetResult().GetDetails()->GetState());
 }
 
-TEST_F(VersionedLayerClientOnlineTest, CancelAllBatch) {
+TEST_F(DataserviceWriteVersionedLayerClientTest, CancelAllBatch) {
   auto versioned_client = CreateVersionedLayerClient();
   auto response_future =
       versioned_client
@@ -260,7 +261,7 @@ TEST_F(VersionedLayerClientOnlineTest, CancelAllBatch) {
   ASSERT_FALSE(response.IsSuccessful());
 }
 
-TEST_F(VersionedLayerClientOnlineTest, PublishToBatch) {
+TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatch) {
   auto versioned_client = CreateVersionedLayerClient();
   auto response = versioned_client
                       ->StartBatch(StartBatchRequest().WithLayers(
@@ -327,7 +328,7 @@ TEST_F(VersionedLayerClientOnlineTest, PublishToBatch) {
   // get_batch_response.GetResult().GetDetails()->GetState());
 }
 
-TEST_F(VersionedLayerClientOnlineTest, PublishToBatchDeleteClient) {
+TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatchDeleteClient) {
   auto versioned_client = CreateVersionedLayerClient();
   auto response = versioned_client
                       ->StartBatch(StartBatchRequest().WithLayers(
@@ -412,7 +413,7 @@ TEST_F(VersionedLayerClientOnlineTest, PublishToBatchDeleteClient) {
   // get_batch_response.GetResult().GetDetails()->GetState());
 }
 
-TEST_F(VersionedLayerClientOnlineTest, PublishToBatchMulti) {
+TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatchMulti) {
   auto versioned_client = CreateVersionedLayerClient();
   auto response = versioned_client
                       ->StartBatch(StartBatchRequest().WithLayers(
@@ -494,7 +495,7 @@ TEST_F(VersionedLayerClientOnlineTest, PublishToBatchMulti) {
   // get_batch_response.GetResult().GetDetails()->GetState());
 }
 
-TEST_F(VersionedLayerClientOnlineTest, PublishToBatchCancel) {
+TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatchCancel) {
   auto versioned_client = CreateVersionedLayerClient();
   auto response = versioned_client
                       ->StartBatch(StartBatchRequest().WithLayers(
@@ -549,7 +550,7 @@ TEST_F(VersionedLayerClientOnlineTest, PublishToBatchCancel) {
             get_batch_response.GetResult().GetDetails()->GetState());
 }
 
-TEST_F(VersionedLayerClientOnlineTest, CheckDataExists) {
+TEST_F(DataserviceWriteVersionedLayerClientTest, CheckDataExists) {
   auto versioned_client = CreateVersionedLayerClient();
   auto fut =
       versioned_client
@@ -566,7 +567,7 @@ TEST_F(VersionedLayerClientOnlineTest, CheckDataExists) {
   ASSERT_EQ(response.GetResult(), 200);
 }
 
-TEST_F(VersionedLayerClientOnlineTest, CheckDataNotExists) {
+TEST_F(DataserviceWriteVersionedLayerClientTest, CheckDataNotExists) {
   auto versioned_client = CreateVersionedLayerClient();
   auto fut =
       versioned_client

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVolatileLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVolatileLayerClientTest.cpp
@@ -48,7 +48,7 @@ void PublishDataSuccessAssertions(
   EXPECT_EQ("", result.GetError().GetMessage());
 }
 
-class VolatileLayerClientOnlineTest : public ::testing::Test {
+class DataserviceWriteVolatileLayerClientTest : public ::testing::Test {
  protected:
   virtual void SetUp() override {
     client_ = CreateVolatileLayerClient();
@@ -117,9 +117,10 @@ class VolatileLayerClientOnlineTest : public ::testing::Test {
 // Static network instance is necessary as it needs to outlive any created
 // clients. This is a known limitation as triggered send requests capture the
 // network instance inside the callbacks.
-std::shared_ptr<olp::http::Network> VolatileLayerClientOnlineTest::s_network;
+std::shared_ptr<olp::http::Network>
+    DataserviceWriteVolatileLayerClientTest::s_network;
 
-TEST_F(VolatileLayerClientOnlineTest, GetBaseVersion) {
+TEST_F(DataserviceWriteVolatileLayerClientTest, GetBaseVersion) {
   auto volatile_client = CreateVolatileLayerClient();
   auto response = volatile_client->GetBaseVersion().GetFuture().get();
 
@@ -128,7 +129,7 @@ TEST_F(VolatileLayerClientOnlineTest, GetBaseVersion) {
   ASSERT_GE(version_response.GetVersion(), 0);
 }
 
-TEST_F(VolatileLayerClientOnlineTest, StartBatchInvalid) {
+TEST_F(DataserviceWriteVolatileLayerClientTest, StartBatchInvalid) {
   auto volatile_client = CreateVolatileLayerClient();
   auto response =
       volatile_client->StartBatch(StartBatchRequest()).GetFuture().get();
@@ -150,7 +151,7 @@ TEST_F(VolatileLayerClientOnlineTest, StartBatchInvalid) {
   ASSERT_FALSE(complete_batch_response.IsSuccessful());
 }
 
-TEST_F(VolatileLayerClientOnlineTest, StartBatch) {
+TEST_F(DataserviceWriteVolatileLayerClientTest, StartBatch) {
   auto volatile_client = CreateVolatileLayerClient();
   auto response =
       volatile_client
@@ -201,7 +202,7 @@ TEST_F(VolatileLayerClientOnlineTest, StartBatch) {
   // get_batch_response.GetResult().GetDetails()->GetState());
 }
 
-TEST_F(VolatileLayerClientOnlineTest, PublishToBatch) {
+TEST_F(DataserviceWriteVolatileLayerClientTest, PublishToBatch) {
   auto volatile_client = CreateVolatileLayerClient();
   auto response =
       volatile_client
@@ -254,7 +255,7 @@ TEST_F(VolatileLayerClientOnlineTest, PublishToBatch) {
   // get_batch_response.GetResult().GetDetails()->GetState());
 }
 
-TEST_F(VolatileLayerClientOnlineTest, PublishToBatchInvalid) {
+TEST_F(DataserviceWriteVolatileLayerClientTest, PublishToBatchInvalid) {
   auto volatile_client = CreateVolatileLayerClient();
   auto response =
       volatile_client
@@ -299,7 +300,8 @@ TEST_F(VolatileLayerClientOnlineTest, PublishToBatchInvalid) {
 // thus looks loke the problem is on the server side.
 // Please, re-enable this test when switched to mocked server or
 // when the server will be more steady for testing
-TEST_F(VolatileLayerClientOnlineTest, DISABLED_StartBatchDeleteClient) {
+TEST_F(DataserviceWriteVolatileLayerClientTest,
+       DISABLED_StartBatchDeleteClient) {
   auto volatile_client = CreateVolatileLayerClient();
   auto response =
       volatile_client
@@ -355,7 +357,7 @@ TEST_F(VolatileLayerClientOnlineTest, DISABLED_StartBatchDeleteClient) {
   // get_batch_response.GetResult().GetDetails()->GetState());
 }
 
-TEST_F(VolatileLayerClientOnlineTest, cancellAllRequests) {
+TEST_F(DataserviceWriteVolatileLayerClientTest, cancellAllRequests) {
   auto volatile_client = CreateVolatileLayerClient();
   auto future = volatile_client->GetBaseVersion().GetFuture();
 
@@ -368,7 +370,7 @@ TEST_F(VolatileLayerClientOnlineTest, cancellAllRequests) {
             response.GetError().GetErrorCode());
 }
 
-TEST_F(VolatileLayerClientOnlineTest, PublishData) {
+TEST_F(DataserviceWriteVolatileLayerClientTest, PublishData) {
   auto response = client_
                       ->PublishPartitionData(PublishPartitionDataRequest()
                                                  .WithData(data_)
@@ -379,7 +381,7 @@ TEST_F(VolatileLayerClientOnlineTest, PublishData) {
   ASSERT_NO_FATAL_FAILURE(PublishDataSuccessAssertions(response));
 }
 
-TEST_F(VolatileLayerClientOnlineTest, PublishDataAsync) {
+TEST_F(DataserviceWriteVolatileLayerClientTest, PublishDataAsync) {
   std::promise<PublishPartitionDataResponse> response_promise;
   bool call_is_async = true;
 


### PR DESCRIPTION
Affected tests:
 * IndexLayerClientOnlineTest
 * StreamLayerClientOnlineTest
 * VersionedLayerClientOnlineTest
 * VolatileLayerClientOnlineTest

Relates-to: OLPEDGE-720
Signed-off-by: Serhii Lysenko <ext-serhii.lysenko@here.com>