### PR TITLE
Added service parameter to DataRepository::GetBlobData()

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
@@ -328,9 +328,9 @@ void DataRepository::GetData(
                   *cache_);
 }
 
-BlobApi::DataResponse DataRepository::GetBlobData(
+DataRepository::DataResponse DataRepository::GetBlobData(
     const client::HRN& catalog, const std::string& layer,
-    const DataRequest& data_request,
+    const std::string& service, const DataRequest& data_request,
     client::CancellationContext cancellation_context,
     client::OlpClientSettings settings) {
   using namespace client;
@@ -347,17 +347,19 @@ BlobApi::DataResponse DataRepository::GetBlobData(
   if (fetch_option != OnlineOnly) {
     auto cached_data = repository.Get(layer, data_handle.value());
     if (cached_data) {
-      OLP_SDK_LOG_INFO_F(kLogTag, "cache data '%s' found!", data_request.CreateKey().c_str());
+      OLP_SDK_LOG_INFO_F(kLogTag, "cache data '%s' found!",
+                         data_request.CreateKey().c_str());
       return cached_data.value();
     } else if (fetch_option == CacheOnly) {
-      OLP_SDK_LOG_INFO_F(kLogTag, "cache data '%s' not found!", data_request.CreateKey().c_str());
+      OLP_SDK_LOG_INFO_F(kLogTag, "cache data '%s' not found!",
+                         data_request.CreateKey().c_str());
       return ApiError(ErrorCode::NotFound,
                       "Cache only resource not found in cache (data).");
     }
   }
 
   auto blob_api = ApiClientLookup::LookupApi(
-      catalog, cancellation_context, "blob", "v1", fetch_option, settings);
+      catalog, cancellation_context, service, "v1", fetch_option, settings);
 
   if (!blob_api.IsSuccessful()) {
     return blob_api.GetError();
@@ -382,9 +384,17 @@ BlobApi::DataResponse DataRepository::GetBlobData(
 
   cancellation_context.ExecuteOrCancelled(
       [&]() {
-        auto token = BlobApi::GetBlob(client, layer, data_handle.value(),
-                                      data_request.GetBillingTag(), boost::none,
-                                      std::move(blob_callback));
+        client::CancellationToken token;
+        if (service == "blob") {
+          token = BlobApi::GetBlob(client, layer, data_handle.value(),
+                                   data_request.GetBillingTag(), boost::none,
+                                   std::move(blob_callback));
+        } else {
+          token = VolatileBlobApi::GetVolatileBlob(
+              client, layer, data_handle.value(), data_request.GetBillingTag(),
+              std::move(blob_callback));
+        }
+
         return client::CancellationToken([&, token, flag]() {
           if (flag->exchange(false)) {
             token.cancel();
@@ -418,7 +428,8 @@ BlobApi::DataResponse DataRepository::GetBlobData(
   } else {
     const auto& error = blob_response.GetError();
     if (error.GetHttpStatusCode() == http::HttpStatusCode::FORBIDDEN) {
-      OLP_SDK_LOG_INFO_F(kLogTag, "clear '%s' cache", data_request.CreateKey().c_str());
+      OLP_SDK_LOG_INFO_F(kLogTag, "clear '%s' cache",
+                         data_request.CreateKey().c_str());
       repository.Clear(layer, data_handle.value());
     }
   }

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
@@ -23,8 +23,8 @@
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/HRN.h>
 #include "MultiRequestContext.h"
-#include "olp/dataservice/read/CatalogClient.h"
 #include "generated/api/BlobApi.h"
+#include "olp/dataservice/read/CatalogClient.h"
 
 namespace olp {
 namespace dataservice {
@@ -38,6 +38,8 @@ class DataCacheRepository;
 
 class DataRepository final {
  public:
+  using DataResponse = client::ApiResponse<model::Data, client::ApiError>;
+
   DataRepository(const client::HRN& hrn, std::shared_ptr<ApiRepository> apiRepo,
                  std::shared_ptr<CatalogRepository> catalogRepo,
                  std::shared_ptr<PartitionsRepository> partitionsRepo,
@@ -52,9 +54,9 @@ class DataRepository final {
                const std::string& layerType, const read::DataRequest& request,
                const read::DataResponseCallback& callback);
 
-  static BlobApi::DataResponse GetBlobData(
+  static DataResponse GetBlobData(
       const client::HRN& catalog, const std::string& layer,
-      const DataRequest& data_request,
+      const std::string& service, const DataRequest& data_request,
       client::CancellationContext cancellation_context,
       client::OlpClientSettings settings);
 

--- a/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
@@ -44,6 +44,9 @@ namespace {
 
 using testing::_;
 
+const std::string kLayerId = "testlayer";
+const std::string kService = "blob";
+
 class DataRepositoryTest : public ::testing::Test {
  protected:
   void SetUp() override;
@@ -93,7 +96,7 @@ TEST_F(DataRepositoryTest, GetBlobData) {
 
   auto response =
       olp::dataservice::read::repository::DataRepository::GetBlobData(
-          hrn, "testlayer", request, context, *settings_);
+          hrn, kLayerId, kService, request, context, *settings_);
 
   ASSERT_TRUE(response.IsSuccessful());
 }
@@ -114,7 +117,7 @@ TEST_F(DataRepositoryTest, GetBlobDataApiLookupFailed403) {
 
   auto response =
       olp::dataservice::read::repository::DataRepository::GetBlobData(
-          hrn, "testlayer", request, context, *settings_);
+          hrn, kLayerId, kService, request, context, *settings_);
 
   ASSERT_FALSE(response.IsSuccessful());
 }
@@ -125,7 +128,7 @@ TEST_F(DataRepositoryTest, GetBlobDataNoDataHandle) {
   olp::client::HRN hrn(GetTestCatalog());
   auto response =
       olp::dataservice::read::repository::DataRepository::GetBlobData(
-          hrn, "testlayer", request, context, *settings_);
+          hrn, kLayerId, kService, request, context, *settings_);
   ASSERT_FALSE(response.IsSuccessful());
 }
 
@@ -151,7 +154,7 @@ TEST_F(DataRepositoryTest, GetBlobDataFailedDataFetch403) {
 
   auto response =
       olp::dataservice::read::repository::DataRepository::GetBlobData(
-          hrn, "testlayer", request, context, *settings_);
+          hrn, kLayerId, kService, request, context, *settings_);
 
   ASSERT_FALSE(response.IsSuccessful());
 }
@@ -179,14 +182,14 @@ TEST_F(DataRepositoryTest, GetBlobDataCache) {
   // This should download data from network and cache it
   auto response =
       olp::dataservice::read::repository::DataRepository::GetBlobData(
-          hrn, "testlayer", request, context, *settings_);
+          hrn, kLayerId, kService, request, context, *settings_);
 
   ASSERT_TRUE(response.IsSuccessful());
 
   // This call should not do any network calls and use already cached values
   // instead
   response = olp::dataservice::read::repository::DataRepository::GetBlobData(
-      hrn, "testlayer", request, context, *settings_);
+      hrn, kLayerId, kService, request, context, *settings_);
 
   ASSERT_TRUE(response.IsSuccessful());
 }
@@ -216,7 +219,7 @@ TEST_F(DataRepositoryTest, GetBlobDataImmediateCancel) {
 
   auto response =
       olp::dataservice::read::repository::DataRepository::GetBlobData(
-          hrn, "testlayer", request, context, *settings_);
+          hrn, kLayerId, kService, request, context, *settings_);
   ASSERT_EQ(response.GetError().GetErrorCode(),
             olp::client::ErrorCode::Cancelled);
 }
@@ -248,7 +251,7 @@ TEST_F(DataRepositoryTest, GetBlobDataInProgressCancel) {
 
   auto response =
       olp::dataservice::read::repository::DataRepository::GetBlobData(
-          hrn, "testlayer", request, context, *settings_);
+          hrn, kLayerId, kService, request, context, *settings_);
   ASSERT_EQ(response.GetError().GetErrorCode(),
             olp::client::ErrorCode::Cancelled);
 }


### PR DESCRIPTION
Added service parameter to DataRepository::GetDataBlob() to switch between blob and volatile-blob REST API
Adjusted tests to use blob service

Relates-to: OLPEDGE-760

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>