### PR TITLE
Make ReturnHttpResponse action a free function

### DIFF
--- a/olp-cpp-sdk-dataservice-read/tests/ApiClientLookupTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/ApiClientLookupTest.cpp
@@ -93,10 +93,9 @@ TEST(ApiClientLookupTest, LookupApi) {
     SCOPED_TRACE("Fetch from network");
     EXPECT_CALL(*network, Send(IsGetRequest(lookup_url), _, _, _, _))
         .Times(1)
-        .WillOnce(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(
-                olp::http::HttpStatusCode::OK),
-            OLP_SDK_HTTP_RESPONSE_LOOKUP_CONFIG));
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     OLP_SDK_HTTP_RESPONSE_LOOKUP_CONFIG));
     EXPECT_CALL(*cache, Put(cache_key, _, _, _))
         .Times(1)
         .WillOnce(Return(true));
@@ -114,10 +113,10 @@ TEST(ApiClientLookupTest, LookupApi) {
     SCOPED_TRACE("Network error propagated to the user");
     EXPECT_CALL(*network, Send(IsGetRequest(lookup_url), _, _, _, _))
         .Times(1)
-        .WillOnce(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(
-                olp::http::HttpStatusCode::UNAUTHORIZED),
-            "Inappropriate"));
+        .WillOnce(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                   olp::http::HttpStatusCode::UNAUTHORIZED),
+                               "Inappropriate"));
 
     client::CancellationContext context;
     auto response = ApiClientLookup::LookupApi(
@@ -222,4 +221,5 @@ TEST(ApiClientLookupTest, LookupApi) {
     EXPECT_EQ(response.GetError().GetErrorCode(),
               olp::client::ErrorCode::Cancelled);
     Mock::VerifyAndClearExpectations(network.get());
-  }}
+  }
+}

--- a/olp-cpp-sdk-dataservice-read/tests/CatalogRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/CatalogRepositoryTest.cpp
@@ -20,9 +20,9 @@
 #include "repositories/CatalogRepository.h"
 
 #include <gtest/gtest.h>
+#include <matchers/NetworkUrlMatchers.h>
 #include <mocks/CacheMock.h>
 #include <mocks/NetworkMock.h>
-#include <matchers/NetworkUrlMatchers.h>
 #include <olp/core/client/OlpClientFactory.h>
 #include "ApiClientLookup.h"
 
@@ -138,10 +138,9 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyNotFound) {
   EXPECT_CALL(*network_,
               Send(IsGetRequest(OLP_SDK_URL_LOOKUP_METADATA), _, _, _, _))
       .Times(1)
-      .WillOnce(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(
-              olp::http::HttpStatusCode::NOT_FOUND),
-          ""));
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::NOT_FOUND),
+                                   ""));
 
   auto response =
       olp::dataservice::read::repository::CatalogRepository::GetLatestVersion(
@@ -169,17 +168,16 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyFoundAndCacheWritten) {
 
   EXPECT_CALL(*network_,
               Send(IsGetRequest(OLP_SDK_URL_LOOKUP_METADATA), _, _, _, _))
-      .WillOnce(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(
-              olp::http::HttpStatusCode::OK),
-          OLP_SDK_HTTP_RESPONSE_LOOKUP_METADATA));
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   OLP_SDK_HTTP_RESPONSE_LOOKUP_METADATA));
 
   EXPECT_CALL(*network_, Send(IsGetRequest(OLP_SDK_URL_LATEST_CATALOG_VERSION),
                               _, _, _, _))
-      .WillOnce(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(
-              olp::http::HttpStatusCode::OK),
-          OLP_SDK_HTTP_RESPONSE_LATEST_CATALOG_VERSION));
+      .WillOnce(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                 olp::http::HttpStatusCode::OK),
+                             OLP_SDK_HTTP_RESPONSE_LATEST_CATALOG_VERSION));
 
   auto response =
       olp::dataservice::read::repository::CatalogRepository::GetLatestVersion(
@@ -237,10 +235,9 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyUserCancelled2) {
 
   ON_CALL(*network_,
           Send(IsGetRequest(OLP_SDK_URL_LOOKUP_METADATA), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(
-              olp::http::HttpStatusCode::OK),
-          OLP_SDK_HTTP_RESPONSE_LOOKUP_METADATA));
+      .WillByDefault(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                            olp::http::HttpStatusCode::OK),
+                                        OLP_SDK_HTTP_RESPONSE_LOOKUP_METADATA));
 
   ON_CALL(*network_,
           Send(IsGetRequest(OLP_SDK_URL_LATEST_CATALOG_VERSION), _, _, _, _))
@@ -296,10 +293,9 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionTimeouted) {
 
   ON_CALL(*network_,
           Send(IsGetRequest(OLP_SDK_URL_LOOKUP_METADATA), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(
-              olp::http::HttpStatusCode::OK),
-          OLP_SDK_HTTP_RESPONSE_LOOKUP_METADATA));
+      .WillByDefault(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                            olp::http::HttpStatusCode::OK),
+                                        OLP_SDK_HTTP_RESPONSE_LOOKUP_METADATA));
 
   ON_CALL(*network_,
           Send(IsGetRequest(OLP_SDK_URL_LATEST_CATALOG_VERSION), _, _, _, _))

--- a/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
@@ -73,16 +73,14 @@ std::string DataRepositoryTest::GetTestCatalog() {
 
 TEST_F(DataRepositoryTest, GetBlobData) {
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
-      .WillOnce(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(
-              olp::http::HttpStatusCode::OK),
-          HTTP_RESPONSE_LOOKUP_BLOB));
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   HTTP_RESPONSE_LOOKUP_BLOB));
 
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
-      .WillOnce(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(
-              olp::http::HttpStatusCode::OK),
-          "someData"));
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   "someData"));
 
   olp::client::CancellationContext context;
 
@@ -100,10 +98,9 @@ TEST_F(DataRepositoryTest, GetBlobData) {
 
 TEST_F(DataRepositoryTest, GetBlobDataApiLookupFailed403) {
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
-      .WillOnce(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(
-              olp::http::HttpStatusCode::FORBIDDEN),
-          HTTP_RESPONSE_403));
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::FORBIDDEN),
+                                   HTTP_RESPONSE_403));
 
   olp::client::CancellationContext context;
 
@@ -131,16 +128,14 @@ TEST_F(DataRepositoryTest, GetBlobDataNoDataHandle) {
 
 TEST_F(DataRepositoryTest, GetBlobDataFailedDataFetch403) {
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
-      .WillOnce(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(
-              olp::http::HttpStatusCode::OK),
-          HTTP_RESPONSE_LOOKUP_BLOB));
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   HTTP_RESPONSE_LOOKUP_BLOB));
 
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
-      .WillOnce(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(
-              olp::http::HttpStatusCode::FORBIDDEN),
-          HTTP_RESPONSE_403));
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::FORBIDDEN),
+                                   HTTP_RESPONSE_403));
 
   olp::client::CancellationContext context;
 
@@ -158,16 +153,14 @@ TEST_F(DataRepositoryTest, GetBlobDataFailedDataFetch403) {
 
 TEST_F(DataRepositoryTest, GetBlobDataCache) {
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
-      .WillOnce(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(
-              olp::http::HttpStatusCode::OK),
-          HTTP_RESPONSE_LOOKUP_BLOB));
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   HTTP_RESPONSE_LOOKUP_BLOB));
 
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
-      .WillOnce(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(
-              olp::http::HttpStatusCode::OK),
-          "someData"));
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   "someData"));
 
   olp::client::CancellationContext context;
 
@@ -193,16 +186,14 @@ TEST_F(DataRepositoryTest, GetBlobDataCache) {
 
 TEST_F(DataRepositoryTest, GetBlobDataImmediateCancel) {
   ON_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(
-              olp::http::HttpStatusCode::OK),
-          HTTP_RESPONSE_LOOKUP_BLOB));
+      .WillByDefault(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                            olp::http::HttpStatusCode::OK),
+                                        HTTP_RESPONSE_LOOKUP_BLOB));
 
   ON_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(
-              olp::http::HttpStatusCode::OK),
-          "someData"));
+      .WillByDefault(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                            olp::http::HttpStatusCode::OK),
+                                        "someData"));
 
   olp::client::CancellationContext context;
 
@@ -223,10 +214,9 @@ TEST_F(DataRepositoryTest, GetBlobDataImmediateCancel) {
 
 TEST_F(DataRepositoryTest, GetBlobDataInProgressCancel) {
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
-      .WillOnce(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(
-              olp::http::HttpStatusCode::OK),
-          HTTP_RESPONSE_LOOKUP_BLOB));
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   HTTP_RESPONSE_LOOKUP_BLOB));
 
   olp::client::CancellationContext context;
 

--- a/tests/common/mocks/NetworkMock.cpp
+++ b/tests/common/mocks/NetworkMock.cpp
@@ -25,8 +25,8 @@ NetworkMock::NetworkMock() = default;
 
 NetworkMock::~NetworkMock() = default;
 
-NetworkCallback NetworkMock::ReturnHttpResponse(
-    olp::http::NetworkResponse response, const std::string& response_body) {
+NetworkCallback ReturnHttpResponse(olp::http::NetworkResponse response,
+                                   const std::string& response_body) {
   return [=](olp::http::NetworkRequest request,
              olp::http::Network::Payload payload,
              olp::http::Network::Callback callback,

--- a/tests/common/mocks/NetworkMock.h
+++ b/tests/common/mocks/NetworkMock.h
@@ -46,9 +46,6 @@ class NetworkMock : public olp::http::Network {
               (override));
 
   MOCK_METHOD(void, Cancel, (olp::http::RequestId id), (override));
-
-  static NetworkCallback ReturnHttpResponse(olp::http::NetworkResponse response,
-                                            const std::string& response_body);
 };
 
 /**
@@ -83,3 +80,9 @@ GenerateNetworkMockActions(std::shared_ptr<std::promise<void>> pre_signal,
                            MockedResponseInformation response_information,
                            std::shared_ptr<std::promise<void>> post_signal =
                                std::make_shared<std::promise<void>>());
+
+///
+/// Mock Actions
+///
+NetworkCallback ReturnHttpResponse(olp::http::NetworkResponse response,
+                                   const std::string& response_body);

--- a/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientCacheTest.cpp
@@ -214,9 +214,8 @@ TEST_P(CatalogClientCacheTest, GetPartitionsLayerVersions) {
 
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(url_testlayer_res), _, _, _, _))
       .Times(1)
-      .WillOnce(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          http_response_testlayer_res));
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                                   http_response_testlayer_res));
 
   auto catalog_client = std::make_unique<olp::dataservice::read::CatalogClient>(
       hrn, settings_, cache_);
@@ -382,9 +381,9 @@ TEST_P(CatalogClientCacheTest, GetVolatilePartitionsExpiry) {
                           "layers/testlayer_volatile/partitions"),
              _, _, _, _))
         .Times(1)
-        .WillRepeatedly(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_PARTITIONS_V2));
+        .WillRepeatedly(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_PARTITIONS_V2));
 
     EXPECT_CALL(
         *network_mock_,
@@ -393,9 +392,9 @@ TEST_P(CatalogClientCacheTest, GetVolatilePartitionsExpiry) {
                           "layers/testlayer_volatile/partitions"),
              _, _, _, _))
         .Times(1)
-        .WillRepeatedly(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_EMPTY_PARTITIONS));
+        .WillRepeatedly(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_EMPTY_PARTITIONS));
   }
 
   auto catalog_client = std::make_unique<olp::dataservice::read::CatalogClient>(

--- a/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
@@ -85,8 +85,8 @@ TEST_P(CatalogClientTest, GetCatalog403) {
   olp::client::HRN hrn(GetTestCatalog());
 
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_CONFIG), _, _, _, _))
-      .WillOnce(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(403), HTTP_RESPONSE_403));
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(403),
+                                   HTTP_RESPONSE_403));
 
   auto catalog_client = std::make_unique<CatalogClient>(hrn, settings_);
   auto request = CatalogRequest();
@@ -167,9 +167,8 @@ TEST_P(CatalogClientTest, GetEmptyPartitions) {
   olp::client::HRN hrn(GetTestCatalog());
 
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
-      .WillOnce(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_EMPTY_PARTITIONS));
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                                   HTTP_RESPONSE_EMPTY_PARTITIONS));
 
   auto catalog_client =
       std::make_unique<olp::dataservice::read::CatalogClient>(hrn, settings_);
@@ -194,8 +193,8 @@ TEST_P(CatalogClientTest, GetVolatileDataHandle) {
                "blobstore/v1/catalogs/hereos-internal-test-v2/layers/"
                "testlayer_volatile/data/volatileHandle"),
            _, _, _, _))
-      .WillOnce(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200), "someData"));
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                                   "someData"));
 
   auto catalog_client =
       std::make_unique<olp::dataservice::read::CatalogClient>(hrn, settings_);
@@ -227,9 +226,8 @@ TEST_P(CatalogClientTest, GetVolatilePartitions) {
                                 "metadata/v1/catalogs/hereos-internal-test-v2/"
                                 "layers/testlayer_volatile/partitions"),
                    _, _, _, _))
-      .WillOnce(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_PARTITIONS_V2));
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                                   HTTP_RESPONSE_PARTITIONS_V2));
 
   auto catalog_client =
       std::make_unique<olp::dataservice::read::CatalogClient>(hrn, settings_);
@@ -267,9 +265,8 @@ TEST_P(CatalogClientTest, GetVolatileDataByPartitionId) {
                         "catalogs/hereos-internal-test-v2/layers/"
                         "testlayer_volatile/partitions?partition=269"),
            _, _, _, _))
-      .WillOnce(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_PARTITIONS_V2));
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                                   HTTP_RESPONSE_PARTITIONS_V2));
 
   EXPECT_CALL(
       *network_mock_,
@@ -278,8 +275,8 @@ TEST_P(CatalogClientTest, GetVolatileDataByPartitionId) {
                "blobstore/v1/catalogs/hereos-internal-test-v2/layers/"
                "testlayer_volatile/data/4eed6ed1-0d32-43b9-ae79-043cb4256410"),
            _, _, _, _))
-      .WillOnce(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200), "someData"));
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                                   "someData"));
 
   auto catalog_client =
       std::make_unique<olp::dataservice::read::CatalogClient>(hrn, settings_);
@@ -326,7 +323,7 @@ TEST_P(CatalogClientTest, GetData429Error) {
     EXPECT_CALL(*network_mock_,
                 Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
         .Times(2)
-        .WillRepeatedly(NetworkMock::ReturnHttpResponse(
+        .WillRepeatedly(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(429),
             "Server busy at the moment."));
 
@@ -368,7 +365,7 @@ TEST_P(CatalogClientTest, GetPartitions429Error) {
 
     EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
         .Times(2)
-        .WillRepeatedly(NetworkMock::ReturnHttpResponse(
+        .WillRepeatedly(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(429),
             "Server busy at the moment."));
 
@@ -404,7 +401,7 @@ TEST_P(CatalogClientTest, ApiLookup429) {
     EXPECT_CALL(*network_mock_,
                 Send(IsGetRequest(URL_LOOKUP_METADATA), _, _, _, _))
         .Times(2)
-        .WillRepeatedly(NetworkMock::ReturnHttpResponse(
+        .WillRepeatedly(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(429),
             "Server busy at the moment."));
 
@@ -458,8 +455,8 @@ TEST_P(CatalogClientTest, GetData404Error) {
                         "blobstore/v1/catalogs/hereos-internal-test-v2/"
                         "layers/testlayer/data/invalidDataHandle"),
            _, _, _, _))
-      .WillOnce(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(404), "Resource not found."));
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(404),
+                                   "Resource not found."));
 
   auto catalog_client =
       std::make_unique<olp::dataservice::read::CatalogClient>(hrn, settings_);
@@ -479,9 +476,8 @@ TEST_P(CatalogClientTest, GetPartitionsGarbageResponse) {
 
   EXPECT_CALL(*network_mock_,
               Send(IsGetRequest(URL_LOOKUP_METADATA), _, _, _, _))
-      .WillOnce(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          R"jsonString(kd3sdf\)jsonString"));
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                                   R"jsonString(kd3sdf\)jsonString"));
 
   auto catalog_client =
       std::make_unique<olp::dataservice::read::CatalogClient>(hrn, settings_);
@@ -1479,9 +1475,9 @@ TEST_P(CatalogClientTest, GetCatalogOnlineOnly) {
         .Times(1);
 
     EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_CONFIG), _, _, _, _))
-        .WillOnce(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(429),
-            "Server busy at the moment."));
+        .WillOnce(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(429),
+                               "Server busy at the moment."));
   }
 
   auto catalog_client = std::make_unique<CatalogClient>(hrn, settings_);
@@ -1577,9 +1573,9 @@ TEST_P(CatalogClientTest, GetDataOnlineOnly) {
 
     EXPECT_CALL(*network_mock_,
                 Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
-        .WillOnce(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(429),
-            "Server busy at the moment."));
+        .WillOnce(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(429),
+                               "Server busy at the moment."));
   }
 
   auto catalog_client =
@@ -1675,9 +1671,9 @@ TEST_P(CatalogClientTest, GetPartitionsOnlineOnly) {
         .Times(1);
 
     EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_CONFIG), _, _, _, _))
-        .WillOnce(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(429),
-            "Server busy at the moment."));
+        .WillOnce(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(429),
+                               "Server busy at the moment."));
   }
 
   auto catalog_client =
@@ -1751,7 +1747,7 @@ TEST_P(CatalogClientTest, GetCatalog403CacheClear) {
     EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_CONFIG), _, _, _, _))
         .Times(1);
     EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_CONFIG), _, _, _, _))
-        .WillOnce(NetworkMock::ReturnHttpResponse(
+        .WillOnce(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(403), HTTP_RESPONSE_403));
   }
 
@@ -1792,7 +1788,7 @@ TEST_P(CatalogClientTest, GetData403CacheClear) {
         .Times(1);
     EXPECT_CALL(*network_mock_,
                 Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
-        .WillOnce(NetworkMock::ReturnHttpResponse(
+        .WillOnce(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(403), HTTP_RESPONSE_403));
   }
 
@@ -1825,7 +1821,7 @@ TEST_P(CatalogClientTest, GetPartitions403CacheClear) {
     EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
         .Times(1);
     EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
-        .WillOnce(NetworkMock::ReturnHttpResponse(
+        .WillOnce(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(403), HTTP_RESPONSE_403));
   }
 

--- a/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTestBase.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTestBase.cpp
@@ -72,178 +72,178 @@ void CatalogClientTestBase::TearDown() {
 
 void CatalogClientTestBase::SetUpCommonNetworkMockCalls() {
   ON_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_LOOKUP_CONFIG));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_LOOKUP_CONFIG));
 
   ON_CALL(*network_mock_, Send(IsGetRequest(URL_CONFIG), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
+      .WillByDefault(ReturnHttpResponse(
           olp::http::NetworkResponse().WithStatus(200), HTTP_RESPONSE_CONFIG));
 
   ON_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_METADATA), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_LOOKUP_METADATA));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_LOOKUP_METADATA));
 
   ON_CALL(*network_mock_,
           Send(IsGetRequest(URL_LATEST_CATALOG_VERSION), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_LATEST_CATALOG_VERSION));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_LATEST_CATALOG_VERSION));
 
   ON_CALL(*network_mock_, Send(IsGetRequest(URL_LAYER_VERSIONS), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_LAYER_VERSIONS));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_LAYER_VERSIONS));
 
   ON_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_PARTITIONS));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_PARTITIONS));
 
   ON_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_QUERY), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_LOOKUP_QUERY));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_LOOKUP_QUERY));
 
   ON_CALL(*network_mock_,
           Send(IsGetRequest(URL_QUERY_PARTITION_269), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_PARTITION_269));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_PARTITION_269));
 
   ON_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_LOOKUP_BLOB));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_LOOKUP_BLOB));
 
   ON_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_BLOB_DATA_269));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_BLOB_DATA_269));
 
   ON_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITION_3), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_PARTITION_3));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_PARTITION_3));
 
   ON_CALL(*network_mock_,
           Send(IsGetRequest(URL_LOOKUP_VOLATILE_BLOB), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_LOOKUP_VOLATILE_BLOB));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_LOOKUP_VOLATILE_BLOB));
 
   ON_CALL(*network_mock_, Send(IsGetRequest(URL_LAYER_VERSIONS_V2), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_LAYER_VERSIONS_V2));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_LAYER_VERSIONS_V2));
 
   ON_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS_V2), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_PARTITIONS_V2));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_PARTITIONS_V2));
 
   ON_CALL(*network_mock_,
           Send(IsGetRequest(URL_QUERY_PARTITION_269_V2), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_PARTITION_269_V2));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_PARTITION_269_V2));
 
   ON_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269_V2), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_BLOB_DATA_269_V2));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_BLOB_DATA_269_V2));
 
   ON_CALL(*network_mock_,
           Send(IsGetRequest(URL_QUERY_PARTITION_269_V10), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(400),
-          HTTP_RESPONSE_INVALID_VERSION_V10));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(400),
+                             HTTP_RESPONSE_INVALID_VERSION_V10));
 
   ON_CALL(*network_mock_,
           Send(IsGetRequest(URL_QUERY_PARTITION_269_VN1), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(400),
-          HTTP_RESPONSE_INVALID_VERSION_VN1));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(400),
+                             HTTP_RESPONSE_INVALID_VERSION_VN1));
 
   ON_CALL(*network_mock_,
           Send(IsGetRequest(URL_LAYER_VERSIONS_V10), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(400),
-          HTTP_RESPONSE_INVALID_VERSION_V10));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(400),
+                             HTTP_RESPONSE_INVALID_VERSION_V10));
 
   ON_CALL(*network_mock_,
           Send(IsGetRequest(URL_LAYER_VERSIONS_VN1), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(400),
-          HTTP_RESPONSE_INVALID_VERSION_VN1));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(400),
+                             HTTP_RESPONSE_INVALID_VERSION_VN1));
 
   ON_CALL(*network_mock_, Send(IsGetRequest(URL_CONFIG_V2), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_CONFIG_V2));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_CONFIG_V2));
 
   ON_CALL(*network_mock_, Send(IsGetRequest(URL_QUADKEYS_23618364), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_QUADKEYS_23618364));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_QUADKEYS_23618364));
 
   ON_CALL(*network_mock_, Send(IsGetRequest(URL_QUADKEYS_1476147), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_QUADKEYS_1476147));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_QUADKEYS_1476147));
 
   ON_CALL(*network_mock_, Send(IsGetRequest(URL_QUADKEYS_5904591), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_QUADKEYS_5904591));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_QUADKEYS_5904591));
 
   ON_CALL(*network_mock_, Send(IsGetRequest(URL_QUADKEYS_369036), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_QUADKEYS_369036));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_QUADKEYS_369036));
 
   ON_CALL(*network_mock_,
           Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_1), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_BLOB_DATA_PREFETCH_1));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_BLOB_DATA_PREFETCH_1));
 
   ON_CALL(*network_mock_,
           Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_2), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_BLOB_DATA_PREFETCH_2));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_BLOB_DATA_PREFETCH_2));
 
   ON_CALL(*network_mock_,
           Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_3), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_BLOB_DATA_PREFETCH_3));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_BLOB_DATA_PREFETCH_3));
 
   ON_CALL(*network_mock_,
           Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_4), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_BLOB_DATA_PREFETCH_4));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_BLOB_DATA_PREFETCH_4));
 
   ON_CALL(*network_mock_,
           Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_5), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_BLOB_DATA_PREFETCH_5));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_BLOB_DATA_PREFETCH_5));
 
   ON_CALL(*network_mock_,
           Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_6), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_BLOB_DATA_PREFETCH_6));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_BLOB_DATA_PREFETCH_6));
 
   ON_CALL(*network_mock_,
           Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_7), _, _, _, _))
-      .WillByDefault(NetworkMock::ReturnHttpResponse(
-          olp::http::NetworkResponse().WithStatus(200),
-          HTTP_RESPONSE_BLOB_DATA_PREFETCH_7));
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_BLOB_DATA_PREFETCH_7));
 
   // Catch any non-interesting network calls that don't need to be verified
   EXPECT_CALL(*network_mock_, Send(_, _, _, _, _)).Times(testing::AtLeast(0));

--- a/tests/integration/olp-cpp-sdk-dataservice-write/IndexLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/IndexLayerClientTest.cpp
@@ -107,8 +107,7 @@ class IndexLayerClientTest : public ::testing::Test {
     // Catch unexpected calls and fail immediatley
     ON_CALL(network, Send(_, _, _, _, _))
         .WillByDefault(testing::DoAll(
-            NetworkMock::ReturnHttpResponse(
-                olp::http::NetworkResponse().WithStatus(-1), ""),
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(-1), ""),
             [](olp::http::NetworkRequest request,
                olp::http::Network::Payload payload,
                olp::http::Network::Callback callback,
@@ -119,41 +118,41 @@ class IndexLayerClientTest : public ::testing::Test {
               return olp::http::SendOutcome(5);
             }));
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_LOOKUP_CONFIG));
+        .WillByDefault(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_LOOKUP_CONFIG));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_INDEX), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_LOOKUP_INDEX));
+        .WillByDefault(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_LOOKUP_INDEX));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_LOOKUP_BLOB));
+        .WillByDefault(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_LOOKUP_BLOB));
 
     ON_CALL(network, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_GET_CATALOG));
+        .WillByDefault(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_GET_CATALOG));
 
     ON_CALL(network,
             Send(IsPutRequestPrefix(URL_PUT_BLOB_INDEX_PREFIX), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
+        .WillByDefault(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(200), ""));
 
     ON_CALL(network, Send(IsPostRequest(URL_INSERT_INDEX), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
+        .WillByDefault(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(201), ""));
 
     ON_CALL(network, Send(IsDeleteRequestPrefix(URL_DELETE_BLOB_INDEX_PREFIX),
                           _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
+        .WillByDefault(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(200), ""));
 
     ON_CALL(network, Send(IsPutRequest(URL_INSERT_INDEX), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
+        .WillByDefault(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(200), ""));
   }
 

--- a/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
@@ -139,8 +139,7 @@ class StreamLayerClientCacheTest : public ::testing::Test {
     // Catch unexpected calls and fail immediatley
     ON_CALL(network, Send(_, _, _, _, _))
         .WillByDefault(testing::DoAll(
-            NetworkMock::ReturnHttpResponse(
-                olp::http::NetworkResponse().WithStatus(-1), ""),
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(-1), ""),
             [](olp::http::NetworkRequest request,
                olp::http::Network::Payload payload,
                olp::http::Network::Callback callback,
@@ -152,68 +151,68 @@ class StreamLayerClientCacheTest : public ::testing::Test {
             }));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_INGEST), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_LOOKUP_INGEST));
+        .WillByDefault(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_LOOKUP_INGEST));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_LOOKUP_CONFIG));
+        .WillByDefault(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_LOOKUP_CONFIG));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_PUBLISH_V2), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_LOOKUP_PUBLISH_V2));
+        .WillByDefault(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_LOOKUP_PUBLISH_V2));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_LOOKUP_BLOB));
+        .WillByDefault(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_LOOKUP_BLOB));
 
     ON_CALL(network,
             Send(testing::AnyOf(IsGetRequest(URL_GET_CATALOG),
                                 IsGetRequest(URL_GET_CATALOG_BILLING_TAG)),
                  _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_GET_CATALOG));
+        .WillByDefault(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_GET_CATALOG));
 
     ON_CALL(network,
             Send(testing::AnyOf(IsPostRequest(URL_INGEST_DATA),
                                 IsPostRequest(URL_INGEST_DATA_BILLING_TAG)),
                  _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_INGEST_DATA));
+        .WillByDefault(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_INGEST_DATA));
 
     ON_CALL(network, Send(IsPostRequest(URL_INGEST_DATA_LAYER_2), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_INGEST_DATA_LAYER_2));
+        .WillByDefault(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_INGEST_DATA_LAYER_2));
 
     ON_CALL(network, Send(IsPostRequest(URL_INIT_PUBLICATION), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_INIT_PUBLICATION));
+        .WillByDefault(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_INIT_PUBLICATION));
 
     ON_CALL(network, Send(IsPutRequestPrefix(URL_PUT_BLOB_PREFIX), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
+        .WillByDefault(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(200), ""));
 
     ON_CALL(network, Send(testing::AnyOf(IsPostRequest(URL_UPLOAD_PARTITIONS),
                                          IsPutRequest(URL_SUBMIT_PUBLICATION)),
                           _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
+        .WillByDefault(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(204), ""));
 
     ON_CALL(network,
             Send(testing::AnyOf(IsPostRequest(URL_INGEST_SDII),
                                 IsPostRequest(URL_INGEST_SDII_BILLING_TAG)),
                  _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_INGEST_SDII));
+        .WillByDefault(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_INGEST_SDII));
   }
 
   void FlushDataOnSettingSuccessAssertions(

--- a/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientTest.cpp
@@ -155,8 +155,7 @@ class StreamLayerClientTest : public ::testing::Test {
     // Catch unexpected calls and fail immediatley
     ON_CALL(network, Send(_, _, _, _, _))
         .WillByDefault(testing::DoAll(
-            NetworkMock::ReturnHttpResponse(
-                olp::http::NetworkResponse().WithStatus(-1), ""),
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(-1), ""),
             [](olp::http::NetworkRequest request,
                olp::http::Network::Payload payload,
                olp::http::Network::Callback callback,
@@ -168,68 +167,68 @@ class StreamLayerClientTest : public ::testing::Test {
             }));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_INGEST), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_LOOKUP_INGEST));
+        .WillByDefault(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_LOOKUP_INGEST));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_LOOKUP_CONFIG));
+        .WillByDefault(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_LOOKUP_CONFIG));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_PUBLISH_V2), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_LOOKUP_PUBLISH_V2));
+        .WillByDefault(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_LOOKUP_PUBLISH_V2));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_LOOKUP_BLOB));
+        .WillByDefault(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_LOOKUP_BLOB));
 
     ON_CALL(network,
             Send(testing::AnyOf(IsGetRequest(URL_GET_CATALOG),
                                 IsGetRequest(URL_GET_CATALOG_BILLING_TAG)),
                  _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_GET_CATALOG));
+        .WillByDefault(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_GET_CATALOG));
 
     ON_CALL(network,
             Send(testing::AnyOf(IsPostRequest(URL_INGEST_DATA),
                                 IsPostRequest(URL_INGEST_DATA_BILLING_TAG)),
                  _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_INGEST_DATA));
+        .WillByDefault(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_INGEST_DATA));
 
     ON_CALL(network, Send(IsPostRequest(URL_INGEST_DATA_LAYER_2), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_INGEST_DATA_LAYER_2));
+        .WillByDefault(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_INGEST_DATA_LAYER_2));
 
     ON_CALL(network, Send(IsPostRequest(URL_INIT_PUBLICATION), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_INIT_PUBLICATION));
+        .WillByDefault(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_INIT_PUBLICATION));
 
     ON_CALL(network, Send(IsPutRequestPrefix(URL_PUT_BLOB_PREFIX), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
+        .WillByDefault(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(200), ""));
 
     ON_CALL(network, Send(testing::AnyOf(IsPostRequest(URL_UPLOAD_PARTITIONS),
                                          IsPutRequest(URL_SUBMIT_PUBLICATION)),
                           _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
+        .WillByDefault(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(204), ""));
 
     ON_CALL(network,
             Send(testing::AnyOf(IsPostRequest(URL_INGEST_SDII),
                                 IsPostRequest(URL_INGEST_SDII_BILLING_TAG)),
                  _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
-            olp::http::NetworkResponse().WithStatus(200),
-            HTTP_RESPONSE_INGEST_SDII));
+        .WillByDefault(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                               HTTP_RESPONSE_INGEST_SDII));
   }
 
  private:

--- a/tests/integration/olp-cpp-sdk-dataservice-write/VolatileLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/VolatileLayerClientTest.cpp
@@ -79,7 +79,7 @@ class VolatileLayerClientTest : public ::testing::Test {
     // Catch unexpected calls and fail immediatley
     ON_CALL(network, Send(_, _, _, _, _))
         .WillByDefault(testing::DoAll(
-            NetworkMock::ReturnHttpResponse(
+            ReturnHttpResponse(
                 olp::http::NetworkResponse().WithStatus(-1), ""),
             [](olp::http::NetworkRequest request,
                olp::http::Network::Payload payload,
@@ -92,43 +92,43 @@ class VolatileLayerClientTest : public ::testing::Test {
             }));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
+        .WillByDefault(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(200),
             HTTP_RESPONSE_LOOKUP_CONFIG));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_METADATA), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
+        .WillByDefault(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(200),
             HTTP_RESPONSE_LOOKUP_METADATA));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_VOLATILE_BLOB), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
+        .WillByDefault(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(200),
             HTTP_RESPONSE_LOOKUP_VOLATILE_BLOB));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_QUERY), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
+        .WillByDefault(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(200),
             HTTP_RESPONSE_LOOKUP_QUERY));
 
     ON_CALL(network, Send(IsGetRequest(URL_LOOKUP_PUBLISH_V2), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
+        .WillByDefault(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(200),
             HTTP_RESPONSE_LOOKUP_PUBLISH_V2));
 
     ON_CALL(network, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
+        .WillByDefault(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(200),
             HTTP_RESPONSE_GET_CATALOG));
 
     ON_CALL(network, Send(IsGetRequest(URL_QUERY_PARTITION_1111), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
+        .WillByDefault(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(200),
             HTTP_RESPONSE_QUERY_DATA_HANDLE));
 
     ON_CALL(network,
             Send(IsPutRequestPrefix(URL_PUT_VOLATILE_BLOB_PREFIX), _, _, _, _))
-        .WillByDefault(NetworkMock::ReturnHttpResponse(
+        .WillByDefault(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(200), ""));
   }
 


### PR DESCRIPTION
Instead of ReturnHttpResponse being a static member function of a
NetworkMock class make it a free function.

Signed-off-by: Serhii Lysenko <ext-serhii.lysenko@here.com>