### PR TITLE
Removed DefaultFlushEventListener from public API

### DIFF
--- a/olp-cpp-sdk-dataservice-write/src/DefaultFlushEventListener.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/DefaultFlushEventListener.cpp
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-#include <olp/dataservice/write/FlushEventListener.h>
+#include "DefaultFlushEventListener.h"
 
 #include <olp/dataservice/write/StreamLayerClient.h>
 

--- a/olp-cpp-sdk-dataservice-write/src/DefaultFlushEventListener.h
+++ b/olp-cpp-sdk-dataservice-write/src/DefaultFlushEventListener.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include <olp/dataservice/write/FlushMetrics.h>
+#include <olp/dataservice/write/FlushEventListener.h>
+
+namespace olp {
+namespace dataservice {
+namespace write {
+
+/**
+ @brief Default implementation of the FlushEventListener.
+ @deprecated Currently deperecated and not used in the public API.
+ Should be refactored and used directly in \c StreamLayerClientImpl and \c
+ AutoFlushController.
+ */
+template <typename FlushResponse>
+class DefaultFlushEventListener : public FlushEventListener<FlushResponse> {
+ public:
+  void NotifyFlushEventStarted() override {
+    FlushMetrics metrics;
+    {
+      std::lock_guard<std::mutex> locker(mutex_);
+      ++metrics_.num_attempted_flush_events;
+      metrics = metrics_;
+    }
+    NotifyFlushMetricsHasChanged(std::move(metrics));
+  }
+
+  void NotifyFlushEventResults(FlushResponse results) override;
+
+  void NotifyFlushMetricsHasChanged(FlushMetrics metrics) override{};
+
+ protected:
+  template <typename T>
+  bool CollateFlushEventResults(const std::vector<T>& results) {
+    metrics_.num_total_flushed_requests += results.size();
+
+    thread_local size_t flush_requests_failed =
+        std::count_if(std::begin(results), std::end(results),
+                      [](T result) -> bool { return !result.IsSuccessful(); });
+    metrics_.num_failed_flushed_requests += flush_requests_failed;
+    return flush_requests_failed > 0ull;
+  }
+
+  mutable std::mutex mutex_;
+  FlushMetrics metrics_;
+};
+
+}  // namespace write
+}  // namespace dataservice
+}  // namespace olp

--- a/tests/common/testables/FlushEventListenerTestable.h
+++ b/tests/common/testables/FlushEventListenerTestable.h
@@ -29,9 +29,12 @@ namespace tests {
 namespace common {
 
 class FlushEventListenerTestable
-    : public olp::dataservice::write::DefaultFlushEventListener<
+    : public olp::dataservice::write::FlushEventListener<
           const olp::dataservice::write::StreamLayerClient::FlushResponse&> {
  public:
+  using FlushResponse =
+      olp::dataservice::write::StreamLayerClient::FlushResponse;
+
   size_t GetNumFlushEventsAttempted() const {
     std::lock_guard<std::mutex> locker(mutex_);
     return metrics_.num_attempted_flush_events;
@@ -55,6 +58,14 @@ class FlushEventListenerTestable
   size_t GetNumFlushedRequestsFailed() const {
     std::lock_guard<std::mutex> locker(mutex_);
     return metrics_.num_failed_flushed_requests;
+  }
+
+  void NotifyFlushEventStarted() override {
+    // no-op
+  }
+
+  void NotifyFlushEventResults(const FlushResponse& response) override {
+    // no-op
   }
 
   void NotifyFlushMetricsHasChanged(

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientCacheTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientCacheTest.cpp
@@ -496,8 +496,8 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest,
 
   ASSERT_NO_FATAL_FAILURE(QueueMultipleEvents(3));
 
-  class NotificationListener : public DefaultFlushEventListener<
-                                   const StreamLayerClient::FlushResponse&> {
+  class NotificationListener
+      : public FlushEventListener<const StreamLayerClient::FlushResponse&> {
    public:
     void NotifyFlushEventStarted() override { events_started_++; }
 
@@ -505,6 +505,10 @@ TEST_F(DataserviceWriteStreamLayerClientCacheTest,
         const StreamLayerClient::FlushResponse& results) override {
       std::lock_guard<std::mutex> lock(results_mutex_);
       results_ = std::move(results);
+    }
+
+    void NotifyFlushMetricsHasChanged(FlushMetrics metrics) override {
+      // no-op
     }
 
     const StreamLayerClient::FlushResponse& GetResults() {

--- a/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
@@ -538,8 +538,8 @@ TEST_F(StreamLayerClientCacheTest, DISABLED_FlushListenerNotifications) {
 
   ASSERT_NO_FATAL_FAILURE(QueueMultipleEvents(3));
 
-  class NotificationListener : public DefaultFlushEventListener<
-                                   const StreamLayerClient::FlushResponse&> {
+  class NotificationListener
+      : public FlushEventListener<const StreamLayerClient::FlushResponse&> {
    public:
     void NotifyFlushEventStarted() override { events_started_++; }
 
@@ -552,6 +552,10 @@ TEST_F(StreamLayerClientCacheTest, DISABLED_FlushListenerNotifications) {
     const StreamLayerClient::FlushResponse& GetResults() {
       std::lock_guard<std::mutex> lock(results_mutex_);
       return results_;
+    }
+
+    void NotifyFlushMetricsHasChanged(FlushMetrics metrics) override {
+      // no-op
     }
 
     int events_started_ = 0;


### PR DESCRIPTION
- Removed the DefaultFlushEventListener from public API - now it resides  in dataservice-write/src folder.
- Updated the corresponding tests which were using this class.

Relates to: OLPEDGE-825

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>