### PR TITLE
Put all test-related code into namespace

### DIFF
--- a/olp-cpp-sdk-dataservice-read/tests/ApiClientLookupTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/ApiClientLookupTest.cpp
@@ -26,6 +26,7 @@
 using namespace olp;
 using namespace client;
 using namespace dataservice::read;
+using namespace olp::tests::common;
 
 #define OLP_SDK_CONFIG_BASE_URL \
   "https://config.data.api.platform.in.here.com/config/v1"
@@ -222,4 +223,5 @@ TEST(ApiClientLookupTest, LookupApi) {
     EXPECT_EQ(response.GetError().GetErrorCode(),
               olp::client::ErrorCode::Cancelled);
     Mock::VerifyAndClearExpectations(network.get());
-  }}
+  }
+}

--- a/olp-cpp-sdk-dataservice-read/tests/CatalogRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/CatalogRepositoryTest.cpp
@@ -20,9 +20,9 @@
 #include "repositories/CatalogRepository.h"
 
 #include <gtest/gtest.h>
+#include <matchers/NetworkUrlMatchers.h>
 #include <mocks/CacheMock.h>
 #include <mocks/NetworkMock.h>
-#include <matchers/NetworkUrlMatchers.h>
 #include <olp/core/client/OlpClientFactory.h>
 #include "ApiClientLookup.h"
 
@@ -41,6 +41,7 @@ namespace {
 
 using namespace olp::dataservice::read;
 using namespace ::testing;
+using namespace olp::tests::common;
 
 const std::string kCatalog = "hrn:here:data:::hereos-internal-test-v2";
 const std::string kCacheKey = kCatalog + "::latestVersion";

--- a/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
@@ -43,6 +43,7 @@
 namespace {
 
 using testing::_;
+using namespace olp::tests::common;
 
 class DataRepositoryTest : public ::testing::Test {
  protected:

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -35,6 +35,7 @@ namespace {
 using namespace olp;
 using namespace client;
 using namespace dataservice::read;
+using namespace olp::tests::common;
 
 const std::string kCatalog = "hrn:here:data:::hereos-internal-test-v2";
 const std::string kLayerId = "test_layer";

--- a/tests/common/matchers/NetworkUrlMatchers.h
+++ b/tests/common/matchers/NetworkUrlMatchers.h
@@ -23,6 +23,10 @@
 
 #include <olp/core/http/NetworkRequest.h>
 
+namespace olp {
+namespace tests {
+namespace common {
+
 MATCHER_P(IsGetRequest, url, "") {
   // uri, verb, null body
   return olp::http::NetworkRequest::HttpVerb::GET == arg.GetVerb() &&
@@ -67,3 +71,7 @@ MATCHER_P(IsDeleteRequestPrefix, url, "") {
 
   return (res.first == url_string.end());
 }
+
+}  // namespace common
+}  // namespace tests
+}  // namespace olp

--- a/tests/common/mocks/CacheMock.cpp
+++ b/tests/common/mocks/CacheMock.cpp
@@ -19,6 +19,14 @@
 
 #include "CacheMock.h"
 
+namespace olp {
+namespace tests {
+namespace common {
+
 CacheMock::CacheMock() = default;
 
 CacheMock::~CacheMock() = default;
+
+}  // namespace common
+}  // namespace tests
+}  // namespace olp

--- a/tests/common/mocks/CacheMock.h
+++ b/tests/common/mocks/CacheMock.h
@@ -22,6 +22,10 @@
 #include <gmock/gmock.h>
 #include <olp/core/cache/KeyValueCache.h>
 
+namespace olp {
+namespace tests {
+namespace common {
+
 class CacheMock : public olp::cache::KeyValueCache {
  public:
   CacheMock();
@@ -49,3 +53,7 @@ class CacheMock : public olp::cache::KeyValueCache {
 
   MOCK_METHOD(bool, RemoveKeysWithPrefix, (const std::string&), (override));
 };
+
+}  // namespace common
+}  // namespace tests
+}  // namespace olp

--- a/tests/common/mocks/NetworkMock.cpp
+++ b/tests/common/mocks/NetworkMock.cpp
@@ -21,6 +21,10 @@
 
 #include <thread>
 
+namespace olp {
+namespace tests {
+namespace common {
+
 NetworkMock::NetworkMock() = default;
 
 NetworkMock::~NetworkMock() = default;
@@ -111,3 +115,7 @@ GenerateNetworkMockActions(std::shared_ptr<std::promise<void>> pre_signal,
   return std::make_tuple(request_id, std::move(mocked_send),
                          std::move(mocked_cancel));
 }
+
+}  // namespace common
+}  // namespace tests
+}  // namespace olp

--- a/tests/common/mocks/NetworkMock.h
+++ b/tests/common/mocks/NetworkMock.h
@@ -24,6 +24,10 @@
 #include <gmock/gmock.h>
 #include <olp/core/http/Network.h>
 
+namespace olp {
+namespace tests {
+namespace common {
+
 using NetworkCallback = std::function<olp::http::SendOutcome(
     olp::http::NetworkRequest, olp::http::Network::Payload,
     olp::http::Network::Callback, olp::http::Network::HeaderCallback,
@@ -83,3 +87,7 @@ GenerateNetworkMockActions(std::shared_ptr<std::promise<void>> pre_signal,
                            MockedResponseInformation response_information,
                            std::shared_ptr<std::promise<void>> post_signal =
                                std::make_shared<std::promise<void>>());
+
+}  // namespace common
+}  // namespace tests
+}  // namespace olp

--- a/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -21,14 +21,15 @@
 #include <memory>
 
 #include <gmock/gmock.h>
-#include <olp/core/porting/make_unique.h>
-#include <olp/core/http/HttpStatusCode.h>
-#include "olp/core/client/OlpClientSettingsFactory.h"
-#include <olp/authentication/AuthenticationClient.h>
 #include <mocks/NetworkMock.h>
+#include <olp/authentication/AuthenticationClient.h>
+#include <olp/core/http/HttpStatusCode.h>
+#include <olp/core/porting/make_unique.h>
 #include "AuthenticationMockedResponses.h"
+#include "olp/core/client/OlpClientSettingsFactory.h"
 
 using namespace olp::authentication;
+using namespace olp::tests::common;
 using testing::_;
 
 namespace {

--- a/tests/integration/olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
@@ -19,16 +19,17 @@
 
 #include <gmock/gmock.h>
 
-#include <olp/core/porting/make_unique.h>
-#include <olp/core/http/HttpStatusCode.h>
-#include <olp/core/client/OlpClientSettingsFactory.h>
+#include <mocks/NetworkMock.h>
 #include <olp/authentication/AuthenticationClient.h>
 #include <olp/authentication/AutoRefreshingToken.h>
-#include <mocks/NetworkMock.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/http/HttpStatusCode.h>
+#include <olp/core/porting/make_unique.h>
 
 #include "AuthenticationMockedResponses.h"
 
 using namespace olp::authentication;
+using namespace olp::tests::common;
 using testing::_;
 
 namespace {

--- a/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientCacheTest.cpp
@@ -20,6 +20,8 @@ namespace {
 
 using namespace olp::dataservice::read;
 using namespace testing;
+using namespace olp::tests::common;
+using namespace olp::tests::integration;
 
 #ifdef _WIN32
 constexpr auto kClientTestDir = "\\catalog_client_test";

--- a/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
@@ -38,6 +38,8 @@ namespace {
 
 using namespace olp::dataservice::read;
 using namespace testing;
+using namespace olp::tests::common;
+using namespace olp::tests::integration;
 
 void DumpTileKey(const olp::geo::TileKey& tile_key) {
   std::cout << "Tile: " << tile_key.ToHereTile()

--- a/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTestBase.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTestBase.cpp
@@ -22,6 +22,12 @@
 #include <matchers/NetworkUrlMatchers.h>
 #include "HttpResponses.h"
 
+namespace olp {
+namespace tests {
+namespace integration {
+
+using namespace olp::tests::common;
+
 using ::testing::_;
 
 std::ostream& operator<<(std::ostream& os, const CacheType cache_type) {
@@ -248,3 +254,7 @@ void CatalogClientTestBase::SetUpCommonNetworkMockCalls() {
   // Catch any non-interesting network calls that don't need to be verified
   EXPECT_CALL(*network_mock_, Send(_, _, _, _, _)).Times(testing::AtLeast(0));
 }
+
+}  // namespace integration
+}  // namespace tests
+}  // namespace olp

--- a/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTestBase.h
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTestBase.h
@@ -25,6 +25,10 @@
 #include <olp/core/client/OlpClient.h>
 #include <olp/core/client/OlpClientFactory.h>
 
+namespace olp {
+namespace tests {
+namespace integration {
+
 enum class CacheType { IN_MEMORY, DISK, BOTH };
 
 std::ostream& operator<<(std::ostream& os, const CacheType cache_type);
@@ -45,5 +49,9 @@ class CatalogClientTestBase : public ::testing::TestWithParam<CacheType> {
  protected:
   std::shared_ptr<olp::client::OlpClientSettings> settings_;
   std::shared_ptr<olp::client::OlpClient> client_;
-  std::shared_ptr<NetworkMock> network_mock_;
+  std::shared_ptr<olp::tests::common::NetworkMock> network_mock_;
 };
+
+}  // namespace integration
+}  // namespace tests
+}  // namespace olp

--- a/tests/integration/olp-cpp-sdk-dataservice-write/IndexLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/IndexLayerClientTest.cpp
@@ -34,6 +34,7 @@ namespace {
 using ::testing::_;
 using namespace olp::dataservice::write;
 using namespace olp::dataservice::write::model;
+using namespace olp::tests::common;
 
 void PublishDataSuccessAssertions(
     const olp::client::ApiResponse<

--- a/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
@@ -36,6 +36,7 @@ namespace {
 using namespace olp::dataservice::write;
 using namespace olp::dataservice::write::model;
 using namespace testing;
+using namespace olp::tests::common;
 
 // Binary SDII Message List protobuf data. See the OLP SDII data specification
 // and schema documents to learn about the format. This char array was created

--- a/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientTest.cpp
@@ -39,6 +39,7 @@ namespace {
 using namespace olp::dataservice::write;
 using namespace olp::dataservice::write::model;
 using namespace testing;
+using namespace olp::tests::common;
 
 const std::string kBillingTag = "OlpCppSdkTest";
 constexpr int64_t kTwentyMib = 20971520;  // 20 MiB

--- a/tests/integration/olp-cpp-sdk-dataservice-write/VolatileLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/VolatileLayerClientTest.cpp
@@ -32,6 +32,7 @@ namespace {
 
 using namespace olp::dataservice::write;
 using namespace olp::dataservice::write::model;
+using namespace olp::tests::common;
 
 using testing::_;
 


### PR DESCRIPTION
All mocks and matchers are now under olp::tests::common.

Relates-to: OLPEDGE-768
Signed-off-by: Serhii Lysenko <ext-serhii.lysenko@here.com>