### PR TITLE
Pass arguments to VolatileLayerClient by value

### DIFF
--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VolatileLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VolatileLayerClient.h
@@ -85,8 +85,7 @@ class DATASERVICE_WRITE_API VolatileLayerClient {
    * @param settings Client settings used to control behaviour of the client
    * instance. Volatile.
    */
-  VolatileLayerClient(const client::HRN& catalog,
-                      const client::OlpClientSettings& settings);
+  VolatileLayerClient(client::HRN catalog, client::OlpClientSettings settings);
 
   /**
    * @brief Cancel all pending requests.
@@ -119,7 +118,7 @@ class DATASERVICE_WRITE_API VolatileLayerClient {
    */
   olp::client::CancellationToken PublishPartitionData(
       const model::PublishPartitionDataRequest& request,
-      const PublishPartitionDataCallback& callback);
+      PublishPartitionDataCallback callback);
 
   /**
    * @brief Get the latest version number of the catalog
@@ -133,7 +132,7 @@ class DATASERVICE_WRITE_API VolatileLayerClient {
    * @return cancellationToken
    */
   olp::client::CancellationToken GetBaseVersion(
-      const GetBaseVersionCallback& callback);
+      GetBaseVersionCallback callback);
 
   /**
    * @brief Start a batch operation.
@@ -150,8 +149,7 @@ class DATASERVICE_WRITE_API VolatileLayerClient {
    * @return olp::client::CancellationToken
    */
   olp::client::CancellationToken StartBatch(
-      const model::StartBatchRequest& request,
-      const StartBatchCallback& callback);
+      const model::StartBatchRequest& request, StartBatchCallback callback);
 
   /**
    * @brief Get the details of the given batch publication
@@ -168,7 +166,7 @@ class DATASERVICE_WRITE_API VolatileLayerClient {
    * @return cancellation token
    */
   olp::client::CancellationToken GetBatch(const model::Publication& pub,
-                                          const GetBatchCallback& callback);
+                                          GetBatchCallback callback);
 
   /**
    * Publish meta data to OLP.
@@ -223,7 +221,7 @@ class DATASERVICE_WRITE_API VolatileLayerClient {
   olp::client::CancellationToken PublishToBatch(
       const model::Publication& pub,
       const std::vector<model::PublishPartitionDataRequest>& partitions,
-      const PublishToBatchCallback& callback);
+      PublishToBatchCallback callback);
 
   /**
    * @brief Complete the given batch operation and commit to OLP.
@@ -239,8 +237,8 @@ class DATASERVICE_WRITE_API VolatileLayerClient {
    * @param callback called when the operation completes.
    * @return cancellation token
    */
-  olp::client::CancellationToken CompleteBatch(
-      const model::Publication& pub, const CompleteBatchCallback& callback);
+  olp::client::CancellationToken CompleteBatch(const model::Publication& pub,
+                                               CompleteBatchCallback callback);
 
  private:
   std::shared_ptr<VolatileLayerClientImpl> impl_;

--- a/olp-cpp-sdk-dataservice-write/src/VolatileLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/VolatileLayerClient.cpp
@@ -24,9 +24,10 @@
 namespace olp {
 namespace dataservice {
 namespace write {
-VolatileLayerClient::VolatileLayerClient(
-    const client::HRN& catalog, const client::OlpClientSettings& settings)
-    : impl_(std::make_shared<VolatileLayerClientImpl>(catalog, settings)) {}
+VolatileLayerClient::VolatileLayerClient(client::HRN catalog,
+                                         client::OlpClientSettings settings)
+    : impl_(std::make_shared<VolatileLayerClientImpl>(std::move(catalog),
+                                                      std::move(settings))) {}
 
 void VolatileLayerClient::cancellAll() { impl_->cancellAll(); }
 
@@ -38,8 +39,8 @@ VolatileLayerClient::PublishPartitionData(
 
 olp::client::CancellationToken VolatileLayerClient::PublishPartitionData(
     const model::PublishPartitionDataRequest& request,
-    const PublishPartitionDataCallback& callback) {
-  return impl_->PublishPartitionData(request, callback);
+    PublishPartitionDataCallback callback) {
+  return impl_->PublishPartitionData(request, std::move(callback));
 }
 
 olp::client::CancellableFuture<GetBaseVersionResponse>
@@ -48,8 +49,8 @@ VolatileLayerClient::GetBaseVersion() {
 }
 
 olp::client::CancellationToken VolatileLayerClient::GetBaseVersion(
-    const GetBaseVersionCallback& callback) {
-  return impl_->GetBaseVersion(callback);
+    GetBaseVersionCallback callback) {
+  return impl_->GetBaseVersion(std::move(callback));
 }
 
 olp::client::CancellableFuture<StartBatchResponse>
@@ -58,9 +59,8 @@ VolatileLayerClient::StartBatch(const model::StartBatchRequest& request) {
 }
 
 olp::client::CancellationToken VolatileLayerClient::StartBatch(
-    const model::StartBatchRequest& request,
-    const StartBatchCallback& callback) {
-  return impl_->StartBatch(request, callback);
+    const model::StartBatchRequest& request, StartBatchCallback callback) {
+  return impl_->StartBatch(request, std::move(callback));
 }
 
 olp::client::CancellableFuture<GetBatchResponse> VolatileLayerClient::GetBatch(
@@ -69,8 +69,8 @@ olp::client::CancellableFuture<GetBatchResponse> VolatileLayerClient::GetBatch(
 }
 
 olp::client::CancellationToken VolatileLayerClient::GetBatch(
-    const model::Publication& pub, const GetBatchCallback& callback) {
-  return impl_->GetBatch(pub, callback);
+    const model::Publication& pub, GetBatchCallback callback) {
+  return impl_->GetBatch(pub, std::move(callback));
 }
 
 olp::client::CancellableFuture<PublishToBatchResponse>
@@ -83,8 +83,8 @@ VolatileLayerClient::PublishToBatch(
 olp::client::CancellationToken VolatileLayerClient::PublishToBatch(
     const model::Publication& pub,
     const std::vector<model::PublishPartitionDataRequest>& partitions,
-    const PublishToBatchCallback& callback) {
-  return impl_->PublishToBatch(pub, partitions, callback);
+    PublishToBatchCallback callback) {
+  return impl_->PublishToBatch(pub, partitions, std::move(callback));
 }
 
 olp::client::CancellableFuture<CompleteBatchResponse>
@@ -93,8 +93,8 @@ VolatileLayerClient::CompleteBatch(const model::Publication& pub) {
 }
 
 olp::client::CancellationToken VolatileLayerClient::CompleteBatch(
-    const model::Publication& pub, const CompleteBatchCallback& callback) {
-  return impl_->CompleteBatch(pub, callback);
+    const model::Publication& pub, CompleteBatchCallback callback) {
+  return impl_->CompleteBatch(pub, std::move(callback));
 }
 
 }  // namespace write

--- a/olp-cpp-sdk-dataservice-write/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/VolatileLayerClientImpl.cpp
@@ -46,9 +46,9 @@ std::string GenerateUuid() {
 namespace olp {
 namespace dataservice {
 namespace write {
-VolatileLayerClientImpl::VolatileLayerClientImpl(
-    const HRN& catalog, const OlpClientSettings& settings)
-    : catalog_(catalog), settings_(settings) {}
+VolatileLayerClientImpl::VolatileLayerClientImpl(HRN catalog,
+                                                 OlpClientSettings settings)
+    : catalog_(std::move(catalog)), settings_(std::move(settings)) {}
 
 olp::client::CancellationToken VolatileLayerClientImpl::InitApiClients(
     std::shared_ptr<client::CancellationContext> cancel_context,
@@ -222,7 +222,7 @@ VolatileLayerClientImpl::GetBaseVersion() {
 }
 
 olp::client::CancellationToken VolatileLayerClientImpl::GetBaseVersion(
-    const GetBaseVersionCallback& callback) {
+    GetBaseVersionCallback callback) {
   auto cancel_context = std::make_shared<client::CancellationContext>();
   auto self = shared_from_this();
   auto id = tokenList_.GetNextId();
@@ -287,8 +287,7 @@ VolatileLayerClientImpl::StartBatch(const model::StartBatchRequest& request) {
 }
 
 client::CancellationToken VolatileLayerClientImpl::StartBatch(
-    const model::StartBatchRequest& request,
-    const StartBatchCallback& callback) {
+    const model::StartBatchRequest& request, StartBatchCallback callback) {
   auto cancel_context = std::make_shared<client::CancellationContext>();
   auto self = shared_from_this();
   auto id = tokenList_.GetNextId();
@@ -355,7 +354,7 @@ VolatileLayerClientImpl::PublishPartitionData(
 
 CancellationToken VolatileLayerClientImpl::PublishPartitionData(
     const model::PublishPartitionDataRequest& request,
-    const PublishPartitionDataCallback& callback) {
+    PublishPartitionDataCallback callback) {
   if (!request.GetData() || !request.GetPartitionId()) {
     callback(PublishPartitionDataResponse(
         ApiError(ErrorCode::InvalidArgument,
@@ -491,7 +490,7 @@ VolatileLayerClientImpl::GetBatch(const model::Publication& pub) {
 }
 
 olp::client::CancellationToken VolatileLayerClientImpl::GetBatch(
-    const model::Publication& pub, const GetBatchCallback& callback) {
+    const model::Publication& pub, GetBatchCallback callback) {
   std::string publicationId = pub.GetId().value_or("");
   if (publicationId.empty()) {
     callback(client::ApiError(client::ErrorCode::InvalidArgument,
@@ -634,7 +633,7 @@ VolatileLayerClientImpl::PublishToBatch(
 olp::client::CancellationToken VolatileLayerClientImpl::PublishToBatch(
     const model::Publication& pub,
     const std::vector<model::PublishPartitionDataRequest>& partitions,
-    const PublishToBatchCallback& callback) {
+    PublishToBatchCallback callback) {
   std::string publication_id = pub.GetId().value_or("");
   if (publication_id.empty()) {
     callback(client::ApiError(client::ErrorCode::InvalidArgument,
@@ -758,7 +757,7 @@ VolatileLayerClientImpl::CompleteBatch(const model::Publication& pub) {
 }
 
 olp::client::CancellationToken VolatileLayerClientImpl::CompleteBatch(
-    const model::Publication& pub, const CompleteBatchCallback& callback) {
+    const model::Publication& pub, CompleteBatchCallback callback) {
   std::string publicationId = pub.GetId().value_or("");
   if (publicationId.empty()) {
     callback(client::ApiError(client::ErrorCode::InvalidArgument,

--- a/olp-cpp-sdk-dataservice-write/src/VolatileLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/VolatileLayerClientImpl.h
@@ -52,13 +52,13 @@ using DataHandleMapCallback = std::function<void(DataHandleMapResponse)>;
 class VolatileLayerClientImpl
     : public std::enable_shared_from_this<VolatileLayerClientImpl> {
  public:
-  VolatileLayerClientImpl(const client::HRN& catalog,
-                          const client::OlpClientSettings& settings);
+  VolatileLayerClientImpl(client::HRN catalog,
+                          client::OlpClientSettings settings);
 
   olp::client::CancellableFuture<GetBaseVersionResponse> GetBaseVersion();
 
   olp::client::CancellationToken GetBaseVersion(
-      const GetBaseVersionCallback& callback);
+      GetBaseVersionCallback callback);
 
   void cancellAll();
 
@@ -67,25 +67,24 @@ class VolatileLayerClientImpl
 
   olp::client::CancellationToken PublishPartitionData(
       const model::PublishPartitionDataRequest& request,
-      const PublishPartitionDataCallback& callback);
+      PublishPartitionDataCallback callback);
 
   client::CancellableFuture<StartBatchResponse> StartBatch(
       const model::StartBatchRequest& request);
 
   olp::client::CancellationToken StartBatch(
-      const model::StartBatchRequest& request,
-      const StartBatchCallback& callback);
+      const model::StartBatchRequest& request, StartBatchCallback callback);
 
   olp::client::CancellableFuture<GetBatchResponse> GetBatch(
       const model::Publication& pub);
 
   olp::client::CancellationToken GetBatch(const model::Publication& pub,
-                                          const GetBatchCallback& callback);
+                                          GetBatchCallback callback);
 
   olp::client::CancellationToken PublishToBatch(
       const model::Publication& pub,
       const std::vector<model::PublishPartitionDataRequest>& partitions,
-      const PublishToBatchCallback& callback);
+      PublishToBatchCallback callback);
 
   olp::client::CancellableFuture<PublishToBatchResponse> PublishToBatch(
       const model::Publication& pub,
@@ -94,8 +93,8 @@ class VolatileLayerClientImpl
   olp::client::CancellableFuture<CompleteBatchResponse> CompleteBatch(
       const model::Publication& pub);
 
-  olp::client::CancellationToken CompleteBatch(
-      const model::Publication& pub, const CompleteBatchCallback& callback);
+  olp::client::CancellationToken CompleteBatch(const model::Publication& pub,
+                                               CompleteBatchCallback callback);
 
  private:
   client::CancellationToken InitApiClients(


### PR DESCRIPTION
Pass HRN, settings and callbacks to VolatileLayerClient by value. This
aligns interface with read dataservice API.

Relates-to: OLPEDGE-798

Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>