### PR TITLE
Implemented VolatileLayerClient::GetData() method

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -19,20 +19,70 @@
 
 #include "VolatileLayerClientImpl.h"
 
+#include <olp/core/client/CancellationContext.h>
+#include <olp/dataservice/read/PartitionsRequest.h>
+#include "repositories/DataRepository.h"
+#include "repositories/ExecuteOrSchedule.inl"
+#include "repositories/PartitionsRepository.h"
+
 namespace olp {
 namespace dataservice {
 namespace read {
 
+namespace {
+constexpr auto kLogTag = "VolatileLayerClientImpl";
+}
+
 VolatileLayerClientImpl::VolatileLayerClientImpl(
     olp::client::HRN catalog, std::string layer_id,
-    olp::client::OlpClientSettings client_settings) {}
+    olp::client::OlpClientSettings client_settings)
+    : catalog_(std::move(catalog)),
+      layer_id_(std::move(layer_id)),
+      client_settings_(std::move(client_settings)) {}
 
 VolatileLayerClientImpl::~VolatileLayerClientImpl() = default;
 
 olp::client::CancellationToken VolatileLayerClientImpl::GetData(
     DataRequest data_request, Callback callback) {
-  return olp::client::CancellationToken{[]() {}};
-}
+  olp::client::CancellationContext context;
+  auto cancellation_token = olp::client::CancellationToken(
+      [context]() mutable { context.CancelOperation(); });
+
+  auto catalog = catalog_;
+  auto client_settings = client_settings_;
+  auto layer_id = layer_id_;
+
+  repository::ExecuteOrSchedule(&client_settings_, [=]() mutable {
+    if (!data_request.GetDataHandle()) {
+      auto response = repository::PartitionsRepository::GetPartitionById(
+          catalog, layer_id, context, data_request, client_settings);
+
+      if (!response.IsSuccessful()) {
+        callback(response.GetError());
+        return;
+      }
+
+      const auto& partitions = response.GetResult().GetPartitions();
+      if (partitions.empty()) {
+        OLP_SDK_LOG_INFO_F(kLogTag, "Partition %s not found",
+                           data_request.GetPartitionId());
+        callback(client::ApiError(client::ErrorCode::NotFound,
+                                  "Partition not found"));
+        return;
+      }
+
+      data_request.WithDataHandle(partitions.front().GetDataHandle());
+    }
+
+    auto blob_response = repository::DataRepository::GetBlobData(
+        catalog_, layer_id_, "volatile-blob", data_request, context,
+        client_settings_);
+
+    callback(blob_response);
+  });
+
+  return cancellation_token;
+}  // namespace read
 
 }  // namespace read
 }  // namespace dataservice

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
@@ -49,6 +49,11 @@ class VolatileLayerClientImpl {
 
   olp::client::CancellationToken GetData(DataRequest data_request,
                                          Callback callback);
+
+private:
+    olp::client::HRN catalog_;
+    std::string layer_id_;
+    olp::client::OlpClientSettings client_settings_;
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
@@ -23,8 +23,8 @@
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/HRN.h>
 #include "MultiRequestContext.h"
-#include "olp/dataservice/read/CatalogClient.h"
 #include "generated/api/BlobApi.h"
+#include "olp/dataservice/read/CatalogClient.h"
 
 namespace olp {
 namespace dataservice {
@@ -54,7 +54,7 @@ class DataRepository final {
 
   static BlobApi::DataResponse GetBlobData(
       const client::HRN& catalog, const std::string& layer,
-      const DataRequest& data_request,
+      const std::string& service, const DataRequest& data_request,
       client::CancellationContext cancellation_context,
       client::OlpClientSettings settings);
 

--- a/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
@@ -93,7 +93,7 @@ TEST_F(DataRepositoryTest, GetBlobData) {
 
   auto response =
       olp::dataservice::read::repository::DataRepository::GetBlobData(
-          hrn, "testlayer", request, context, *settings_);
+          hrn, "testlayer", "blob", request, context, *settings_);
 
   ASSERT_TRUE(response.IsSuccessful());
 }
@@ -114,7 +114,7 @@ TEST_F(DataRepositoryTest, GetBlobDataApiLookupFailed403) {
 
   auto response =
       olp::dataservice::read::repository::DataRepository::GetBlobData(
-          hrn, "testlayer", request, context, *settings_);
+          hrn, "testlayer", "blob", request, context, *settings_);
 
   ASSERT_FALSE(response.IsSuccessful());
 }
@@ -125,7 +125,7 @@ TEST_F(DataRepositoryTest, GetBlobDataNoDataHandle) {
   olp::client::HRN hrn(GetTestCatalog());
   auto response =
       olp::dataservice::read::repository::DataRepository::GetBlobData(
-          hrn, "testlayer", request, context, *settings_);
+          hrn, "testlayer", "blob", request, context, *settings_);
   ASSERT_FALSE(response.IsSuccessful());
 }
 
@@ -151,7 +151,7 @@ TEST_F(DataRepositoryTest, GetBlobDataFailedDataFetch403) {
 
   auto response =
       olp::dataservice::read::repository::DataRepository::GetBlobData(
-          hrn, "testlayer", request, context, *settings_);
+          hrn, "testlayer", "blob", request, context, *settings_);
 
   ASSERT_FALSE(response.IsSuccessful());
 }
@@ -179,14 +179,14 @@ TEST_F(DataRepositoryTest, GetBlobDataCache) {
   // This should download data from network and cache it
   auto response =
       olp::dataservice::read::repository::DataRepository::GetBlobData(
-          hrn, "testlayer", request, context, *settings_);
+          hrn, "testlayer", "blob", request, context, *settings_);
 
   ASSERT_TRUE(response.IsSuccessful());
 
   // This call should not do any network calls and use already cached values
   // instead
   response = olp::dataservice::read::repository::DataRepository::GetBlobData(
-      hrn, "testlayer", request, context, *settings_);
+      hrn, "testlayer", "blob", request, context, *settings_);
 
   ASSERT_TRUE(response.IsSuccessful());
 }
@@ -216,7 +216,7 @@ TEST_F(DataRepositoryTest, GetBlobDataImmediateCancel) {
 
   auto response =
       olp::dataservice::read::repository::DataRepository::GetBlobData(
-          hrn, "testlayer", request, context, *settings_);
+          hrn, "testlayer", "blob", request, context, *settings_);
   ASSERT_EQ(response.GetError().GetErrorCode(),
             olp::client::ErrorCode::Cancelled);
 }
@@ -248,7 +248,7 @@ TEST_F(DataRepositoryTest, GetBlobDataInProgressCancel) {
 
   auto response =
       olp::dataservice::read::repository::DataRepository::GetBlobData(
-          hrn, "testlayer", request, context, *settings_);
+          hrn, "testlayer", "blob", request, context, *settings_);
   ASSERT_EQ(response.GetError().GetErrorCode(),
             olp::client::ErrorCode::Cancelled);
 }

--- a/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
@@ -18,24 +18,177 @@
  */
 
 #include <gtest/gtest.h>
+
+#include <matchers/NetworkUrlMatchers.h>
+#include <mocks/NetworkMock.h>
+#include <olp/dataservice/read/CatalogClient.h>
 #include "VolatileLayerClientImpl.h"
+
+#define URL_LOOKUP_VOLATILE_BLOB \
+  R"(https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data:::hereos-internal-test-v2/apis/volatile-blob/v1)"
+
+#define URL_VOLATILE_BLOB_DATA \
+  R"(https://volatile-blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2/layers/testlayer/data/4eed6ed1-0d32-43b9-ae79-043cb4256432)"
+
+#define URL_LOOKUP_QUERY \
+  R"(https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data:::hereos-internal-test-v2/apis/query/v1)"
+
+#define URL_QUERY_PARTITION_269 \
+  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/testlayer/partitions?partition=269)"
+
+#define HTTP_RESPONSE_LOOKUP_VOLATILE_BLOB \
+  R"jsonString([{"api":"volatile-blob","version":"v1","baseURL":"https://volatile-blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2","parameters":{}}])jsonString"
+
+#define HTTP_RESPONSE_LOOKUP_QUERY \
+  R"jsonString([{"api":"query","version":"v1","baseURL":"https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2","parameters":{}}])jsonString"
+
+#define HTTP_RESPONSE_PARTITION_269 \
+  R"jsonString({ "partitions": [{"version":4,"partition":"269","layer":"testlayer","dataHandle":"4eed6ed1-0d32-43b9-ae79-043cb4256432"}]})jsonString"
+
+#define HTTP_RESPONSE_NO_PARTITION \
+  R"jsonString({ "partitions": []})jsonString"
+
+#define BLOB_DATA_HANDLE R"(4eed6ed1-0d32-43b9-ae79-043cb4256432)"
 
 namespace {
 using namespace olp::dataservice::read;
 using namespace ::testing;
 const std::string kCatalog = "hrn:here:data:::hereos-internal-test-v2";
-const std::string kLayerId = "olp-sdk-test";
+const std::string kLayerId = "testlayer";
 const auto kHRN = olp::client::HRN::FromString(kCatalog);
 
-TEST(VolatileLayerClientImplTest, GetData) {
-  olp::client::OlpClientSettings settings;
+class VolatileLayerClientImplTest : public ::testing::Test {
+ protected:
+  void SetUp() override;
+  void TearDown() override;
 
-  VolatileLayerClientImpl client(kHRN, kLayerId, settings);
+  std::unique_ptr<olp::client::OlpClientSettings> settings_;
+  std::shared_ptr<NetworkMock> network_mock_;
+};
+
+void VolatileLayerClientImplTest::SetUp() {
+  network_mock_ = std::make_shared<NetworkMock>();
+  settings_.reset(new olp::client::OlpClientSettings());
+  settings_->cache = olp::dataservice::read::CreateDefaultCache();
+  settings_->network_request_handler = network_mock_;
+}
+
+void VolatileLayerClientImplTest::TearDown() {
+  settings_.reset();
+  network_mock_.reset();
+}
+
+TEST_F(VolatileLayerClientImplTest, GetDataWithDataHandle) {
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(URL_LOOKUP_VOLATILE_BLOB), _, _, _, _))
+      .WillOnce(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::OK),
+          HTTP_RESPONSE_LOOKUP_VOLATILE_BLOB));
+
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(URL_VOLATILE_BLOB_DATA), _, _, _, _))
+      .WillOnce(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::OK),
+          "SomeData"));
+
+  VolatileLayerClientImpl client(kHRN, kLayerId, *settings_);
 
   DataRequest request;
+  request.WithDataHandle(BLOB_DATA_HANDLE);
 
-  VolatileLayerClientImpl::Callback cb;
-  auto token = client.GetData(request, cb);
-  token.cancel();
+  using DataResponse =
+      olp::client::ApiResponse<VolatileLayerClientImpl::DataResult,
+                               olp::client::ApiError>;
+  std::promise<DataResponse> promise;
+  std::future<DataResponse> future(promise.get_future());
+
+  auto token = client.GetData(
+      request, [&](DataResponse response) { promise.set_value(response); });
+
+  const auto& response = future.get();
+  ASSERT_TRUE(response.IsSuccessful());
 }
+
+TEST_F(VolatileLayerClientImplTest, GetDataWithPartitionId) {
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_QUERY), _, _, _, _))
+      .WillOnce(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::OK),
+          HTTP_RESPONSE_LOOKUP_QUERY));
+
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(URL_QUERY_PARTITION_269), _, _, _, _))
+      .WillOnce(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::OK),
+          HTTP_RESPONSE_PARTITION_269));
+
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(URL_LOOKUP_VOLATILE_BLOB), _, _, _, _))
+      .WillOnce(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::OK),
+          HTTP_RESPONSE_LOOKUP_VOLATILE_BLOB));
+
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(URL_VOLATILE_BLOB_DATA), _, _, _, _))
+      .WillOnce(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::OK),
+          "SomeData"));
+
+  VolatileLayerClientImpl client(kHRN, kLayerId, *settings_);
+
+  DataRequest request;
+  request.WithPartitionId("269");
+
+  using DataResponse =
+      olp::client::ApiResponse<VolatileLayerClientImpl::DataResult,
+                               olp::client::ApiError>;
+  std::promise<DataResponse> promise;
+  std::future<DataResponse> future = promise.get_future();
+
+  auto token = client.GetData(
+      request, [&](DataResponse response) { promise.set_value(response); });
+
+  const auto& response = future.get();
+  ASSERT_TRUE(response.IsSuccessful());
+}
+
+TEST_F(VolatileLayerClientImplTest, GetDataNoPartition) {
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_QUERY), _, _, _, _))
+      .WillOnce(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::OK),
+          HTTP_RESPONSE_LOOKUP_QUERY));
+
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(URL_QUERY_PARTITION_269), _, _, _, _))
+      .WillOnce(NetworkMock::ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::OK),
+          HTTP_RESPONSE_NO_PARTITION));
+
+  VolatileLayerClientImpl client(kHRN, kLayerId, *settings_);
+
+  DataRequest request;
+  request.WithPartitionId("269");
+
+  using DataResponse =
+      olp::client::ApiResponse<VolatileLayerClientImpl::DataResult,
+                               olp::client::ApiError>;
+  std::promise<DataResponse> promise;
+  std::future<DataResponse> future = promise.get_future();
+
+  auto token = client.GetData(
+      request, [&](DataResponse response) { promise.set_value(response); });
+
+  const auto& response = future.get();
+  ASSERT_FALSE(response.IsSuccessful());
+}
+
 }  // namespace
+
+


### PR DESCRIPTION
Added service parameter to DataRepository::GetBlobData() to switch between blob and volatile-blob REST API
Added Tests for VolatileLayerClientImpl class

Resolves: OLPEDGE-760

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>