### PR TITLE
Pass arguments to IndexLayerClient by value

### DIFF
--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/IndexLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/IndexLayerClient.h
@@ -63,8 +63,7 @@ class DATASERVICE_WRITE_API IndexLayerClient {
    * @param settings Client settings used to control behaviour of the client
    * instance. Index.
    */
-  IndexLayerClient(const client::HRN& catalog,
-                   const client::OlpClientSettings& settings);
+  IndexLayerClient(client::HRN catalog, client::OlpClientSettings settings);
 
   /**
    * @brief Cancel all pending requests.
@@ -81,7 +80,7 @@ class DATASERVICE_WRITE_API IndexLayerClient {
    * @return A CancellableFuture containing the PublishIndexResponse.
    */
   olp::client::CancellableFuture<PublishIndexResponse> PublishIndex(
-      const model::PublishIndexRequest& request);
+      model::PublishIndexRequest request);
 
   /**
    * @brief Call to publish index into an OLP Index Layer.
@@ -96,8 +95,7 @@ class DATASERVICE_WRITE_API IndexLayerClient {
    * request.
    */
   olp::client::CancellationToken PublishIndex(
-      const model::PublishIndexRequest& request,
-      const PublishIndexCallback& callback);
+      model::PublishIndexRequest request, PublishIndexCallback callback);
 
   /**
    * @brief Call to delete data blob that is stored under index
@@ -110,8 +108,7 @@ class DATASERVICE_WRITE_API IndexLayerClient {
    * request.
    */
   olp::client::CancellationToken DeleteIndexData(
-      const model::DeleteIndexDataRequest& request,
-      const DeleteIndexDataCallback& callback);
+      model::DeleteIndexDataRequest request, DeleteIndexDataCallback callback);
 
   /**
    * @brief Call to delete data blob that is stored under index
@@ -121,7 +118,7 @@ class DATASERVICE_WRITE_API IndexLayerClient {
    * @return A CancellableFuture containing the DeleteIndexDataResponse.
    */
   olp::client::CancellableFuture<DeleteIndexDataResponse> DeleteIndexData(
-      const model::DeleteIndexDataRequest& request);
+      model::DeleteIndexDataRequest request);
 
   /**
    * @brief Call to update index information to an OLP Index Layer.
@@ -131,7 +128,7 @@ class DATASERVICE_WRITE_API IndexLayerClient {
    * @return A CancellableFuture containing the PublishIndexResponse.
    */
   olp::client::CancellableFuture<UpdateIndexResponse> UpdateIndex(
-      const model::UpdateIndexRequest& request);
+      model::UpdateIndexRequest request);
 
   /**
    * @brief Call to update index information to an OLP Index Layer
@@ -143,9 +140,8 @@ class DATASERVICE_WRITE_API IndexLayerClient {
    * @return A CancellationToken which can be used to cancel the ongoing
    * request.
    */
-  olp::client::CancellationToken UpdateIndex(
-      const model::UpdateIndexRequest& request,
-      const UpdateIndexCallback& callback);
+  olp::client::CancellationToken UpdateIndex(model::UpdateIndexRequest request,
+                                             UpdateIndexCallback callback);
 
  private:
   std::shared_ptr<IndexLayerClientImpl> impl_;

--- a/olp-cpp-sdk-dataservice-write/src/IndexLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/IndexLayerClient.cpp
@@ -24,43 +24,39 @@
 namespace olp {
 namespace dataservice {
 namespace write {
-IndexLayerClient::IndexLayerClient(const client::HRN& catalog,
-                                   const client::OlpClientSettings& settings)
+IndexLayerClient::IndexLayerClient(client::HRN catalog,
+                                   client::OlpClientSettings settings)
     : impl_(std::make_shared<IndexLayerClientImpl>(catalog, settings)) {}
 
 void IndexLayerClient::CancelAll() { impl_->CancelAll(); }
 
 olp::client::CancellableFuture<PublishIndexResponse>
-IndexLayerClient::PublishIndex(const model::PublishIndexRequest& request) {
+IndexLayerClient::PublishIndex(model::PublishIndexRequest request) {
   return impl_->PublishIndex(request);
 }
 
 olp::client::CancellationToken IndexLayerClient::PublishIndex(
-    const model::PublishIndexRequest& request,
-    const PublishIndexCallback& callback) {
+    model::PublishIndexRequest request, PublishIndexCallback callback) {
   return impl_->PublishIndex(request, callback);
 }
 
 olp::client::CancellationToken IndexLayerClient::DeleteIndexData(
-    const model::DeleteIndexDataRequest& request,
-    const DeleteIndexDataCallback& callback) {
+    model::DeleteIndexDataRequest request, DeleteIndexDataCallback callback) {
   return impl_->DeleteIndexData(request, callback);
 }
 
 olp::client::CancellableFuture<DeleteIndexDataResponse>
-IndexLayerClient::DeleteIndexData(
-    const model::DeleteIndexDataRequest& request) {
+IndexLayerClient::DeleteIndexData(model::DeleteIndexDataRequest request) {
   return impl_->DeleteIndexData(request);
 }
 
 olp::client::CancellableFuture<UpdateIndexResponse>
-IndexLayerClient::UpdateIndex(const model::UpdateIndexRequest& request) {
+IndexLayerClient::UpdateIndex(model::UpdateIndexRequest request) {
   return impl_->UpdateIndex(request);
 }
 
 olp::client::CancellationToken IndexLayerClient::UpdateIndex(
-    const model::UpdateIndexRequest& request,
-    const UpdateIndexCallback& callback) {
+    model::UpdateIndexRequest request, UpdateIndexCallback callback) {
   return impl_->UpdateIndex(request, callback);
 }
 }  // namespace write

--- a/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.cpp
@@ -47,11 +47,11 @@ namespace olp {
 namespace dataservice {
 namespace write {
 
-IndexLayerClientImpl::IndexLayerClientImpl(const HRN& catalog,
-                                           const OlpClientSettings& settings)
-    : catalog_(catalog),
+IndexLayerClientImpl::IndexLayerClientImpl(HRN catalog,
+                                           OlpClientSettings settings)
+    : catalog_(std::move(catalog)),
       catalog_model_(),
-      settings_(settings),
+      settings_(std::move(settings)),
       apiclient_config_(nullptr),
       apiclient_blob_(nullptr),
       apiclient_index_(nullptr),

--- a/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.h
@@ -48,8 +48,7 @@ using InitCatalogModelCallback =
 class IndexLayerClientImpl
     : public std::enable_shared_from_this<IndexLayerClientImpl> {
  public:
-  IndexLayerClientImpl(const client::HRN& catalog,
-                       const client::OlpClientSettings& settings);
+  IndexLayerClientImpl(client::HRN catalog, client::OlpClientSettings settings);
 
   void CancelAll();
 


### PR DESCRIPTION
Pass HRN, settings and callbacks to IndexLayerClient by value, cache is
passed in OlpClientSettings. This aligns interface with read dataservice
API.

Relates-to: OLPEDGE-798
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>