### PR TITLE
Pass arguments to VersionedLayerClient by value

### DIFF
--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VersionedLayerClient.h
@@ -87,8 +87,7 @@ class DATASERVICE_WRITE_API VersionedLayerClient {
    * @param settings Client settings used to control behaviour of the client
    * instance
    */
-  VersionedLayerClient(const client::HRN& catalog,
-                       const client::OlpClientSettings& settings);
+  VersionedLayerClient(client::HRN catalog, client::OlpClientSettings settings);
   ~VersionedLayerClient();
 
   /**
@@ -106,8 +105,7 @@ class DATASERVICE_WRITE_API VersionedLayerClient {
    * @return olp::client::CancellationToken
    */
   olp::client::CancellationToken StartBatch(
-      const model::StartBatchRequest& request,
-      const StartBatchCallback& callback);
+      const model::StartBatchRequest& request, StartBatchCallback callback);
 
   /**
    * @brief Get the latest version number of the catalog
@@ -121,7 +119,7 @@ class DATASERVICE_WRITE_API VersionedLayerClient {
    * @return cancellationToken
    */
   olp::client::CancellationToken GetBaseVersion(
-      const GetBaseVersionCallback& callback);
+      GetBaseVersionCallback callback);
 
   /**
    * @brief Get the details of the given batch publication
@@ -138,7 +136,7 @@ class DATASERVICE_WRITE_API VersionedLayerClient {
    * @return cancellation token
    */
   olp::client::CancellationToken GetBatch(const model::Publication& pub,
-                                          const GetBatchCallback& callback);
+                                          GetBatchCallback callback);
 
   /**
    * @brief Complete the given batch operation and commit to OLP.
@@ -154,8 +152,8 @@ class DATASERVICE_WRITE_API VersionedLayerClient {
    * @param callback called when the operation completes.
    * @return cancellation token
    */
-  olp::client::CancellationToken CompleteBatch(
-      const model::Publication& pub, const CompleteBatchCallback& callback);
+  olp::client::CancellationToken CompleteBatch(const model::Publication& pub,
+                                               CompleteBatchCallback callback);
 
   /**
    * @brief Cancel the given batch operation
@@ -171,8 +169,8 @@ class DATASERVICE_WRITE_API VersionedLayerClient {
    * @param callback called when the operation cancel
    * @return cancellation token
    */
-  olp::client::CancellationToken CancelBatch(
-      const model::Publication& pub, const CancelBatchCallback& callback);
+  olp::client::CancellationToken CancelBatch(const model::Publication& pub,
+                                             CancelBatchCallback callback);
 
   /**
    * @brief Cancel all pending operations started by this client. This will only
@@ -210,7 +208,7 @@ class DATASERVICE_WRITE_API VersionedLayerClient {
   olp::client::CancellationToken PublishToBatch(
       const model::Publication& pub,
       const model::PublishPartitionDataRequest& request,
-      const PublishPartitionDataCallback& callback);
+      PublishPartitionDataCallback callback);
 
   /**
    * @brief Check if a datahandle exits.
@@ -228,7 +226,7 @@ class DATASERVICE_WRITE_API VersionedLayerClient {
    */
   olp::client::CancellationToken CheckDataExists(
       const model::CheckDataExistsRequest& request,
-      const CheckDataExistsCallback& callback);
+      CheckDataExistsCallback callback);
 
  private:
   std::shared_ptr<VersionedLayerClientImpl> impl_;

--- a/olp-cpp-sdk-dataservice-write/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/VersionedLayerClient.cpp
@@ -25,9 +25,10 @@ namespace olp {
 namespace dataservice {
 namespace write {
 
-VersionedLayerClient::VersionedLayerClient(
-    const client::HRN& catalog, const client::OlpClientSettings& settings)
-    : impl_(std::make_shared<VersionedLayerClientImpl>(catalog, settings)) {}
+VersionedLayerClient::VersionedLayerClient(client::HRN catalog,
+                                           client::OlpClientSettings settings)
+    : impl_(std::make_shared<VersionedLayerClientImpl>(std::move(catalog),
+                                                       std::move(settings))) {}
 
 VersionedLayerClient::~VersionedLayerClient() = default;
 
@@ -37,9 +38,8 @@ VersionedLayerClient::StartBatch(const model::StartBatchRequest& request) {
 }
 
 olp::client::CancellationToken VersionedLayerClient::StartBatch(
-    const model::StartBatchRequest& request,
-    const StartBatchCallback& callback) {
-  return impl_->StartBatch(request, callback);
+    const model::StartBatchRequest& request, StartBatchCallback callback) {
+  return impl_->StartBatch(request, std::move(callback));
 }
 
 olp::client::CancellableFuture<GetBaseVersionResponse>
@@ -48,8 +48,8 @@ VersionedLayerClient::GetBaseVersion() {
 }
 
 olp::client::CancellationToken VersionedLayerClient::GetBaseVersion(
-    const GetBaseVersionCallback& callback) {
-  return impl_->GetBaseVersion(callback);
+    GetBaseVersionCallback callback) {
+  return impl_->GetBaseVersion(std::move(callback));
 }
 
 olp::client::CancellableFuture<GetBatchResponse> VersionedLayerClient::GetBatch(
@@ -58,8 +58,8 @@ olp::client::CancellableFuture<GetBatchResponse> VersionedLayerClient::GetBatch(
 }
 
 olp::client::CancellationToken VersionedLayerClient::GetBatch(
-    const model::Publication& pub, const GetBatchCallback& callback) {
-  return impl_->GetBatch(pub, callback);
+    const model::Publication& pub, GetBatchCallback callback) {
+  return impl_->GetBatch(pub, std::move(callback));
 }
 
 olp::client::CancellableFuture<CompleteBatchResponse>
@@ -68,8 +68,8 @@ VersionedLayerClient::CompleteBatch(const model::Publication& pub) {
 }
 
 olp::client::CancellationToken VersionedLayerClient::CompleteBatch(
-    const model::Publication& pub, const CompleteBatchCallback& callback) {
-  return impl_->CompleteBatch(pub, callback);
+    const model::Publication& pub, CompleteBatchCallback callback) {
+  return impl_->CompleteBatch(pub, std::move(callback));
 }
 
 olp::client::CancellableFuture<CancelBatchResponse>
@@ -78,8 +78,8 @@ VersionedLayerClient::CancelBatch(const model::Publication& pub) {
 }
 
 olp::client::CancellationToken VersionedLayerClient::CancelBatch(
-    const model::Publication& pub, const CancelBatchCallback& callback) {
-  return impl_->CancelBatch(pub, callback);
+    const model::Publication& pub, CancelBatchCallback callback) {
+  return impl_->CancelBatch(pub, std::move(callback));
 }
 
 void VersionedLayerClient::CancelAll() { impl_->CancelAll(); }
@@ -94,8 +94,8 @@ VersionedLayerClient::PublishToBatch(
 olp::client::CancellationToken VersionedLayerClient::PublishToBatch(
     const model::Publication& pub,
     const model::PublishPartitionDataRequest& request,
-    const PublishPartitionDataCallback& callback) {
-  return impl_->PublishToBatch(pub, request, callback);
+    PublishPartitionDataCallback callback) {
+  return impl_->PublishToBatch(pub, request, std::move(callback));
 }
 
 olp::client::CancellableFuture<CheckDataExistsResponse>
@@ -106,8 +106,8 @@ VersionedLayerClient::CheckDataExists(
 
 olp::client::CancellationToken VersionedLayerClient::CheckDataExists(
     const model::CheckDataExistsRequest& request,
-    const CheckDataExistsCallback& callback) {
-  return impl_->CheckDataExists(request, callback);
+    CheckDataExistsCallback callback) {
+  return impl_->CheckDataExists(request, std::move(callback));
 }
 
 }  // namespace write

--- a/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.cpp
@@ -45,9 +45,9 @@ namespace dataservice {
 namespace write {
 
 VersionedLayerClientImpl::VersionedLayerClientImpl(
-    const client::HRN& catalog, const client::OlpClientSettings& settings)
-    : catalog_(catalog),
-      settings_(settings),
+    client::HRN catalog, client::OlpClientSettings settings)
+    : catalog_(std::move(catalog)),
+      settings_(std::move(settings)),
       apiclient_blob_(nullptr),
       apiclient_config_(nullptr),
       apiclient_metadata_(nullptr),
@@ -169,8 +169,7 @@ VersionedLayerClientImpl::StartBatch(const model::StartBatchRequest& request) {
 }
 
 client::CancellationToken VersionedLayerClientImpl::StartBatch(
-    const model::StartBatchRequest& request,
-    const StartBatchCallback& callback) {
+    const model::StartBatchRequest& request, StartBatchCallback callback) {
   if (!request.GetLayers() || request.GetLayers()->empty()) {
     callback(client::ApiError(client::ErrorCode::InvalidArgument,
                               "Invalid layer", true));
@@ -241,7 +240,7 @@ VersionedLayerClientImpl::GetBaseVersion() {
 }
 
 olp::client::CancellationToken VersionedLayerClientImpl::GetBaseVersion(
-    const GetBaseVersionCallback& callback) {
+    GetBaseVersionCallback callback) {
   auto self = shared_from_this();
   auto cancel_context = std::make_shared<client::CancellationContext>();
   auto id = tokenList_.GetNextId();
@@ -306,7 +305,7 @@ VersionedLayerClientImpl::GetBatch(const model::Publication& pub) {
 }
 
 olp::client::CancellationToken VersionedLayerClientImpl::GetBatch(
-    const model::Publication& pub, const GetBatchCallback& callback) {
+    const model::Publication& pub, GetBatchCallback callback) {
   std::string publicationId = pub.GetId().value_or("");
   if (publicationId.empty()) {
     callback(client::ApiError(client::ErrorCode::InvalidArgument,
@@ -372,7 +371,7 @@ VersionedLayerClientImpl::CompleteBatch(const model::Publication& pub) {
 }
 
 olp::client::CancellationToken VersionedLayerClientImpl::CompleteBatch(
-    const model::Publication& pub, const CompleteBatchCallback& callback) {
+    const model::Publication& pub, CompleteBatchCallback callback) {
   std::string publicationId = pub.GetId().value_or("");
   if (publicationId.empty()) {
     callback(client::ApiError(client::ErrorCode::InvalidArgument,
@@ -438,7 +437,7 @@ VersionedLayerClientImpl::CancelBatch(const model::Publication& pub) {
 }
 
 olp::client::CancellationToken VersionedLayerClientImpl::CancelBatch(
-    const model::Publication& pub, const CancelBatchCallback& callback) {
+    const model::Publication& pub, CancelBatchCallback callback) {
   std::string publicationId = pub.GetId().value_or("");
   if (publicationId.empty()) {
     callback(client::ApiError(client::ErrorCode::InvalidArgument,
@@ -510,7 +509,7 @@ VersionedLayerClientImpl::PublishToBatch(
 olp::client::CancellationToken VersionedLayerClientImpl::PublishToBatch(
     const model::Publication& pub,
     const model::PublishPartitionDataRequest& request,
-    const PublishPartitionDataCallback& callback) {
+    PublishPartitionDataCallback callback) {
   std::string publication_id = pub.GetId().value_or("");
   if (publication_id.empty()) {
     callback(client::ApiError(client::ErrorCode::InvalidArgument,
@@ -752,7 +751,7 @@ VersionedLayerClientImpl::CheckDataExists(
 
 client::CancellationToken VersionedLayerClientImpl::CheckDataExists(
     const model::CheckDataExistsRequest& request,
-    const CheckDataExistsCallback& callback) {
+    CheckDataExistsCallback callback) {
   if (request.GetLayerId().empty()) {
     callback(client::ApiError(client::ErrorCode::InvalidArgument,
                               "Invalid layer", true));

--- a/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.h
@@ -55,37 +55,36 @@ using UploadBlobCallback = std::function<void(UploadBlobResponse response)>;
 class VersionedLayerClientImpl
     : public std::enable_shared_from_this<VersionedLayerClientImpl> {
  public:
-  VersionedLayerClientImpl(const client::HRN& catalog,
-                           const client::OlpClientSettings& settings);
+  VersionedLayerClientImpl(client::HRN catalog,
+                           client::OlpClientSettings settings);
 
   client::CancellableFuture<StartBatchResponse> StartBatch(
       const model::StartBatchRequest& request);
 
   client::CancellationToken StartBatch(const model::StartBatchRequest& request,
-                                       const StartBatchCallback& callback);
+                                       StartBatchCallback callback);
 
   client::CancellableFuture<GetBaseVersionResponse> GetBaseVersion();
 
-  client::CancellationToken GetBaseVersion(
-      const GetBaseVersionCallback& callback);
+  client::CancellationToken GetBaseVersion(GetBaseVersionCallback callback);
 
   client::CancellableFuture<GetBatchResponse> GetBatch(
       const model::Publication& pub);
 
   client::CancellationToken GetBatch(const model::Publication& pub,
-                                     const GetBatchCallback& callback);
+                                     GetBatchCallback callback);
 
   client::CancellableFuture<CompleteBatchResponse> CompleteBatch(
       const model::Publication& pub);
 
-  client::CancellationToken CompleteBatch(
-      const model::Publication& pub, const CompleteBatchCallback& callback);
+  client::CancellationToken CompleteBatch(const model::Publication& pub,
+                                          CompleteBatchCallback callback);
 
   client::CancellableFuture<CancelBatchResponse> CancelBatch(
       const model::Publication& pub);
 
   client::CancellationToken CancelBatch(const model::Publication& pub,
-                                        const CancelBatchCallback& callback);
+                                        CancelBatchCallback callback);
 
   void CancelAll();
 
@@ -96,14 +95,14 @@ class VersionedLayerClientImpl
   client::CancellationToken PublishToBatch(
       const model::Publication& pub,
       const model::PublishPartitionDataRequest& request,
-      const PublishPartitionDataCallback& callback);
+      PublishPartitionDataCallback callback);
 
   client::CancellableFuture<CheckDataExistsResponse> CheckDataExists(
       const model::CheckDataExistsRequest& request);
 
   client::CancellationToken CheckDataExists(
       const model::CheckDataExistsRequest& request,
-      const CheckDataExistsCallback& callback);
+      CheckDataExistsCallback callback);
 
  private:
   std::string FindContentTypeForLayerId(const std::string& layer_id);


### PR DESCRIPTION
Pass HRN, settings and callbacks to VersionedLayerClient by value. This
aligns interface with read dataservice API.

Relates-to: OLPEDGE-798
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>