### PR TITLE
Add VolatileLayerClient class.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <olp/core/client/ApiError.h>
+#include <olp/core/client/ApiResponse.h>
+#include <olp/core/client/CancellationToken.h>
+#include <olp/core/client/HRN.h>
+#include <olp/core/client/OlpClientSettings.h>
+#include <olp/dataservice/read/DataRequest.h>
+#include <olp/dataservice/read/model/Data.h>
+
+namespace olp {
+namespace dataservice {
+namespace read {
+class VolatileLayerClientImpl;
+
+/**
+ * @brief The VolatileLayerClient is aimed at acquiring data from a volatile
+ * layer of the OLP. The volatile layer is a key/value store. Values for a given
+ * key can change, and only the latest value is retrievable.
+ *
+ * Example:
+ * @code{.cpp}
+ * const std::string kCatalog = "hrn:here:data:::hereos-internal-test-v2";
+ * const std::string kLayerId = "hype-test";
+ * const auto kHRN = olp::client::HRN::FromString(kCatalog);
+ *
+ * std::shared_ptr<olp::thread::TaskScheduler> task_scheduler =
+ *    olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler(1u);
+ * std::shared_ptr<olp::http::Network> http_client = olp::client::
+ *    OlpClientSettingsFactory::CreateDefaultNetworkRequestHandler();
+ *
+ * olp::authentication::Settings settings;
+ * settings.task_scheduler = task_scheduler;
+ * settings.network_request_handler = http_client;
+ *
+ * olp::client::AuthenticationSettings auth_settings;
+ * auth_settings.provider = olp::authentication::TokenProviderDefault(
+ *     kKeyId, kKeySecret, std::move(settings));
+ *
+ * auto client_settings = olp::client::OlpClientSettings();
+ * client_settings.authentication_settings = auth_settings;
+ * client_settings.task_scheduler = std::move(task_scheduler);
+ * client_settings.network_request_handler = std::move(http_client);
+ *
+ * VolatileLayerClient client{kHRN, kLayerId, client_settings};
+ * VolatileLayerClient::Callback<model::Data> callback = ... ;
+ * auto token = client.GetData(request, cb);
+ * @endcode
+ *
+ * @see
+ * https://developer.here.com/olp/documentation/data-api/data_dev_guide/shared_content/topics/olp/concepts/layers.html
+ */
+class DATASERVICE_READ_API VolatileLayerClient final {
+ public:
+  /// DataResult alias
+  using DataResult = model::Data;
+  /// CallbackResponse alias
+  using CallbackResponse = client::ApiResponse<DataResult, client::ApiError>;
+  /// Callback alias
+  using Callback = std::function<void(CallbackResponse response)>;
+
+  /**
+   * @brief VolatileLayerClient constructor.
+   * @param catalog a catalog that the volatile layer client uses during
+   * requests.
+   * @param layer_id a layer id that the volatile layer client uses during
+   * requests.
+   * @param client_settings settings used to control the client instance
+   * behavior.
+   */
+  VolatileLayerClient(olp::client::HRN catalog, std::string layer_id,
+                      olp::client::OlpClientSettings client_settings);
+
+  ~VolatileLayerClient();
+
+  /**
+   * @brief GetData fetches data for a partition or data handle asynchronously.
+   * If the specified partition or data handle cannot be found in the layer, the
+   * callback is invoked with an empty DataResponse (a nullptr result and
+   * error). If Partition Id or Data Handle are not set in the request, the
+   * callback is invoked with the error ErrorCode::InvalidRequest.
+   * @param data_request contains a complete set of request parameters.
+   * @param callback is invoked once the DataResult is available, or an
+   * error is encountered.
+   * @return A token that can be used to cancel this request.
+   */
+  olp::client::CancellationToken GetData(DataRequest data_request,
+                                         Callback callback);
+
+ private:
+  std::unique_ptr<VolatileLayerClientImpl> impl_;
+};
+
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClient.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <olp/dataservice/read/VolatileLayerClient.h>
+
+#include <olp/core/porting/make_unique.h>
+#include "VolatileLayerClientImpl.h"
+
+namespace olp {
+namespace dataservice {
+namespace read {
+
+VolatileLayerClient::VolatileLayerClient(
+    olp::client::HRN catalog, std::string layer_id,
+    olp::client::OlpClientSettings client_settings)
+    : impl_(std::make_unique<VolatileLayerClientImpl>(
+          std::move(catalog), std::move(layer_id),
+          std::move(client_settings))) {}
+
+VolatileLayerClient::~VolatileLayerClient() = default;
+
+olp::client::CancellationToken VolatileLayerClient::GetData(
+    DataRequest data_request, Callback callback) {
+  return impl_->GetData(std::move(data_request), std::move(callback));
+}
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "VolatileLayerClientImpl.h"
+
+namespace olp {
+namespace dataservice {
+namespace read {
+
+VolatileLayerClientImpl::VolatileLayerClientImpl(
+    olp::client::HRN catalog, std::string layer_id,
+    olp::client::OlpClientSettings client_settings) {}
+
+VolatileLayerClientImpl::~VolatileLayerClientImpl() = default;
+
+olp::client::CancellationToken VolatileLayerClientImpl::GetData(
+    DataRequest data_request, Callback callback) {
+  return olp::client::CancellationToken{[]() {}};
+}
+
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <olp/core/client/ApiError.h>
+#include <olp/core/client/ApiResponse.h>
+#include <olp/core/client/CancellationToken.h>
+#include <olp/core/client/HRN.h>
+#include <olp/core/client/OlpClientSettings.h>
+#include <olp/dataservice/read/DataRequest.h>
+#include <olp/dataservice/read/model/Data.h>
+
+namespace olp {
+namespace dataservice {
+namespace read {
+
+class VolatileLayerClientImpl {
+ public:
+  /// DataResult alias
+  using DataResult = model::Data;
+  /// CallbackResponse alias
+  using CallbackResponse = client::ApiResponse<DataResult, client::ApiError>;
+  /// Callback alias
+  using Callback = std::function<void(CallbackResponse response)>;
+
+  VolatileLayerClientImpl(olp::client::HRN catalog, std::string layer_id,
+                          olp::client::OlpClientSettings client_settings);
+
+  ~VolatileLayerClientImpl();
+
+  olp::client::CancellationToken GetData(DataRequest data_request,
+                                         Callback callback);
+};
+
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
@@ -27,6 +27,8 @@ set(OLP_SDK_DATASERVICE_READ_TEST_SOURCES
     PartitionsRepositoryTest.cpp
     PendingRequestsTest.cpp
     SerializerTest.cpp
+    VolatileLayerClientImplTest.cpp
+    VolatileLayerClientTest.cpp
 )
 
 if (ANDROID OR IOS)

--- a/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gtest/gtest.h>
+#include "VolatileLayerClientImpl.h"
+
+namespace {
+using namespace olp::dataservice::read;
+using namespace ::testing;
+const std::string kCatalog = "hrn:here:data:::hereos-internal-test-v2";
+const std::string kLayerId = "olp-sdk-test";
+const auto kHRN = olp::client::HRN::FromString(kCatalog);
+
+TEST(VolatileLayerClientImplTest, GetData) {
+  olp::client::OlpClientSettings settings;
+
+  VolatileLayerClientImpl client(kHRN, kLayerId, settings);
+
+  DataRequest request;
+
+  VolatileLayerClientImpl::Callback cb;
+  auto token = client.GetData(request, cb);
+  token.cancel();
+}
+}  // namespace

--- a/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientTest.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gtest/gtest.h>
+#include <olp/dataservice/read/VolatileLayerClient.h>
+
+namespace {
+using namespace olp::dataservice::read;
+using namespace ::testing;
+const std::string kCatalog = "hrn:here:data:::hereos-internal-test-v2";
+const std::string kLayerId = "olp-sdk-test";
+const auto kHRN = olp::client::HRN::FromString(kCatalog);
+
+TEST(VolatileLayerClientTest, GetData) {
+  olp::client::OlpClientSettings settings;
+
+  VolatileLayerClient client(kHRN, kLayerId, settings);
+
+  DataRequest request;
+
+  VolatileLayerClient::Callback cb;
+  auto token = client.GetData(request, cb);
+  token.cancel();
+}
+}  // namespace


### PR DESCRIPTION
Create VolatileLayerClient and VolatileLayerClientImpl classes:
- document usage of VolatileLayerClient
- add test skeletons for VolatileLayerClient and VolatileLayerClientImpl

Relates-to: OLPEDGE-758
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>