### PR TITLE
Added dependency on system frameworks for iOS build

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -271,6 +271,14 @@ if(IOS)
     else()
         target_compile_options(${PROJECT_NAME} PRIVATE "-fobjc-arc")
     endif()
+
+    find_library(OLP_SDK_CORE_FOUNDATION_FRAMEWORK CoreFoundation)
+    find_library(OLP_SDK_SECURITY_FRAMEWORK Security)
+    find_library(OLP_SDK_CFNETWORK_FRAMEWORK CFNetwork)
+
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${OLP_SDK_CORE_FOUNDATION_FRAMEWORK}
+                                                  ${OLP_SDK_SECURITY_FRAMEWORK}
+                                                  ${OLP_SDK_CFNETWORK_FRAMEWORK})
 elseif(ANDROID)
     # Make sure that OlpHttpClient.jar is built before olp-cpp-sdk-core
     add_dependencies(${PROJECT_NAME} ${OLP_SDK_ANDROID_HTTP_CLIENT_JAR})


### PR DESCRIPTION
Added missing dependencies on system frameworks for iOS build when building with shared libraries turned on.

Relates to: OLPEDGE-532

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>