### PR TITLE
Cancel pending requests when clients are destroyed.

### DIFF
--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VersionedLayerClient.h
@@ -88,7 +88,11 @@ class DATASERVICE_WRITE_API VersionedLayerClient {
    * instance
    */
   VersionedLayerClient(client::HRN catalog, client::OlpClientSettings settings);
-  ~VersionedLayerClient();
+  
+  /**
+   * @brief Cancel all pending requests.
+   */
+  void CancellAll();
 
   /**
    * @brief Start a batch operation.

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VolatileLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VolatileLayerClient.h
@@ -90,7 +90,7 @@ class DATASERVICE_WRITE_API VolatileLayerClient {
   /**
    * @brief Cancel all pending requests.
    */
-  void cancellAll();
+  void CancellAll();
 
   /**
    * @brief Call to publish data into an OLP Volatile Layer.

--- a/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.cpp
@@ -57,6 +57,8 @@ IndexLayerClientImpl::IndexLayerClientImpl(HRN catalog,
       apiclient_index_(nullptr),
       init_in_progress_(false) {}
 
+IndexLayerClientImpl::~IndexLayerClientImpl() { CancelAll(); }
+
 olp::client::CancellationToken IndexLayerClientImpl::InitApiClients(
     std::shared_ptr<client::CancellationContext> cancel_context,
     InitApiClientsCallback callback) {

--- a/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.h
@@ -50,6 +50,8 @@ class IndexLayerClientImpl
  public:
   IndexLayerClientImpl(client::HRN catalog, client::OlpClientSettings settings);
 
+  virtual ~IndexLayerClientImpl();
+
   void CancelAll();
 
   olp::client::CancellableFuture<PublishIndexResponse> PublishIndex(

--- a/olp-cpp-sdk-dataservice-write/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/VersionedLayerClient.cpp
@@ -30,7 +30,8 @@ VersionedLayerClient::VersionedLayerClient(client::HRN catalog,
     : impl_(std::make_shared<VersionedLayerClientImpl>(std::move(catalog),
                                                        std::move(settings))) {}
 
-VersionedLayerClient::~VersionedLayerClient() = default;
+
+void VersionedLayerClient::CancellAll() { impl_->CancelAll(); }
 
 olp::client::CancellableFuture<StartBatchResponse>
 VersionedLayerClient::StartBatch(model::StartBatchRequest request) {

--- a/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.cpp
@@ -55,6 +55,8 @@ VersionedLayerClientImpl::VersionedLayerClientImpl(
       apiclient_query_(nullptr),
       init_in_progress_(false) {}
 
+VersionedLayerClientImpl::~VersionedLayerClientImpl() { CancelAll(); }
+
 olp::client::CancellationToken VersionedLayerClientImpl::InitApiClients(
     std::shared_ptr<client::CancellationContext> cancel_context,
     InitApiClientsCallback callback) {

--- a/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.h
@@ -58,6 +58,8 @@ class VersionedLayerClientImpl
   VersionedLayerClientImpl(client::HRN catalog,
                            client::OlpClientSettings settings);
 
+  virtual ~VersionedLayerClientImpl();
+
   client::CancellableFuture<StartBatchResponse> StartBatch(
       const model::StartBatchRequest& request);
 

--- a/olp-cpp-sdk-dataservice-write/src/VolatileLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/VolatileLayerClient.cpp
@@ -29,7 +29,7 @@ VolatileLayerClient::VolatileLayerClient(client::HRN catalog,
     : impl_(std::make_shared<VolatileLayerClientImpl>(std::move(catalog),
                                                       std::move(settings))) {}
 
-void VolatileLayerClient::cancellAll() { impl_->cancellAll(); }
+void VolatileLayerClient::CancellAll() { impl_->CancellAll(); }
 
 olp::client::CancellableFuture<PublishPartitionDataResponse>
 VolatileLayerClient::PublishPartitionData(

--- a/olp-cpp-sdk-dataservice-write/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/VolatileLayerClientImpl.cpp
@@ -50,6 +50,8 @@ VolatileLayerClientImpl::VolatileLayerClientImpl(HRN catalog,
                                                  OlpClientSettings settings)
     : catalog_(std::move(catalog)), settings_(std::move(settings)) {}
 
+VolatileLayerClientImpl::~VolatileLayerClientImpl() { CancellAll(); }
+
 olp::client::CancellationToken VolatileLayerClientImpl::InitApiClients(
     std::shared_ptr<client::CancellationContext> cancel_context,
     InitApiClientsCallback callback) {
@@ -171,7 +173,7 @@ olp::client::CancellationToken VolatileLayerClientImpl::InitApiClients(
                                     configApi_callback);
 }
 
-void VolatileLayerClientImpl::cancellAll() { tokenList_.CancelAll(); }
+void VolatileLayerClientImpl::CancellAll() { tokenList_.CancelAll(); }
 
 CancellationToken VolatileLayerClientImpl::InitCatalogModel(
     const model::PublishPartitionDataRequest& /*request*/,

--- a/olp-cpp-sdk-dataservice-write/src/VolatileLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/VolatileLayerClientImpl.h
@@ -55,12 +55,14 @@ class VolatileLayerClientImpl
   VolatileLayerClientImpl(client::HRN catalog,
                           client::OlpClientSettings settings);
 
+  virtual ~VolatileLayerClientImpl();
+
   olp::client::CancellableFuture<GetBaseVersionResponse> GetBaseVersion();
 
   olp::client::CancellationToken GetBaseVersion(
       GetBaseVersionCallback callback);
 
-  void cancellAll();
+  void CancellAll();
 
   olp::client::CancellableFuture<PublishPartitionDataResponse>
   PublishPartitionData(const model::PublishPartitionDataRequest& request);

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVolatileLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVolatileLayerClientTest.cpp
@@ -357,12 +357,12 @@ TEST_F(DataserviceWriteVolatileLayerClientTest,
   // get_batch_response.GetResult().GetDetails()->GetState());
 }
 
-TEST_F(DataserviceWriteVolatileLayerClientTest, cancellAllRequests) {
+TEST_F(DataserviceWriteVolatileLayerClientTest, CancellAllRequests) {
   auto volatile_client = CreateVolatileLayerClient();
   auto future = volatile_client->GetBaseVersion().GetFuture();
 
   std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  volatile_client->cancellAll();
+  volatile_client->CancellAll();
 
   auto response = future.get();
   ASSERT_FALSE(response.IsSuccessful());


### PR DESCRIPTION
Cancel pending requests when Versioned/Volatile/Index clients are destroyed.

Resolves: OLPEDGE-880

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>