### PR TITLE
Move credentials to authentication settings.

### DIFF
--- a/docs/dataservice-read-catalog-example.md
+++ b/docs/dataservice-read-catalog-example.md
@@ -139,21 +139,36 @@ The main entry point for the OLP is `CatalogClient`. This class provides a high-
 To create a `CatalogClient`, provide the corresponding `HRN` (Here Resource Name) and preconfigured `OlpClientSettings`:
 
 ```cpp
-// Setup AuthenticationSettings with a default token provider that will
-// retrieve an OAuth 2.0 token from OLP.
-olp::client::AuthenticationSettings authSettings;
-authSettings.provider =
-    olp::authentication::TokenProviderDefault(kKeyId, kKeySecret);
+// Create a task scheduler instance
+std::shared_ptr<olp::thread::TaskScheduler> task_scheduler =
+    olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler(1u);
 
-// Setup OlpClientSettings and provide it to the CatalogClient.
-auto settings = std::make_shared<olp::client::OlpClientSettings>();
-settings->authentication_settings = authSettings;
-client_settings.network_request_handler =
+// Create a network client
+std::shared_ptr<olp::http::Network> http_client = olp::client::
     OlpClientSettingsFactory::CreateDefaultNetworkRequestHandler();
 
+// Initialize authentication settings
+olp::authentication::Settings settings({kKeyId, kKeySecret});
+settings.task_scheduler = task_scheduler;
+settings.network_request_handler = http_client;
+
+// Setup AuthenticationSettings with a default token provider that will
+// retrieve an OAuth 2.0 token from OLP.
+olp::client::AuthenticationSettings auth_settings;
+auth_settings.provider =
+    olp::authentication::TokenProviderDefault(std::move(settings));
+
+// Setup OlpClientSettings and provide it to the CatalogClient.
+olp::client::OlpClientSettings client_settings;
+client_settings.authentication_settings = auth_settings;
+client_settings.task_scheduler = std::move(task_scheduler);
+client_settings.network_request_handler = std::move(http_client);
+client_settings.cache =
+    olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
+
 // Create a CatalogClient with appropriate HRN and settings.
-auto serviceClient = std::make_unique<olp::dataservice::read::CatalogClient>(
-    olp::client::HRN(gCatalogHRN), settings);
+auto service_client = std::make_unique<olp::dataservice::read::CatalogClient>(
+    olp::client::HRN(kCatalogHRN), std::move(client_settings));
 ```
 
 The `OlpClientSettings` class pulls together all the different settings for customization of the client library behavior.

--- a/examples/dataservice-read/example.cpp
+++ b/examples/dataservice-read/example.cpp
@@ -132,24 +132,23 @@ int RunExample() {
       OlpClientSettingsFactory::CreateDefaultNetworkRequestHandler();
 
   // Initialize authentication settings
-  olp::authentication::Settings settings;
+  olp::authentication::Settings settings({kKeyId, kKeySecret});
   settings.task_scheduler = task_scheduler;
   settings.network_request_handler = http_client;
 
   // Setup AuthenticationSettings with a default token provider that will
   // retrieve an OAuth 2.0 token from OLP.
   olp::client::AuthenticationSettings auth_settings;
-  auth_settings.provider = olp::authentication::TokenProviderDefault(
-      kKeyId, kKeySecret, std::move(settings));
+  auth_settings.provider =
+      olp::authentication::TokenProviderDefault(std::move(settings));
 
   // Setup OlpClientSettings and provide it to the CatalogClient.
-  auto client_settings = olp::client::OlpClientSettings();
-  olp::cache::CacheSettings cache_settings;
+  olp::client::OlpClientSettings client_settings;
   client_settings.authentication_settings = auth_settings;
   client_settings.task_scheduler = std::move(task_scheduler);
   client_settings.network_request_handler = std::move(http_client);
   client_settings.cache =
-      olp::client::OlpClientSettingsFactory::CreateDefaultCache(cache_settings);
+      olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
 
   // Create a CatalogClient with appropriate HRN and settings.
   auto service_client = std::make_unique<olp::dataservice::read::CatalogClient>(

--- a/examples/dataservice-write/example.cpp
+++ b/examples/dataservice-write/example.cpp
@@ -58,15 +58,15 @@ int RunExample() {
       OlpClientSettingsFactory::CreateDefaultNetworkRequestHandler();
 
   // Initialize authentication settings
-  olp::authentication::Settings settings;
+  olp::authentication::Settings settings({kKeyId, kKeySecret});
   settings.task_scheduler = std::move(task_scheduler);
   settings.network_request_handler = http_client;
 
   // Setup AuthenticationSettings with a default token provider that will
   // retrieve an OAuth 2.0 token from OLP.
   olp::client::AuthenticationSettings auth_settings;
-  auth_settings.provider = olp::authentication::TokenProviderDefault(
-      kKeyId, kKeySecret, std::move(settings));
+  auth_settings.provider =
+      olp::authentication::TokenProviderDefault(std::move(settings));
 
   // Setup OlpClientSettings and provide it to the StreamLayerClient.
   olp::client::OlpClientSettings client_settings;
@@ -74,7 +74,7 @@ int RunExample() {
   client_settings.network_request_handler = std::move(http_client);
 
   auto client = std::make_shared<StreamLayerClient>(
-      olp::client::HRN{kCatalogHRN}, client_settings);
+      olp::client::HRN{kCatalogHRN}, std::move(client_settings));
 
   // Create a publish data request
   auto request = PublishDataRequest().WithData(buffer).WithLayerId(kLayer);

--- a/olp-cpp-sdk-authentication/include/olp/authentication/Settings.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/Settings.h
@@ -44,18 +44,29 @@ static const std::string kHereAccountProductionTokenUrl =
  * @brief Settings which can be used to configure a TokenEndpoint instance.
  */
 struct AUTHENTICATION_API Settings {
-  /// Optional. network_proxy_settings containing proxy configuration settings
-  /// for the network layer.
-  boost::optional<http::NetworkProxySettings> network_proxy_settings;
+  /**
+   * @brief Constructor
+   * @param credentials The client credentials to access OLP.
+   */
+  Settings(AuthenticationCredentials credentials)
+      : credentials(std::move(credentials)) {}
+
+  /// Client credentials
+  AuthenticationCredentials credentials;
 
   /// The network instance to be used to internally operate with OLP services.
   std::shared_ptr<http::Network> network_request_handler;
 
-  /// The TaskScheduler class to be used for managing callbacks enqueue
+  /// Optional. The TaskScheduler class to be used for managing callbacks
+  /// enqueue
   std::shared_ptr<thread::TaskScheduler> task_scheduler;
 
-  /// The token endpoint server URL. Note that only standard OAuth2 Token URLs
-  /// (those ending in 'oauth2/token') are supported.
+  /// Optional. network_proxy_settings containing proxy configuration settings
+  /// for the network layer.
+  boost::optional<http::NetworkProxySettings> network_proxy_settings;
+
+  /// Optional. The token endpoint server URL. Note that only standard OAuth2
+  /// Token URLs (those ending in 'oauth2/token') are supported.
   std::string token_endpoint_url{kHereAccountProductionTokenUrl};
 };
 

--- a/olp-cpp-sdk-authentication/include/olp/authentication/TokenEndpoint.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/TokenEndpoint.h
@@ -99,11 +99,9 @@ class AUTHENTICATION_API TokenEndpoint {
 
   /**
    * @brief Constructor
-   * @param credentials the credentials to use for this endpoint
    * @param settings the settings object for this endpoint
    */
-  TokenEndpoint(const AuthenticationCredentials& credentials,
-                const Settings& settings);
+  explicit TokenEndpoint(Settings settings);
 
  private:
   struct Impl;

--- a/olp-cpp-sdk-authentication/include/olp/authentication/TokenProvider.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/TokenProvider.h
@@ -43,26 +43,11 @@ class TokenProvider {
  public:
   /**
    * @brief Constructor
-   * @param key The client access key identifier.
-   * @param secret The client access key secret.
-   */
-  TokenProvider(const std::string& key, const std::string& secret)
-      : TokenProvider(key, secret, Settings{}) {}
-
-  /**
-   * @brief Constructor
-   * @param key The client access key identifier.
-   * @param secret The client access key secret.
    * @param settings Settings which can be used to configure a TokenEndpoint
    * instance.
    */
-  TokenProvider(const std::string& key, const std::string& secret,
-                Settings settings)
-      : key_(key),
-        secret_(secret),
-        settings_(settings),
-        token_(TokenEndpoint({key_, secret_}, settings_)
-                   .RequestAutoRefreshingToken()) {}
+  explicit TokenProvider(Settings settings)
+      : token_(TokenEndpoint(std::move(settings)).RequestAutoRefreshingToken()) {}
 
   /**
    * @brief bool type conversion
@@ -113,9 +98,6 @@ class TokenProvider {
            resp.GetResult().GetErrorResponse().code == 0ul;
   }
 
-  std::string key_;
-  std::string secret_;
-  Settings settings_;
   AutoRefreshingToken token_;
 };
 

--- a/tests/functional/olp-cpp-sdk-dataservice-read/ApiTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/ApiTest.cpp
@@ -52,13 +52,15 @@ class ApiTest : public ::testing::Test {
     auto network = olp::client::OlpClientSettingsFactory::
         CreateDefaultNetworkRequestHandler();
 
-    olp::authentication::Settings authentication_settings;
+    const auto key_id =
+        CustomParameters::getArgument("dataservice_read_test_appid");
+    const auto secret =
+        CustomParameters::getArgument("dataservice_read_test_secret");
+
+    olp::authentication::Settings authentication_settings({key_id, secret});
     authentication_settings.network_request_handler = network;
 
-    olp::authentication::TokenProviderDefault provider(
-        CustomParameters::getArgument("dataservice_read_test_appid"),
-        CustomParameters::getArgument("dataservice_read_test_secret"),
-        authentication_settings);
+    olp::authentication::TokenProviderDefault provider(authentication_settings);
     olp::client::AuthenticationSettings auth_client_settings;
     auth_client_settings.provider = provider;
 

--- a/tests/functional/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
@@ -86,13 +86,15 @@ class CatalogClientTest : public ::testing::TestWithParam<CacheType> {
     auto network = olp::client::OlpClientSettingsFactory::
         CreateDefaultNetworkRequestHandler();
 
-    olp::authentication::Settings auth_settings;
-    auth_settings.network_request_handler = network;
+    const auto key_id =
+        CustomParameters::getArgument("dataservice_read_test_appid");
+    const auto secret =
+        CustomParameters::getArgument("dataservice_read_test_secret");
 
-    olp::authentication::TokenProviderDefault provider(
-        CustomParameters::getArgument("dataservice_read_test_appid"),
-        CustomParameters::getArgument("dataservice_read_test_secret"),
-        auth_settings);
+    olp::authentication::Settings authentication_settings({key_id, secret});
+    authentication_settings.network_request_handler = network;
+
+    olp::authentication::TokenProviderDefault provider(authentication_settings);
     olp::client::AuthenticationSettings auth_client_settings;
     auth_client_settings.provider = provider;
     settings_ = olp::client::OlpClientSettings();

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteIndexLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteIndexLayerClientTest.cpp
@@ -65,14 +65,15 @@ class DataserviceWriteIndexLayerClientTest : public ::testing::Test {
   std::shared_ptr<IndexLayerClient> CreateIndexLayerClient() {
     auto network = s_network;
 
-    olp::authentication::Settings authentication_settings;
+    const auto key_id = CustomParameters::getArgument(kAppid);
+    const auto secret = CustomParameters::getArgument(kSecret);
+
+    olp::authentication::Settings authentication_settings({key_id, secret});
     authentication_settings.token_endpoint_url =
         CustomParameters::getArgument(kEndpoint);
     authentication_settings.network_request_handler = network;
 
-    olp::authentication::TokenProviderDefault provider(
-        CustomParameters::getArgument(kAppid),
-        CustomParameters::getArgument(kSecret), authentication_settings);
+    olp::authentication::TokenProviderDefault provider(authentication_settings);
 
     olp::client::AuthenticationSettings auth_client_settings;
     auth_client_settings.provider = provider;

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientCacheTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientCacheTest.cpp
@@ -130,14 +130,15 @@ class DataserviceWriteStreamLayerClientCacheTest : public ::testing::Test {
   virtual std::shared_ptr<StreamLayerClient> CreateStreamLayerClient() {
     auto network = s_network;
 
-    olp::authentication::Settings authentication_settings;
+    const auto app_id = CustomParameters::getArgument(kAppid);
+    const auto secret = CustomParameters::getArgument(kSecret);
+
+    olp::authentication::Settings authentication_settings({app_id, secret});
     authentication_settings.token_endpoint_url =
         CustomParameters::getArgument(kEndpoint);
     authentication_settings.network_request_handler = network;
 
-    olp::authentication::TokenProviderDefault provider(
-        CustomParameters::getArgument(kAppid),
-        CustomParameters::getArgument(kSecret), authentication_settings);
+    olp::authentication::TokenProviderDefault provider(authentication_settings);
 
     olp::client::AuthenticationSettings auth_client_settings;
     auth_client_settings.provider = provider;

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientTest.cpp
@@ -164,14 +164,15 @@ class DataserviceWriteStreamLayerClientTest : public ::testing::Test {
   virtual std::shared_ptr<StreamLayerClient> CreateStreamLayerClient() {
     auto network = s_network;
 
-    olp::authentication::Settings authentication_settings;
+    const auto app_id = CustomParameters::getArgument(kAppid);
+    const auto secret = CustomParameters::getArgument(kSecret);
+
+    olp::authentication::Settings authentication_settings({app_id, secret});
     authentication_settings.token_endpoint_url =
         CustomParameters::getArgument(kEndpoint);
     authentication_settings.network_request_handler = network;
 
-    olp::authentication::TokenProviderDefault provider(
-        CustomParameters::getArgument(kAppid),
-        CustomParameters::getArgument(kSecret), authentication_settings);
+    olp::authentication::TokenProviderDefault provider(authentication_settings);
 
     olp::client::AuthenticationSettings auth_client_settings;
     auth_client_settings.provider = provider;

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVersionedLayerClientTest.cpp
@@ -55,14 +55,16 @@ class DataserviceWriteVersionedLayerClientTest : public ::testing::Test {
 
   std::shared_ptr<VersionedLayerClient> CreateVersionedLayerClient() {
     auto network = s_network;
-    olp::authentication::Settings authentication_settings;
+
+    const auto key_id = CustomParameters::getArgument(kAppid);
+    const auto secret = CustomParameters::getArgument(kSecret);
+
+    olp::authentication::Settings authentication_settings({key_id, secret});
     authentication_settings.token_endpoint_url =
         CustomParameters::getArgument(kEndpoint);
     authentication_settings.network_request_handler = network;
 
-    olp::authentication::TokenProviderDefault provider(
-        CustomParameters::getArgument(kAppid),
-        CustomParameters::getArgument(kSecret), authentication_settings);
+    olp::authentication::TokenProviderDefault provider(authentication_settings);
 
     olp::client::AuthenticationSettings auth_client_settings;
     auth_client_settings.provider = provider;

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVolatileLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVolatileLayerClientTest.cpp
@@ -75,14 +75,15 @@ class DataserviceWriteVolatileLayerClientTest : public ::testing::Test {
   virtual std::shared_ptr<VolatileLayerClient> CreateVolatileLayerClient() {
     auto network = s_network;
 
-    olp::authentication::Settings authentication_settings;
+    const auto key_id = CustomParameters::getArgument(kAppid);
+    const auto secret = CustomParameters::getArgument(kSecret);
+
+    olp::authentication::Settings authentication_settings({key_id, secret});
     authentication_settings.token_endpoint_url =
         CustomParameters::getArgument(kEndpoint);
     authentication_settings.network_request_handler = network;
 
-    olp::authentication::TokenProviderDefault provider(
-        CustomParameters::getArgument(kAppid),
-        CustomParameters::getArgument(kSecret), authentication_settings);
+    olp::authentication::TokenProviderDefault provider(authentication_settings);
 
     olp::client::AuthenticationSettings auth_client_settings;
     auth_client_settings.provider = provider;

--- a/tests/integration/olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
@@ -155,10 +155,9 @@ TEST_F(HereAccountOauth2Test, AutoRefreshingTokenCancelSync) {
         return olp::http::SendOutcome(request_id);
       });
 
-  Settings settings;
+  Settings settings({key_, secret_});
   settings.network_request_handler = network_;
-  TokenEndpoint token_endpoint(AuthenticationCredentials(key_, secret_),
-                               settings);
+  TokenEndpoint token_endpoint(settings);
 
   TestAutoRefreshingTokenCancel(
       token_endpoint, [](olp::client::CancellationToken& cancellationToken,
@@ -195,10 +194,9 @@ TEST_F(HereAccountOauth2Test, AutoRefreshingTokenCancelAsync) {
         return olp::http::SendOutcome(request_id);
       });
 
-  Settings settings;
+  Settings settings({key_, secret_});
   settings.network_request_handler = network_;
-  TokenEndpoint token_endpoint(AuthenticationCredentials(key_, secret_),
-                               settings);
+  TokenEndpoint token_endpoint(settings);
 
   TestAutoRefreshingTokenCancel(
       token_endpoint, [](olp::client::CancellationToken& cancellationToken,

--- a/tests/performance/CatalogClientTest.cpp
+++ b/tests/performance/CatalogClientTest.cpp
@@ -22,7 +22,6 @@
 
 #include <gtest/gtest.h>
 
-#include "olp/authentication/TokenProvider.h"
 #include "olp/core/cache/KeyValueCache.h"
 #include "olp/core/client/HRN.h"
 #include "olp/core/client/OlpClientSettings.h"
@@ -76,10 +75,6 @@ class CatalogClientTest
           olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler(
               parameter.task_scheduler_capacity);
     }
-
-    olp::authentication::Settings settings;
-    settings.task_scheduler = task_scheduler;
-    settings.network_request_handler = s_network;
 
     olp::client::AuthenticationSettings auth_settings;
     auth_settings.provider = []() { return "invalid"; };


### PR DESCRIPTION
Remove old constructor in TokenProvider, because the constructed
authentication client had no network instance and is considered invalid.

Reorder members in Settings, first required then optional.

Update examples to reflect changes.
Update docs to reflect changes.

Relates-To: OLPEDGE-839

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>