### PR TITLE
Add missing include.

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/Settings.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/Settings.h
@@ -26,6 +26,7 @@
 #include <olp/core/http/NetworkProxySettings.h>
 
 #include "AuthenticationApi.h"
+#include "AuthenticationCredentials.h"
 
 namespace olp {
 namespace http {


### PR DESCRIPTION
Added a missing AuthenticationCredentials.h include.

Relates-To: OLPEDGE-839

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>