### PR TITLE
Pass arguments to StreamLayerClient by value

### DIFF
--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClient.h
@@ -30,7 +30,8 @@
 #include <olp/dataservice/write/FlushSettings.h>
 #include <olp/dataservice/write/generated/model/ResponseOk.h>
 #include <olp/dataservice/write/generated/model/ResponseOkSingle.h>
-
+#include <olp/dataservice/write/model/PublishDataRequest.h>
+#include <olp/dataservice/write/model/PublishSdiiRequest.h>
 
 namespace olp {
 namespace client {
@@ -41,11 +42,6 @@ class HRN;
 namespace dataservice {
 namespace write {
 class StreamLayerClientImpl;
-
-namespace model {
-class PublishDataRequest;
-class PublishSdiiRequest;
-}  // namespace model
 
 /**
  * @brief Creates an instance of the default cache with provided settings.
@@ -80,14 +76,11 @@ class DATASERVICE_WRITE_API StreamLayerClient {
    * @param catalog OLP HRN specifying the catalog this client will write to.
    * @param settings Client settings used to control behaviour of this
    * StreamLayerClient instance.
-   * @param cache Optional KeyValueCache instance used for queuing. If no cache
    * @param flush_settings Optional defines settings that effect cached
    * partitions to be flushed. is provided a default in-memory cache is used.
    */
-  StreamLayerClient(
-      const client::HRN& catalog, const client::OlpClientSettings& settings,
-      const std::shared_ptr<cache::KeyValueCache>& cache = CreateDefaultCache(),
-      const FlushSettings& flush_settings = FlushSettings());
+  StreamLayerClient(client::HRN catalog, client::OlpClientSettings settings,
+                    FlushSettings flush_settings = FlushSettings());
 
   /**
    * @brief Call to publish data into an OLP Stream Layer.
@@ -99,7 +92,7 @@ class DATASERVICE_WRITE_API StreamLayerClient {
    * @return A CancellableFuture containing the PublishDataResponse.
    */
   olp::client::CancellableFuture<PublishDataResponse> PublishData(
-      const model::PublishDataRequest& request);
+      model::PublishDataRequest request);
 
   /**
    * @brief Call to publish data into an OLP Stream Layer.
@@ -113,9 +106,8 @@ class DATASERVICE_WRITE_API StreamLayerClient {
    * @return A CancellationToken which can be used to cancel the ongoing
    * request.
    */
-  olp::client::CancellationToken PublishData(
-      const model::PublishDataRequest& request,
-      const PublishDataCallback& callback);
+  olp::client::CancellationToken PublishData(model::PublishDataRequest request,
+                                             PublishDataCallback callback);
 
   /**
    * @brief Queue a PublishDataRequest to be sent over the wire at a later time.
@@ -124,7 +116,7 @@ class DATASERVICE_WRITE_API StreamLayerClient {
    * @return A boost optional which will be boost::none if the queue call was
    * successful, otherwise it will contain a string with error details.
    */
-  boost::optional<std::string> Queue(const model::PublishDataRequest& request);
+  boost::optional<std::string> Queue(model::PublishDataRequest request);
 
   /**
    * @brief Flush PublishDataRequests which have been queued via the Queue
@@ -139,7 +131,7 @@ class DATASERVICE_WRITE_API StreamLayerClient {
    * @return A CancellationToken which can be used to cancel the ongoing
    * request.
    */
-  olp::client::CancellationToken Flush(const FlushCallback& callback);
+  olp::client::CancellationToken Flush(FlushCallback callback);
 
   /**
    * @brief Enable the StreamLayerClient auto-flushing mechanism.
@@ -178,7 +170,7 @@ class DATASERVICE_WRITE_API StreamLayerClient {
    * @return A CancellableFuture containing the PublishSdiiResponse.
    */
   olp::client::CancellableFuture<PublishSdiiResponse> PublishSdii(
-      const model::PublishSdiiRequest& request);
+      model::PublishSdiiRequest request);
 
   /**
    * @brief Call to send a list of SDII messages to an OLP Stream Layer.
@@ -193,9 +185,8 @@ class DATASERVICE_WRITE_API StreamLayerClient {
    * @return A CancellationToken which can be used to cancel the ongoing
    * request.
    */
-  olp::client::CancellationToken PublishSdii(
-      const model::PublishSdiiRequest& request,
-      const PublishSdiiCallback& callback);
+  olp::client::CancellationToken PublishSdii(model::PublishSdiiRequest request,
+                                             PublishSdiiCallback callback);
 
  private:
   std::shared_ptr<StreamLayerClientImpl> impl_;

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClient.cpp
@@ -34,26 +34,27 @@ std::shared_ptr<cache::KeyValueCache> CreateDefaultCache(
   return std::move(cache);
 }
 
-StreamLayerClient::StreamLayerClient(
-    const client::HRN& catalog, const client::OlpClientSettings& settings,
-    const std::shared_ptr<cache::KeyValueCache>& cache,
-    const FlushSettings& flush_settings)
-    : impl_(std::make_shared<StreamLayerClientImpl>(catalog, settings, cache,
-                                                    flush_settings)) {}
+StreamLayerClient::StreamLayerClient(client::HRN catalog,
+                                     client::OlpClientSettings settings,
+                                     FlushSettings flush_settings) {
+  auto cache = settings.cache;
+  impl_ = std::make_shared<StreamLayerClientImpl>(
+      std::move(catalog), std::move(settings), std::move(cache),
+      std::move(flush_settings));
+}
 
 olp::client::CancellableFuture<PublishDataResponse>
-StreamLayerClient::PublishData(const model::PublishDataRequest& request) {
+StreamLayerClient::PublishData(model::PublishDataRequest request) {
   return impl_->PublishData(request);
 }
 
 olp::client::CancellationToken StreamLayerClient::PublishData(
-    const model::PublishDataRequest& request,
-    const PublishDataCallback& callback) {
-  return impl_->PublishData(request, callback);
+    model::PublishDataRequest request, PublishDataCallback callback) {
+  return impl_->PublishData(request, std::move(callback));
 }
 
 boost::optional<std::string> StreamLayerClient::Queue(
-    const model::PublishDataRequest& request) {
+    model::PublishDataRequest request) {
   return impl_->Queue(request);
 }
 
@@ -63,8 +64,8 @@ StreamLayerClient::Flush() {
 }
 
 olp::client::CancellationToken StreamLayerClient::Flush(
-    const FlushCallback& callback) {
-  return impl_->Flush(callback);
+    FlushCallback callback) {
+  return impl_->Flush(std::move(callback));
 }
 
 void StreamLayerClient::Enable(std::shared_ptr<FlushListener> listener) {
@@ -79,14 +80,13 @@ StreamLayerClient::DefaultListener() {
 }
 
 olp::client::CancellableFuture<PublishSdiiResponse>
-StreamLayerClient::PublishSdii(const model::PublishSdiiRequest& request) {
+StreamLayerClient::PublishSdii(model::PublishSdiiRequest request) {
   return impl_->PublishSdii(request);
 }
 
 olp::client::CancellationToken StreamLayerClient::PublishSdii(
-    const model::PublishSdiiRequest& request,
-    const PublishSdiiCallback& callback) {
-  return impl_->PublishSdii(request, callback);
+    model::PublishSdiiRequest request, PublishSdiiCallback callback) {
+  return impl_->PublishSdii(request, std::move(callback));
 }
 
 }  // namespace write

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
@@ -371,7 +371,7 @@ StreamLayerClientImpl::Flush() {
 }
 
 olp::client::CancellationToken StreamLayerClientImpl::Flush(
-    const StreamLayerClient::FlushCallback& callback) {
+    StreamLayerClient::FlushCallback callback) {
   CancellationContext cancel_context;
 
   auto self = shared_from_this();
@@ -440,8 +440,7 @@ std::future<void> StreamLayerClientImpl::Disable() {
 }
 
 CancellationToken StreamLayerClientImpl::PublishData(
-    const model::PublishDataRequest& request,
-    const PublishDataCallback& callback) {
+    const model::PublishDataRequest& request, PublishDataCallback callback) {
   if (!request.GetData()) {
     callback(PublishDataResponse(
         ApiError(ErrorCode::InvalidArgument, "Request data null.")));
@@ -778,8 +777,7 @@ CancellableFuture<PublishSdiiResponse> StreamLayerClientImpl::PublishSdii(
 }
 
 CancellationToken StreamLayerClientImpl::PublishSdii(
-    const model::PublishSdiiRequest& request,
-    const PublishSdiiCallback& callback) {
+    const model::PublishSdiiRequest& request, PublishSdiiCallback callback) {
   if (!request.GetSdiiMessageList()) {
     callback(PublishSdiiResponse(ApiError(ErrorCode::InvalidArgument,
                                           "Request sdii message list null.")));

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.h
@@ -54,13 +54,12 @@ class StreamLayerClientImpl
   olp::client::CancellableFuture<PublishDataResponse> PublishData(
       const model::PublishDataRequest& request);
   olp::client::CancellationToken PublishData(
-      const model::PublishDataRequest& request,
-      const PublishDataCallback& callback);
+      const model::PublishDataRequest& request, PublishDataCallback callback);
 
   boost::optional<std::string> Queue(const model::PublishDataRequest& request);
   olp::client::CancellableFuture<StreamLayerClient::FlushResponse> Flush();
   olp::client::CancellationToken Flush(
-      const StreamLayerClient::FlushCallback& callback);
+      StreamLayerClient::FlushCallback callback);
   size_t QueueSize() const;
   boost::optional<model::PublishDataRequest> PopFromQueue();
 
@@ -70,8 +69,7 @@ class StreamLayerClientImpl
   olp::client::CancellableFuture<PublishSdiiResponse> PublishSdii(
       const model::PublishSdiiRequest& request);
   olp::client::CancellationToken PublishSdii(
-      const model::PublishSdiiRequest& request,
-      const PublishSdiiCallback& callback);
+      const model::PublishSdiiRequest& request, PublishSdiiCallback callback);
 
  private:
   client::CancellationToken InitApiClients(

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientCacheTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientCacheTest.cpp
@@ -149,10 +149,10 @@ class DataserviceWriteStreamLayerClientCacheTest : public ::testing::Test {
     disk_cache_ = std::make_shared<olp::cache::DefaultCache>();
     EXPECT_EQ(disk_cache_->Open(),
               olp::cache::DefaultCache::StorageOpenResult::Success);
+    settings.cache = disk_cache_;
 
     return std::make_shared<StreamLayerClient>(
-        olp::client::HRN{GetTestCatalog()}, settings, disk_cache_,
-        flush_settings_);
+        olp::client::HRN{GetTestCatalog()}, settings, flush_settings_);
   }
 
  private:

--- a/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
@@ -128,11 +128,11 @@ class StreamLayerClientCacheTest : public ::testing::Test {
 
     network_ = std::make_shared<NetworkMock>();
     client_settings.network_request_handler = network_;
+    client_settings.cache = disk_cache_;
     SetUpCommonNetworkMockCalls(*network_);
 
     return std::make_shared<StreamLayerClient>(
-        olp::client::HRN{GetTestCatalog()}, client_settings, disk_cache_,
-        flush_settings_);
+        olp::client::HRN{GetTestCatalog()}, client_settings, flush_settings_);
   }
 
   void SetUpCommonNetworkMockCalls(NetworkMock& network) {


### PR DESCRIPTION
Pass HRN, settings and callbacks to StreamLayerClient by value, cache is
passed in OlpClientSettings. This aligns interface with read dataservice
API.

Relates-to: OLPEDGE-798
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>