### PR TITLE
PartitionsRepository version handling

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
@@ -473,9 +473,6 @@ QueryApi::PartitionsResponse PartitionsRepository::GetPartitionById(
   }
 
   const auto& version = data_request.GetVersion();
-  if (!version) {
-    return ApiError(ErrorCode::PreconditionFailed, "Version is not identified");
-  }
 
   std::chrono::seconds timeout{settings.retry_settings.timeout};
   repository::PartitionsCacheRepository repository(catalog, settings.cache);


### PR DESCRIPTION
PartitionsRepository now can handle empty version in DataRequest.
PartitionsRepositoryTest cleaned up.

Signed-off-by: Sergii Vostrikov <ext-sergii.vostrikov@here.com>