### PR TITLE
Added FlushMetrics to FlushEventListener

### DIFF
--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/FlushMetrics.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/FlushMetrics.h
@@ -17,28 +17,45 @@
  * License-Filename: LICENSE
  */
 
-#include <olp/dataservice/write/FlushEventListener.h>
+#pragma once
 
-#include <olp/dataservice/write/StreamLayerClient.h>
+#include <cstddef>
 
 namespace olp {
 namespace dataservice {
 namespace write {
 
-template <>
-void DefaultFlushEventListener<const StreamLayerClient::FlushResponse&>::
-    NotifyFlushEventResults(const StreamLayerClient::FlushResponse& results) {
-  FlushMetrics metrics;
-  {
-    std::lock_guard<std::mutex> locker(mutex_);
-    ++metrics_.num_total_flush_events;
-    if (results.empty() || CollateFlushEventResults(results)) {
-      ++metrics_.num_failed_flush_events;
-    }
-    metrics = metrics_;
-  }
-  NotifyFlushMetricsHasChanged(std::move(metrics));
-}
+/**
+ * @brief Struct which gather the metrics of Flush events and requests queued
+ * by \c StreamLayerClient.
+ */
+struct FlushMetrics {
+  /**
+  * @brief Number of attempted flush events.
+  */
+  size_t num_attempted_flush_events;
+
+  /**
+   * @brief Number of failed flush events
+   */
+  size_t num_failed_flush_events;
+
+  /**
+   * @brief Total number of flush events.
+   */
+  size_t num_total_flush_events;
+
+  /**
+   * @brief Total number of requests queued to \c StreamLayerClient.
+   */
+  size_t num_total_flushed_requests;
+
+  /**
+   * @brief Number of failed requests, which were queued to \c
+   * StreamLayerClient.
+   */
+  size_t num_failed_flushed_requests;
+};
 
 }  // namespace write
 }  // namespace dataservice

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -21,6 +21,7 @@ set(OLP_SDK_TESTS_COMMON_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/matchers/NetworkUrlMatchers.h
     ${CMAKE_CURRENT_SOURCE_DIR}/mocks/NetworkMock.h
     ${CMAKE_CURRENT_SOURCE_DIR}/mocks/CacheMock.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/testables/FlushEventListenerTestable.h
 )
 
 set(OLP_SDK_TESTS_COMMON_SOURCES
@@ -40,4 +41,5 @@ target_link_libraries(olp-cpp-sdk-tests-common
     PRIVATE
         gmock
         olp-cpp-sdk-core
+        olp-cpp-sdk-dataservice-write
 )

--- a/tests/common/testables/FlushEventListenerTestable.h
+++ b/tests/common/testables/FlushEventListenerTestable.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <mutex>
+
+#include <olp/dataservice/write/StreamLayerClient.h>
+
+namespace olp {
+namespace tests {
+namespace common {
+
+class FlushEventListenerTestable
+    : public olp::dataservice::write::DefaultFlushEventListener<
+          const olp::dataservice::write::StreamLayerClient::FlushResponse&> {
+ public:
+  size_t GetNumFlushEventsAttempted() const {
+    std::lock_guard<std::mutex> locker(mutex_);
+    return metrics_.num_attempted_flush_events;
+  }
+
+  size_t GetNumFlushEventsFailed() const {
+    std::lock_guard<std::mutex> locker(mutex_);
+    return metrics_.num_failed_flush_events;
+  }
+
+  size_t GetNumFlushEvents() const {
+    std::lock_guard<std::mutex> locker(mutex_);
+    return metrics_.num_total_flush_events;
+  }
+
+  size_t GetNumFlushedRequests() const {
+    std::lock_guard<std::mutex> locker(mutex_);
+    return metrics_.num_total_flushed_requests;
+  }
+
+  size_t GetNumFlushedRequestsFailed() const {
+    std::lock_guard<std::mutex> locker(mutex_);
+    return metrics_.num_failed_flushed_requests;
+  }
+
+  void NotifyFlushMetricsHasChanged(
+      olp::dataservice::write::FlushMetrics metrics) override {
+    std::lock_guard<std::mutex> locker(mutex_);
+    metrics_ = std::move(metrics);
+  }
+
+ private:
+  mutable std::mutex mutex_;
+  olp::dataservice::write::FlushMetrics metrics_;
+};
+
+}  // namespace common
+}  // namespace tests
+}  // namespace olp

--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -55,6 +55,7 @@ if (ANDROID OR IOS)
         PRIVATE
             custom-params
             gtest
+            olp-cpp-sdk-tests-common
             olp-cpp-sdk-core
             olp-cpp-sdk-authentication
             olp-cpp-sdk-dataservice-read
@@ -87,6 +88,7 @@ else()
         PRIVATE
             custom-params
             gtest_main
+            olp-cpp-sdk-tests-common
             olp-cpp-sdk-core
             olp-cpp-sdk-authentication
             olp-cpp-sdk-dataservice-read

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientCacheTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientCacheTest.cpp
@@ -38,9 +38,11 @@
 #include <olp/dataservice/write/model/PublishDataRequest.h>
 #include <olp/dataservice/write/model/PublishSdiiRequest.h>
 #include <testutils/CustomParameters.hpp>
+#include "testables/FlushEventListenerTestable.h"
 
 using namespace olp::dataservice::write;
 using namespace olp::dataservice::write::model;
+using namespace olp::tests::common;
 using namespace testing;
 
 const std::string kEndpoint = "endpoint";
@@ -328,7 +330,7 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest, FlushListenerMetrics) {
 
   ASSERT_NO_FATAL_FAILURE(QueueMultipleEvents(3));
 
-  auto default_listener = StreamLayerClient::DefaultListener();
+  auto default_listener = std::make_shared<FlushEventListenerTestable>();
 
   client_->Enable(default_listener);
 
@@ -352,7 +354,7 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest,
   flush_settings_.auto_flush_num_events = 3;
   client_ = CreateStreamLayerClient();
 
-  auto default_listener = StreamLayerClient::DefaultListener();
+  auto default_listener = std::make_shared<FlushEventListenerTestable>();
   client_->Enable(default_listener);
 
   ASSERT_NO_FATAL_FAILURE(QueueMultipleEvents(3));
@@ -376,7 +378,7 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest, FlushListenerDisable) {
   flush_settings_.auto_flush_num_events = 3;
   client_ = CreateStreamLayerClient();
 
-  auto default_listener = StreamLayerClient::DefaultListener();
+  auto default_listener = std::make_shared<FlushEventListenerTestable>();
   client_->Enable(default_listener);
 
   ASSERT_NO_FATAL_FAILURE(QueueMultipleEvents(3));
@@ -401,7 +403,7 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest,
   flush_settings_.auto_flush_num_events = 2;
   client_ = CreateStreamLayerClient();
 
-  auto default_listener = StreamLayerClient::DefaultListener();
+  auto default_listener = std::make_shared<FlushEventListenerTestable>();
   client_->Enable(default_listener);
 
   ASSERT_NO_FATAL_FAILURE(QueueMultipleEvents(2));
@@ -435,7 +437,7 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest,
       flush_settings_.auto_flush_num_events;
   client_ = CreateStreamLayerClient();
 
-  auto default_listener = StreamLayerClient::DefaultListener();
+  auto default_listener = std::make_shared<FlushEventListenerTestable>();
   client_->Enable(default_listener);
 
   ASSERT_NO_FATAL_FAILURE(QueueMultipleEvents(6));
@@ -464,7 +466,7 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest,
       flush_settings_.auto_flush_num_events;
   client_ = CreateStreamLayerClient();
 
-  auto default_listener = StreamLayerClient::DefaultListener();
+  auto default_listener = std::make_shared<FlushEventListenerTestable>();
   client_->Enable(default_listener);
 
   ASSERT_NO_FATAL_FAILURE(QueueMultipleEvents(4));
@@ -543,7 +545,7 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest,
 
   ASSERT_NO_FATAL_FAILURE(QueueMultipleEvents(2));
 
-  auto default_listener = StreamLayerClient::DefaultListener();
+  auto default_listener = std::make_shared<FlushEventListenerTestable>();
   client_->Enable(default_listener);
 
   for (int i = 0; default_listener->GetNumFlushEvents() < 1; i++) {
@@ -568,7 +570,7 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest,
 
   ASSERT_NO_FATAL_FAILURE(QueueMultipleEvents(2));
 
-  auto default_listener = StreamLayerClient::DefaultListener();
+  auto default_listener = std::make_shared<FlushEventListenerTestable>();
   client_->Enable(default_listener);
 
   std::this_thread::sleep_for(std::chrono::milliseconds(2100));

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -36,6 +36,7 @@ if (ANDROID OR IOS)
     target_link_libraries(olp-cpp-sdk-integration-tests-lib
         PRIVATE
             gtest
+            olp-cpp-sdk-tests-common
             olp-cpp-sdk-core
             olp-cpp-sdk-authentication
             olp-cpp-sdk-dataservice-read
@@ -62,6 +63,7 @@ else()
     target_link_libraries(olp-cpp-sdk-integration-tests
         PRIVATE
             gmock_main
+            olp-cpp-sdk-tests-common
             olp-cpp-sdk-core
             olp-cpp-sdk-authentication
             olp-cpp-sdk-dataservice-read

--- a/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
@@ -30,6 +30,7 @@
 #include <olp/dataservice/write/StreamLayerClient.h>
 #include <olp/dataservice/write/model/PublishDataRequest.h>
 #include "HttpResponses.h"
+#include "testables/FlushEventListenerTestable.h"
 
 namespace {
 
@@ -391,7 +392,7 @@ TEST_F(StreamLayerClientCacheTest, FlushListenerMetrics) {
 
   ASSERT_NO_FATAL_FAILURE(QueueMultipleEvents(3));
 
-  auto default_listener = StreamLayerClient::DefaultListener();
+  auto default_listener = std::make_shared<FlushEventListenerTestable>();
 
   client_->Enable(default_listener);
 
@@ -415,7 +416,7 @@ TEST_F(StreamLayerClientCacheTest,
   flush_settings_.auto_flush_num_events = 3;
   client_ = CreateStreamLayerClient();
 
-  auto default_listener = StreamLayerClient::DefaultListener();
+  auto default_listener = std::make_shared<FlushEventListenerTestable>();
   client_->Enable(default_listener);
   {
     testing::InSequence dummy;
@@ -451,7 +452,7 @@ TEST_F(StreamLayerClientCacheTest,
   flush_settings_.auto_flush_num_events = 2;
   client_ = CreateStreamLayerClient();
 
-  auto default_listener = StreamLayerClient::DefaultListener();
+  auto default_listener = std::make_shared<FlushEventListenerTestable>();
   client_->Enable(default_listener);
   {
     testing::InSequence dummy;
@@ -494,7 +495,7 @@ TEST_F(StreamLayerClientCacheTest,
   flush_settings_.auto_flush_num_events = 2;
   client_ = CreateStreamLayerClient();
 
-  auto default_listener = StreamLayerClient::DefaultListener();
+  auto default_listener = std::make_shared<FlushEventListenerTestable>();
   client_->Enable(default_listener);
   {
     testing::InSequence dummy;
@@ -661,7 +662,7 @@ TEST_F(StreamLayerClientCacheTest, FlushSettingsAutoFlushInterval) {
 
   ASSERT_NO_FATAL_FAILURE(QueueMultipleEvents(2));
 
-  auto default_listener = StreamLayerClient::DefaultListener();
+  auto default_listener = std::make_shared<FlushEventListenerTestable>();
   client_->Enable(default_listener);
 
   for (int i = 0; default_listener->GetNumFlushEvents() < 1; i++) {


### PR DESCRIPTION
- added FlushMetrics struct to dataservice-write component;
- removed all GetNum...() methods from FlushEventListener;
- added NotifyFlushMetricsHasChanged callback;
- updated integration and functional tests with FlushEventListenerTestable.

Resolved: OLPEDGE-816

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>