### PR TITLE
Pass arguments to CatalogClient by value

### DIFF
--- a/examples/dataservice-read/example.cpp
+++ b/examples/dataservice-read/example.cpp
@@ -21,6 +21,8 @@
 
 #include <olp/authentication/TokenProvider.h>
 
+#include <olp/core/cache/CacheSettings.h>
+#include <olp/core/cache/KeyValueCache.h>
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
@@ -141,10 +143,13 @@ int RunExample() {
       kKeyId, kKeySecret, std::move(settings));
 
   // Setup OlpClientSettings and provide it to the CatalogClient.
-  auto client_settings = std::make_shared<olp::client::OlpClientSettings>();
-  client_settings->authentication_settings = auth_settings;
-  client_settings->task_scheduler = std::move(task_scheduler);
-  client_settings->network_request_handler = std::move(http_client);
+  auto client_settings = olp::client::OlpClientSettings();
+  olp::cache::CacheSettings cache_settings;
+  client_settings.authentication_settings = auth_settings;
+  client_settings.task_scheduler = std::move(task_scheduler);
+  client_settings.network_request_handler = std::move(http_client);
+  client_settings.cache =
+      olp::client::OlpClientSettingsFactory::CreateDefaultCache(cache_settings);
 
   // Create a CatalogClient with appropriate HRN and settings.
   auto service_client = std::make_unique<olp::dataservice::read::CatalogClient>(

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogClient.h
@@ -26,6 +26,7 @@
 #include <olp/core/cache/CacheSettings.h>
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>
+#include <olp/core/client/OlpClientSettings.h>
 #include <olp/core/geo/tiling/TileKey.h>
 #include "olp/dataservice/read/model/Catalog.h"
 #include "olp/dataservice/read/model/Data.h"
@@ -34,12 +35,7 @@
 
 namespace olp {
 
-namespace cache {
-class KeyValueCache;
-}
-
 namespace client {
-struct OlpClientSettings;
 class HRN;
 }  // namespace client
 
@@ -150,10 +146,7 @@ class CatalogClientImpl;
  */
 class DATASERVICE_READ_API CatalogClient final {
  public:
-  CatalogClient(
-      const client::HRN& hrn,
-      std::shared_ptr<client::OlpClientSettings> settings,
-      std::shared_ptr<cache::KeyValueCache> cache = CreateDefaultCache());
+  CatalogClient(client::HRN catalog, client::OlpClientSettings settings);
 
   ~CatalogClient() = default;
 

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClient.cpp
@@ -32,10 +32,14 @@ std::shared_ptr<cache::KeyValueCache> CreateDefaultCache(
   return std::move(cache);
 }
 
-CatalogClient::CatalogClient(
-    const client::HRN& hrn, std::shared_ptr<client::OlpClientSettings> settings,
-    std::shared_ptr<cache::KeyValueCache> cache)
-    : impl_(std::make_shared<CatalogClientImpl>(hrn, settings, cache)) {}
+CatalogClient::CatalogClient(client::HRN catalog,
+                             client::OlpClientSettings settings) {
+  auto cache = settings.cache;
+  auto settings_ptr =
+      std::make_shared<client::OlpClientSettings>(std::move(settings));
+  impl_ = std::make_shared<CatalogClientImpl>(
+      std::move(catalog), std::move(settings_ptr), std::move(cache));
+}
 
 bool CatalogClient::cancelPendingRequests() {
   return impl_->CancelPendingRequests();

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.h
@@ -50,7 +50,7 @@ class PendingRequests;
 
 class CatalogClientImpl final {
  public:
-  CatalogClientImpl(const client::HRN& hrn,
+  CatalogClientImpl(client::HRN catalog,
                     std::shared_ptr<client::OlpClientSettings> settings,
                     std::shared_ptr<cache::KeyValueCache> cache);
 
@@ -91,7 +91,7 @@ class CatalogClientImpl final {
       const PrefetchTilesRequest& request);
 
  private:
-  client::HRN hrn_;
+  client::HRN catalog_;
   std::shared_ptr<client::OlpClientSettings> settings_;
   std::shared_ptr<client::OlpClient> api_client_;
   std::shared_ptr<repository::CatalogRepository> catalog_repo_;

--- a/tests/functional/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
@@ -95,16 +95,18 @@ class CatalogClientTest : public ::testing::TestWithParam<CacheType> {
         auth_settings);
     olp::client::AuthenticationSettings auth_client_settings;
     auth_client_settings.provider = provider;
-    settings_ = std::make_shared<olp::client::OlpClientSettings>();
-    settings_->network_request_handler = network;
-    settings_->authentication_settings = auth_client_settings;
-    client_ = olp::client::OlpClientFactory::Create(*settings_);
+    settings_ = olp::client::OlpClientSettings();
+    settings_.network_request_handler = network;
+    settings_.authentication_settings = auth_client_settings;
+    olp::cache::CacheSettings cache_settings;
+    settings_.cache = olp::client::OlpClientSettingsFactory::CreateDefaultCache(
+        cache_settings);
+    client_ = olp::client::OlpClientFactory::Create(settings_);
   }
 
   void TearDown() override {
     client_.reset();
-    auto network = std::move(settings_->network_request_handler);
-    settings_.reset();
+    auto network = std::move(settings_.network_request_handler);
     // when test ends we must be sure that network pointer is not captured
     // anywhere
     assert(network.use_count() == 1);
@@ -135,7 +137,7 @@ class CatalogClientTest : public ::testing::TestWithParam<CacheType> {
   }
 
  protected:
-  std::shared_ptr<olp::client::OlpClientSettings> settings_;
+  olp::client::OlpClientSettings settings_;
   std::shared_ptr<olp::client::OlpClient> client_;
 };
 

--- a/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientCacheTest.cpp
@@ -60,6 +60,7 @@ class CatalogClientCacheTest : public CatalogClientTestBase {
     cache_ = std::make_shared<olp::cache::DefaultCache>(settings);
     ASSERT_EQ(olp::cache::DefaultCache::StorageOpenResult::Success,
               cache_->Open());
+    settings_.cache = cache_;
   }
 
   void TearDown() override {
@@ -86,7 +87,7 @@ TEST_P(CatalogClientCacheTest, GetApi) {
               Send(IsGetRequest(URL_LATEST_CATALOG_VERSION), _, _, _, _))
       .Times(2);
 
-  auto catalog_client = std::make_unique<CatalogClient>(hrn, settings_, cache_);
+  auto catalog_client = std::make_unique<CatalogClient>(hrn, settings_);
 
   auto request = CatalogVersionRequest().WithStartVersion(-1);
 
@@ -114,7 +115,7 @@ TEST_P(CatalogClientCacheTest, GetCatalog) {
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_CONFIG), _, _, _, _))
       .Times(1);
 
-  auto catalog_client = std::make_unique<CatalogClient>(hrn, settings_, cache_);
+  auto catalog_client = std::make_unique<CatalogClient>(hrn, settings_);
   auto request = CatalogRequest();
   auto future = catalog_client->GetCatalog(request);
   CatalogResponse catalog_response = future.GetFuture().get();
@@ -161,8 +162,8 @@ TEST_P(CatalogClientCacheTest, GetDataWithPartitionId) {
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
       .Times(1);
 
-  auto catalog_client = std::make_unique<olp::dataservice::read::CatalogClient>(
-      hrn, settings_, cache_);
+  auto catalog_client =
+      std::make_unique<olp::dataservice::read::CatalogClient>(hrn, settings_);
 
   auto request = olp::dataservice::read::DataRequest();
   request.WithLayerId("testlayer").WithPartitionId("269");
@@ -218,8 +219,8 @@ TEST_P(CatalogClientCacheTest, GetPartitionsLayerVersions) {
           olp::http::NetworkResponse().WithStatus(200),
           http_response_testlayer_res));
 
-  auto catalog_client = std::make_unique<olp::dataservice::read::CatalogClient>(
-      hrn, settings_, cache_);
+  auto catalog_client =
+      std::make_unique<olp::dataservice::read::CatalogClient>(hrn, settings_);
 
   auto request = olp::dataservice::read::PartitionsRequest();
   request.WithLayerId("testlayer");
@@ -258,8 +259,8 @@ TEST_P(CatalogClientCacheTest, GetPartitions) {
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
       .Times(1);
 
-  auto catalog_client = std::make_unique<olp::dataservice::read::CatalogClient>(
-      hrn, settings_, cache_);
+  auto catalog_client =
+      std::make_unique<olp::dataservice::read::CatalogClient>(hrn, settings_);
 
   auto request = olp::dataservice::read::PartitionsRequest();
   request.WithLayerId("testlayer");
@@ -398,8 +399,8 @@ TEST_P(CatalogClientCacheTest, GetVolatilePartitionsExpiry) {
             HTTP_RESPONSE_EMPTY_PARTITIONS));
   }
 
-  auto catalog_client = std::make_unique<olp::dataservice::read::CatalogClient>(
-      hrn, settings_, cache_);
+  auto catalog_client =
+      std::make_unique<olp::dataservice::read::CatalogClient>(hrn, settings_);
 
   auto request = olp::dataservice::read::PartitionsRequest();
   request.WithLayerId("testlayer_volatile");

--- a/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
@@ -340,7 +340,7 @@ TEST_P(CatalogClientTest, GetData429Error) {
       [](const olp::client::HttpResponse& response) {
         return 429 == response.status;
       };
-  settings_->retry_settings = retry_settings;
+  settings_.retry_settings = retry_settings;
   auto catalog_client =
       std::make_unique<olp::dataservice::read::CatalogClient>(hrn, settings_);
 
@@ -381,7 +381,7 @@ TEST_P(CatalogClientTest, GetPartitions429Error) {
       [](const olp::client::HttpResponse& response) {
         return 429 == response.status;
       };
-  settings_->retry_settings = retry_settings;
+  settings_.retry_settings = retry_settings;
   auto catalog_client =
       std::make_unique<olp::dataservice::read::CatalogClient>(hrn, settings_);
 
@@ -418,7 +418,7 @@ TEST_P(CatalogClientTest, ApiLookup429) {
       [](const olp::client::HttpResponse& response) {
         return 429 == response.status;
       };
-  settings_->retry_settings = retry_settings;
+  settings_.retry_settings = retry_settings;
   auto catalog_client =
       std::make_unique<olp::dataservice::read::CatalogClient>(hrn, settings_);
 
@@ -1034,9 +1034,9 @@ TEST_P(CatalogClientTest, GetDataWithPartitionIdCancelInnerConfig) {
 
   olp::cache::CacheSettings cache_settings;
   cache_settings.max_memory_cache_size = 0;
-  auto catalog_client = std::make_unique<olp::dataservice::read::CatalogClient>(
-      hrn, settings_,
-      olp::dataservice::read::CreateDefaultCache(cache_settings));
+  settings_.cache = olp::dataservice::read::CreateDefaultCache(cache_settings);
+  auto catalog_client =
+      std::make_unique<olp::dataservice::read::CatalogClient>(hrn, settings_);
 
   auto request = olp::dataservice::read::DataRequest();
   request.WithLayerId("testlayer").WithPartitionId("269");

--- a/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTestBase.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTestBase.cpp
@@ -20,6 +20,9 @@
 #include "CatalogClientTestBase.h"
 
 #include <matchers/NetworkUrlMatchers.h>
+#include <olp/core/cache/CacheSettings.h>
+#include <olp/core/cache/KeyValueCache.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
 #include "HttpResponses.h"
 
 using ::testing::_;
@@ -56,16 +59,18 @@ std::string CatalogClientTestBase::ApiErrorToString(
 
 void CatalogClientTestBase::SetUp() {
   network_mock_ = std::make_shared<NetworkMock>();
-  settings_ = std::make_shared<olp::client::OlpClientSettings>();
-  settings_->network_request_handler = network_mock_;
-  client_ = olp::client::OlpClientFactory::Create(*settings_);
+  settings_ = olp::client::OlpClientSettings();
+  settings_.network_request_handler = network_mock_;
+  olp::cache::CacheSettings cache_settings;
+  settings_.cache =
+      olp::client::OlpClientSettingsFactory::CreateDefaultCache(cache_settings);
+  client_ = olp::client::OlpClientFactory::Create(settings_);
 
   SetUpCommonNetworkMockCalls();
 }
 
 void CatalogClientTestBase::TearDown() {
   client_.reset();
-  settings_.reset();
   ::testing::Mock::VerifyAndClearExpectations(network_mock_.get());
   network_mock_.reset();
 }

--- a/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTestBase.h
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTestBase.h
@@ -43,7 +43,7 @@ class CatalogClientTestBase : public ::testing::TestWithParam<CacheType> {
   void SetUpCommonNetworkMockCalls();
 
  protected:
-  std::shared_ptr<olp::client::OlpClientSettings> settings_;
+  olp::client::OlpClientSettings settings_;
   std::shared_ptr<olp::client::OlpClient> client_;
   std::shared_ptr<NetworkMock> network_mock_;
 };


### PR DESCRIPTION
Pass HRN and settings to CatalogClient by value. Cache is passed as
OlpClientSettings. This aligns interface with read dataservice API.

Relates-to: OLPEDGE-798
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>