### PR TITLE
Pass arguments to VersionedLayerClient by value

### DIFF
--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VersionedLayerClient.h
@@ -96,7 +96,7 @@ class DATASERVICE_WRITE_API VersionedLayerClient {
    * @return olp::client::CancellableFuture<StartBatchResponse>
    */
   olp::client::CancellableFuture<StartBatchResponse> StartBatch(
-      const model::StartBatchRequest& request);
+      model::StartBatchRequest request);
 
   /**
    * @brief Start a batch operation.
@@ -104,8 +104,8 @@ class DATASERVICE_WRITE_API VersionedLayerClient {
    * @param callback of type std::function<void(StartBatchResponse response)>
    * @return olp::client::CancellationToken
    */
-  olp::client::CancellationToken StartBatch(
-      const model::StartBatchRequest& request, StartBatchCallback callback);
+  olp::client::CancellationToken StartBatch(model::StartBatchRequest request,
+                                            StartBatchCallback callback);
 
   /**
    * @brief Get the latest version number of the catalog
@@ -191,7 +191,7 @@ class DATASERVICE_WRITE_API VersionedLayerClient {
    */
   olp::client::CancellableFuture<PublishPartitionDataResponse> PublishToBatch(
       const model::Publication& pub,
-      const model::PublishPartitionDataRequest& request);
+      model::PublishPartitionDataRequest request);
 
   /**
    * @brief Call to publish data into an OLP Versioned Layer.
@@ -206,8 +206,7 @@ class DATASERVICE_WRITE_API VersionedLayerClient {
    * request.
    */
   olp::client::CancellationToken PublishToBatch(
-      const model::Publication& pub,
-      const model::PublishPartitionDataRequest& request,
+      const model::Publication& pub, model::PublishPartitionDataRequest request,
       PublishPartitionDataCallback callback);
 
   /**
@@ -216,7 +215,7 @@ class DATASERVICE_WRITE_API VersionedLayerClient {
    * @return olp::client::CancellableFuture<CheckDataExistsResponse>
    */
   olp::client::CancellableFuture<CheckDataExistsResponse> CheckDataExists(
-      const model::CheckDataExistsRequest& request);
+      model::CheckDataExistsRequest request);
 
   /**
    * @brief Check if a datahandle exits.
@@ -225,8 +224,7 @@ class DATASERVICE_WRITE_API VersionedLayerClient {
    * @return olp::client::CancellationToken
    */
   olp::client::CancellationToken CheckDataExists(
-      const model::CheckDataExistsRequest& request,
-      CheckDataExistsCallback callback);
+      model::CheckDataExistsRequest request, CheckDataExistsCallback callback);
 
  private:
   std::shared_ptr<VersionedLayerClientImpl> impl_;

--- a/olp-cpp-sdk-dataservice-write/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/VersionedLayerClient.cpp
@@ -33,12 +33,12 @@ VersionedLayerClient::VersionedLayerClient(client::HRN catalog,
 VersionedLayerClient::~VersionedLayerClient() = default;
 
 olp::client::CancellableFuture<StartBatchResponse>
-VersionedLayerClient::StartBatch(const model::StartBatchRequest& request) {
+VersionedLayerClient::StartBatch(model::StartBatchRequest request) {
   return impl_->StartBatch(request);
 }
 
 olp::client::CancellationToken VersionedLayerClient::StartBatch(
-    const model::StartBatchRequest& request, StartBatchCallback callback) {
+    model::StartBatchRequest request, StartBatchCallback callback) {
   return impl_->StartBatch(request, std::move(callback));
 }
 
@@ -86,27 +86,23 @@ void VersionedLayerClient::CancelAll() { impl_->CancelAll(); }
 
 olp::client::CancellableFuture<PublishPartitionDataResponse>
 VersionedLayerClient::PublishToBatch(
-    const model::Publication& pub,
-    const model::PublishPartitionDataRequest& request) {
+    const model::Publication& pub, model::PublishPartitionDataRequest request) {
   return impl_->PublishToBatch(pub, request);
 }
 
 olp::client::CancellationToken VersionedLayerClient::PublishToBatch(
-    const model::Publication& pub,
-    const model::PublishPartitionDataRequest& request,
+    const model::Publication& pub, model::PublishPartitionDataRequest request,
     PublishPartitionDataCallback callback) {
   return impl_->PublishToBatch(pub, request, std::move(callback));
 }
 
 olp::client::CancellableFuture<CheckDataExistsResponse>
-VersionedLayerClient::CheckDataExists(
-    const model::CheckDataExistsRequest& request) {
+VersionedLayerClient::CheckDataExists(model::CheckDataExistsRequest request) {
   return impl_->CheckDataExists(request);
 }
 
 olp::client::CancellationToken VersionedLayerClient::CheckDataExists(
-    const model::CheckDataExistsRequest& request,
-    CheckDataExistsCallback callback) {
+    model::CheckDataExistsRequest request, CheckDataExistsCallback callback) {
   return impl_->CheckDataExists(request, std::move(callback));
 }
 


### PR DESCRIPTION
Pass request to VersionedLayerClient by value. This aligns interface with
read dataservice API.

Relates-to: OLPEDGE-798
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>