### PR TITLE
Removed Enable, Disable, DefaultListener from StreamLayerClient

### DIFF
--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClient.h
@@ -26,7 +26,6 @@
 #include <olp/core/client/OlpClientSettings.h>
 
 #include <olp/dataservice/write/DataServiceWriteApi.h>
-#include <olp/dataservice/write/FlushEventListener.h>
 #include <olp/dataservice/write/FlushSettings.h>
 #include <olp/dataservice/write/generated/model/ResponseOk.h>
 #include <olp/dataservice/write/generated/model/ResponseOkSingle.h>
@@ -69,7 +68,6 @@ class DATASERVICE_WRITE_API StreamLayerClient {
  public:
   using FlushResponse = std::vector<PublishDataResponse>;
   using FlushCallback = std::function<void(FlushResponse response)>;
-  using FlushListener = FlushEventListener<const FlushResponse&>;
 
   /**
    * @brief StreamLayerClient Constructor.
@@ -132,32 +130,6 @@ class DATASERVICE_WRITE_API StreamLayerClient {
    * request.
    */
   olp::client::CancellationToken Flush(FlushCallback callback);
-
-  /**
-   * @brief Enable the StreamLayerClient auto-flushing mechanism.
-   * @param listener Optional FlushEventListener used for optaining metrics and
-   * getting events related to auto flushing.
-   */
-  void Enable(std::shared_ptr<FlushListener> listener = nullptr);
-
-  /**
-   * @brief Disable the StreamLayerClient auto-flushing mechanism. Will cancel
-   * any ongoing background flush tasks.
-   *
-   * @return std::future object, which will be set when all pending background
-   * flush events have completed or have been cancelled. Ensure that the
-   * StreamLayerClient is not destructed prior to this future being set.
-   */
-  std::future<void> Disable();
-
-  /**
-   * @brief Create a listener object of type DefaultFlushEventListener for this
-   * API.
-   *
-   * @return std::shared_ptr< FlushDataListener > object, of appropriate type
-   * for this API.
-   */
-  static std::shared_ptr<FlushListener> DefaultListener();
 
   /**
    * @brief Call to send a list of SDII messages to an OLP Stream Layer.

--- a/olp-cpp-sdk-dataservice-write/src/AutoFlushController.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/AutoFlushController.cpp
@@ -249,7 +249,8 @@ void AutoFlushController::Enable(
 template void AutoFlushController::Enable<
     StreamLayerClientImpl, const StreamLayerClient::FlushResponse&>(
     std::shared_ptr<StreamLayerClientImpl> apiIngestPublish,
-    std::shared_ptr<StreamLayerClient::FlushListener> listener);
+    std::shared_ptr<FlushEventListener<const StreamLayerClient::FlushResponse&>>
+        listener);
 
 std::future<void> AutoFlushController::Disable() {
   auto sp = std::atomic_exchange(

--- a/olp-cpp-sdk-dataservice-write/src/AutoFlushController.h
+++ b/olp-cpp-sdk-dataservice-write/src/AutoFlushController.h
@@ -21,6 +21,7 @@
 
 #include <memory>
 
+#include <olp/dataservice/write/FlushEventListener.h>
 #include <olp/dataservice/write/StreamLayerClient.h>
 
 namespace olp {

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClient.cpp
@@ -68,17 +68,6 @@ olp::client::CancellationToken StreamLayerClient::Flush(
   return impl_->Flush(std::move(callback));
 }
 
-void StreamLayerClient::Enable(std::shared_ptr<FlushListener> listener) {
-  impl_->Enable(listener);
-}
-
-std::future<void> StreamLayerClient::Disable() { return impl_->Disable(); }
-
-std::shared_ptr<StreamLayerClient::FlushListener>
-StreamLayerClient::DefaultListener() {
-  return std::make_shared<DefaultFlushEventListener<const FlushResponse&> >();
-}
-
 olp::client::CancellableFuture<PublishSdiiResponse>
 StreamLayerClient::PublishSdii(model::PublishSdiiRequest request) {
   return impl_->PublishSdii(request);

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
@@ -430,15 +430,6 @@ olp::client::CancellationToken StreamLayerClientImpl::Flush(
   return CancellationToken([=]() mutable { cancel_context.CancelOperation(); });
 }
 
-void StreamLayerClientImpl::Enable(
-    std::shared_ptr<StreamLayerClient::FlushListener> listener) {
-  auto_flush_controller_->Enable(shared_from_this(), listener);
-}
-
-std::future<void> StreamLayerClientImpl::Disable() {
-  return auto_flush_controller_->Disable();
-}
-
 CancellationToken StreamLayerClientImpl::PublishData(
     const model::PublishDataRequest& request, PublishDataCallback callback) {
   if (!request.GetData()) {

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.h
@@ -63,9 +63,6 @@ class StreamLayerClientImpl
   size_t QueueSize() const;
   boost::optional<model::PublishDataRequest> PopFromQueue();
 
-  void Enable(std::shared_ptr<StreamLayerClient::FlushListener> listener);
-  std::future<void> Disable();
-
   olp::client::CancellableFuture<PublishSdiiResponse> PublishSdii(
       const model::PublishSdiiRequest& request);
   olp::client::CancellationToken PublishSdii(

--- a/tests/common/testables/FlushEventListenerTestable.h
+++ b/tests/common/testables/FlushEventListenerTestable.h
@@ -21,6 +21,7 @@
 
 #include <mutex>
 
+#include <olp/dataservice/write/FlushEventListener.h>
 #include <olp/dataservice/write/StreamLayerClient.h>
 
 namespace olp {

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientCacheTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientCacheTest.cpp
@@ -323,7 +323,8 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest, FlushDataCancel) {
   ASSERT_NO_FATAL_FAILURE(PublishFailureAssertions(response[0]));
 }
 
-TEST_F(DataserviceWriteStreamLayerClientCacheTest, FlushListenerMetrics) {
+TEST_F(DataserviceWriteStreamLayerClientCacheTest,
+       DISABLED_FlushListenerMetrics) {
   disk_cache_->Close();
   flush_settings_.auto_flush_num_events = 3;
   client_ = CreateStreamLayerClient();
@@ -331,8 +332,6 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest, FlushListenerMetrics) {
   ASSERT_NO_FATAL_FAILURE(QueueMultipleEvents(3));
 
   auto default_listener = std::make_shared<FlushEventListenerTestable>();
-
-  client_->Enable(default_listener);
 
   for (int i = 0; default_listener->GetNumFlushEvents() < 1; i++) {
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
@@ -349,13 +348,12 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest, FlushListenerMetrics) {
 }
 
 TEST_F(DataserviceWriteStreamLayerClientCacheTest,
-       FlushListenerMetricsSetListenerBeforeQueuing) {
+       DISABLED_FlushListenerMetricsSetListenerBeforeQueuing) {
   disk_cache_->Close();
   flush_settings_.auto_flush_num_events = 3;
   client_ = CreateStreamLayerClient();
 
   auto default_listener = std::make_shared<FlushEventListenerTestable>();
-  client_->Enable(default_listener);
 
   ASSERT_NO_FATAL_FAILURE(QueueMultipleEvents(3));
 
@@ -373,24 +371,25 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest,
   EXPECT_EQ(0, default_listener->GetNumFlushedRequestsFailed());
 }
 
-TEST_F(DataserviceWriteStreamLayerClientCacheTest, FlushListenerDisable) {
+TEST_F(DataserviceWriteStreamLayerClientCacheTest,
+       DISABLED_FlushListenerDisable) {
   disk_cache_->Close();
   flush_settings_.auto_flush_num_events = 3;
   client_ = CreateStreamLayerClient();
 
   auto default_listener = std::make_shared<FlushEventListenerTestable>();
-  client_->Enable(default_listener);
 
   ASSERT_NO_FATAL_FAILURE(QueueMultipleEvents(3));
 
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-  auto disable_future = client_->Disable();
-  auto status = disable_future.wait_for(std::chrono::seconds(5));
-  if (status != std::future_status::ready) {
-    FAIL() << "Timeout waiting for auto flushing to be disabled";
-  }
-  disable_future.get();
+  // TODO: uncomment this code once the auto-flush mechanism will be turned.
+  //  auto disable_future = client_->Disable();
+  //  auto status = disable_future.wait_for(std::chrono::seconds(5));
+  //  if (status != std::future_status::ready) {
+  //    FAIL() << "Timeout waiting for auto flushing to be disabled";
+  //  }
+  //  disable_future.get();
 
   EXPECT_EQ(1, default_listener->GetNumFlushEvents());
   EXPECT_EQ(1, default_listener->GetNumFlushEventsAttempted());
@@ -398,13 +397,12 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest, FlushListenerDisable) {
 }
 
 TEST_F(DataserviceWriteStreamLayerClientCacheTest,
-       FlushListenerMetricsMultipleFlushEventsInSeries) {
+       DISABLED_FlushListenerMetricsMultipleFlushEventsInSeries) {
   disk_cache_->Close();
   flush_settings_.auto_flush_num_events = 2;
   client_ = CreateStreamLayerClient();
 
   auto default_listener = std::make_shared<FlushEventListenerTestable>();
-  client_->Enable(default_listener);
 
   ASSERT_NO_FATAL_FAILURE(QueueMultipleEvents(2));
 
@@ -430,7 +428,7 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest,
 }
 
 TEST_F(DataserviceWriteStreamLayerClientCacheTest,
-       FlushListenerMetricsMultipleFlushEventsInParallel) {
+       DISABLED_FlushListenerMetricsMultipleFlushEventsInParallel) {
   disk_cache_->Close();
   flush_settings_.auto_flush_num_events = 2;
   flush_settings_.events_per_single_flush =
@@ -438,7 +436,6 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest,
   client_ = CreateStreamLayerClient();
 
   auto default_listener = std::make_shared<FlushEventListenerTestable>();
-  client_->Enable(default_listener);
 
   ASSERT_NO_FATAL_FAILURE(QueueMultipleEvents(6));
 
@@ -458,8 +455,9 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest,
   EXPECT_EQ(0, default_listener->GetNumFlushedRequestsFailed());
 }
 
-TEST_F(DataserviceWriteStreamLayerClientCacheTest,
-       FlushListenerMetricsMultipleFlushEventsInParallelStaggeredQueue) {
+TEST_F(
+    DataserviceWriteStreamLayerClientCacheTest,
+    DISABLED_FlushListenerMetricsMultipleFlushEventsInParallelStaggeredQueue) {
   disk_cache_->Close();
   flush_settings_.auto_flush_num_events = 2;
   flush_settings_.events_per_single_flush =
@@ -467,7 +465,6 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest,
   client_ = CreateStreamLayerClient();
 
   auto default_listener = std::make_shared<FlushEventListenerTestable>();
-  client_->Enable(default_listener);
 
   ASSERT_NO_FATAL_FAILURE(QueueMultipleEvents(4));
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
@@ -491,7 +488,8 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest,
   EXPECT_EQ(0, default_listener->GetNumFlushedRequestsFailed());
 }
 
-TEST_F(DataserviceWriteStreamLayerClientCacheTest, FlushListenerNotifications) {
+TEST_F(DataserviceWriteStreamLayerClientCacheTest,
+       DISABLED_FlushListenerNotifications) {
   disk_cache_->Close();
   flush_settings_.auto_flush_num_events = 3;
   client_ = CreateStreamLayerClient();
@@ -522,7 +520,6 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest, FlushListenerNotifications) {
   };
 
   auto notification_listener = std::make_shared<NotificationListener>();
-  client_->Enable(notification_listener);
 
   for (int i = 0; notification_listener->GetResults().size() < 3; i++) {
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
@@ -538,7 +535,7 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest, FlushListenerNotifications) {
 }
 
 TEST_F(DataserviceWriteStreamLayerClientCacheTest,
-       FlushSettingsAutoFlushInterval) {
+       DISABLED_FlushSettingsAutoFlushInterval) {
   disk_cache_->Close();
   flush_settings_.auto_flush_interval = 10;
   client_ = CreateStreamLayerClient();
@@ -546,7 +543,6 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest,
   ASSERT_NO_FATAL_FAILURE(QueueMultipleEvents(2));
 
   auto default_listener = std::make_shared<FlushEventListenerTestable>();
-  client_->Enable(default_listener);
 
   for (int i = 0; default_listener->GetNumFlushEvents() < 1; i++) {
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
@@ -563,7 +559,7 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest,
 }
 
 TEST_F(DataserviceWriteStreamLayerClientCacheTest,
-       FlushSettingsAutoFlushIntervalDisable) {
+       DISABLED_FlushSettingsAutoFlushIntervalDisable) {
   disk_cache_->Close();
   flush_settings_.auto_flush_interval = 2;
   client_ = CreateStreamLayerClient();
@@ -571,16 +567,16 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest,
   ASSERT_NO_FATAL_FAILURE(QueueMultipleEvents(2));
 
   auto default_listener = std::make_shared<FlushEventListenerTestable>();
-  client_->Enable(default_listener);
 
   std::this_thread::sleep_for(std::chrono::milliseconds(2100));
 
-  auto disable_future = client_->Disable();
-  auto status = disable_future.wait_for(std::chrono::seconds(5));
-  if (status != std::future_status::ready) {
-    FAIL() << "Timeout waiting for auto flushing to be disabled";
-  }
-  disable_future.get();
+  // TODO: uncomment this code once the auto-flush mechanism will be turned.
+  //  auto disable_future = client_->Disable();
+  //  auto status = disable_future.wait_for(std::chrono::seconds(5));
+  //  if (status != std::future_status::ready) {
+  //    FAIL() << "Timeout waiting for auto flushing to be disabled";
+  //  }
+  //  disable_future.get();
 
   EXPECT_EQ(1, default_listener->GetNumFlushEvents());
   EXPECT_EQ(1, default_listener->GetNumFlushEventsAttempted());

--- a/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
@@ -372,7 +372,7 @@ TEST_F(StreamLayerClientCacheTest, DISABLED_FlushDataCancel) {
   ASSERT_NO_FATAL_FAILURE(PublishFailureAssertions(response[0]));
 }
 
-TEST_F(StreamLayerClientCacheTest, FlushListenerMetrics) {
+TEST_F(StreamLayerClientCacheTest, DISABLED_FlushListenerMetrics) {
   disk_cache_->Close();
   flush_settings_.auto_flush_num_events = 3;
   client_ = CreateStreamLayerClient();
@@ -393,8 +393,6 @@ TEST_F(StreamLayerClientCacheTest, FlushListenerMetrics) {
 
   auto default_listener = std::make_shared<FlushEventListenerTestable>();
 
-  client_->Enable(default_listener);
-
   for (int i = 0; default_listener->GetNumFlushEvents() < 1; i++) {
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
     if (i > 200) {
@@ -410,13 +408,12 @@ TEST_F(StreamLayerClientCacheTest, FlushListenerMetrics) {
 }
 
 TEST_F(StreamLayerClientCacheTest,
-       FlushListenerMetricsSetListenerBeforeQueuing) {
+       DISABLED_FlushListenerMetricsSetListenerBeforeQueuing) {
   disk_cache_->Close();
   flush_settings_.auto_flush_num_events = 3;
   client_ = CreateStreamLayerClient();
 
   auto default_listener = std::make_shared<FlushEventListenerTestable>();
-  client_->Enable(default_listener);
   {
     testing::InSequence dummy;
 
@@ -446,13 +443,12 @@ TEST_F(StreamLayerClientCacheTest,
 }
 
 TEST_F(StreamLayerClientCacheTest,
-       FlushListenerMetricsMultipleFlushEventsInSeries) {
+       DISABLED_FlushListenerMetricsMultipleFlushEventsInSeries) {
   disk_cache_->Close();
   flush_settings_.auto_flush_num_events = 2;
   client_ = CreateStreamLayerClient();
 
   auto default_listener = std::make_shared<FlushEventListenerTestable>();
-  client_->Enable(default_listener);
   {
     testing::InSequence dummy;
 
@@ -489,13 +485,12 @@ TEST_F(StreamLayerClientCacheTest,
 }
 
 TEST_F(StreamLayerClientCacheTest,
-       FlushListenerMetricsMultipleFlushEventsInParallel) {
+       DISABLED_FlushListenerMetricsMultipleFlushEventsInParallel) {
   disk_cache_->Close();
   flush_settings_.auto_flush_num_events = 2;
   client_ = CreateStreamLayerClient();
 
   auto default_listener = std::make_shared<FlushEventListenerTestable>();
-  client_->Enable(default_listener);
   {
     testing::InSequence dummy;
 
@@ -524,7 +519,7 @@ TEST_F(StreamLayerClientCacheTest,
   EXPECT_EQ(0, default_listener->GetNumFlushedRequestsFailed());
 }
 
-TEST_F(StreamLayerClientCacheTest, FlushListenerNotifications) {
+TEST_F(StreamLayerClientCacheTest, DISABLED_FlushListenerNotifications) {
   disk_cache_->Close();
   flush_settings_.auto_flush_num_events = 3;
   client_ = CreateStreamLayerClient();
@@ -567,7 +562,6 @@ TEST_F(StreamLayerClientCacheTest, FlushListenerNotifications) {
   };
 
   auto notification_listener = std::make_shared<NotificationListener>();
-  client_->Enable(notification_listener);
 
   for (int i = 0; notification_listener->GetResults().size() < 3; i++) {
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
@@ -642,7 +636,7 @@ TEST_F(StreamLayerClientCacheTest, FlushDataMaxEventsInvalidCustomSetting) {
       FlushDataOnSettingSuccessAssertions(max_events_per_flush));
 }
 
-TEST_F(StreamLayerClientCacheTest, FlushSettingsAutoFlushInterval) {
+TEST_F(StreamLayerClientCacheTest, DISABLED_FlushSettingsAutoFlushInterval) {
   disk_cache_->Close();
   flush_settings_.auto_flush_interval = 1;
   client_ = CreateStreamLayerClient();
@@ -662,7 +656,6 @@ TEST_F(StreamLayerClientCacheTest, FlushSettingsAutoFlushInterval) {
   ASSERT_NO_FATAL_FAILURE(QueueMultipleEvents(2));
 
   auto default_listener = std::make_shared<FlushEventListenerTestable>();
-  client_->Enable(default_listener);
 
   for (int i = 0; default_listener->GetNumFlushEvents() < 1; i++) {
     std::this_thread::sleep_for(std::chrono::milliseconds(50));


### PR DESCRIPTION
Removed next methods from StreamLayerClient:
 - void Enable(std::shared_ptr<FlushListener> listener = nullptr);
 - std::future<void> Disable();
 - static std::shared_ptr<FlushListener> DefaultListener()

Also, disabled all the integration & functional tests which were using those API.

Relates to: OLPEDGE-825

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>