### PR TITLE
[Draft] Removed FlushSettings from StreamLayerClient's ctor

### DIFF
--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClient.h
@@ -26,7 +26,6 @@
 #include <olp/core/client/OlpClientSettings.h>
 
 #include <olp/dataservice/write/DataServiceWriteApi.h>
-#include <olp/dataservice/write/FlushSettings.h>
 #include <olp/dataservice/write/generated/model/ResponseOk.h>
 #include <olp/dataservice/write/generated/model/ResponseOkSingle.h>
 #include <olp/dataservice/write/model/PublishDataRequest.h>
@@ -74,11 +73,8 @@ class DATASERVICE_WRITE_API StreamLayerClient {
    * @param catalog OLP HRN specifying the catalog this client will write to.
    * @param settings Client settings used to control behaviour of this
    * StreamLayerClient instance.
-   * @param flush_settings Optional defines settings that effect cached
-   * partitions to be flushed. is provided a default in-memory cache is used.
    */
-  StreamLayerClient(client::HRN catalog, client::OlpClientSettings settings,
-                    FlushSettings flush_settings = FlushSettings());
+  StreamLayerClient(client::HRN catalog, client::OlpClientSettings settings);
 
   /**
    * @brief Call to publish data into an OLP Stream Layer.

--- a/olp-cpp-sdk-dataservice-write/src/AutoFlushController.h
+++ b/olp-cpp-sdk-dataservice-write/src/AutoFlushController.h
@@ -22,6 +22,7 @@
 #include <memory>
 
 #include <olp/dataservice/write/FlushEventListener.h>
+#include <olp/dataservice/write/FlushSettings.h>
 #include <olp/dataservice/write/StreamLayerClient.h>
 
 namespace olp {

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClient.cpp
@@ -35,12 +35,10 @@ std::shared_ptr<cache::KeyValueCache> CreateDefaultCache(
 }
 
 StreamLayerClient::StreamLayerClient(client::HRN catalog,
-                                     client::OlpClientSettings settings,
-                                     FlushSettings flush_settings) {
+                                     client::OlpClientSettings settings) {
   auto cache = settings.cache;
   impl_ = std::make_shared<StreamLayerClientImpl>(
-      std::move(catalog), std::move(settings), std::move(cache),
-      std::move(flush_settings));
+      std::move(catalog), std::move(settings), std::move(cache));
 }
 
 olp::client::CancellableFuture<PublishDataResponse>

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
@@ -76,8 +76,7 @@ void ExecuteOrSchedule(const OlpClientSettings& settings,
 
 StreamLayerClientImpl::StreamLayerClientImpl(
     const HRN& catalog, const OlpClientSettings& settings,
-    const std::shared_ptr<cache::KeyValueCache>& cache,
-    const FlushSettings& flush_settings)
+    const std::shared_ptr<cache::KeyValueCache>& cache)
     : catalog_(catalog),
       catalog_model_(),
       settings_(settings),
@@ -90,7 +89,7 @@ StreamLayerClientImpl::StreamLayerClientImpl(
       init_inprogress_(false),
       cache_(cache),
       cache_mutex_(),
-      flush_settings_(flush_settings),
+      flush_settings_(FlushSettings{}),
       auto_flush_controller_(new AutoFlushController(flush_settings_)) {}
 
 CancellationToken StreamLayerClientImpl::InitApiClients(

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.h
@@ -24,7 +24,7 @@
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClient.h>
 #include <olp/core/client/OlpClientFactory.h>
-
+#include <olp/dataservice/write/FlushSettings.h>
 #include <olp/dataservice/write/StreamLayerClient.h>
 #include "ApiClientLookup.h"
 #include "AutoFlushController.h"
@@ -48,8 +48,7 @@ class StreamLayerClientImpl
  public:
   StreamLayerClientImpl(const client::HRN& catalog,
                         const client::OlpClientSettings& settings,
-                        const std::shared_ptr<cache::KeyValueCache>& cache,
-                        const FlushSettings& flush_settings);
+                        const std::shared_ptr<cache::KeyValueCache>& cache);
 
   olp::client::CancellableFuture<PublishDataResponse> PublishData(
       const model::PublishDataRequest& request);
@@ -113,6 +112,8 @@ class StreamLayerClientImpl
 
   std::shared_ptr<cache::KeyValueCache> cache_;
   mutable std::mutex cache_mutex_;
+
+  /// These fields are currently not used - will be refactored after 1.0
   FlushSettings flush_settings_;
   std::unique_ptr<AutoFlushController> auto_flush_controller_;
 };

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientCacheTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientCacheTest.cpp
@@ -34,6 +34,7 @@
 #include <olp/core/client/OlpClient.h>
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/dataservice/write/FlushSettings.h>
 #include <olp/dataservice/write/StreamLayerClient.h>
 #include <olp/dataservice/write/model/PublishDataRequest.h>
 #include <olp/dataservice/write/model/PublishSdiiRequest.h>
@@ -155,7 +156,7 @@ class DataserviceWriteStreamLayerClientCacheTest : public ::testing::Test {
     settings.cache = disk_cache_;
 
     return std::make_shared<StreamLayerClient>(
-        olp::client::HRN{GetTestCatalog()}, settings, flush_settings_);
+        olp::client::HRN{GetTestCatalog()}, settings);
   }
 
  private:

--- a/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
@@ -27,6 +27,7 @@
 #include <olp/core/client/OlpClient.h>
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/dataservice/write/FlushSettings.h>
 #include <olp/dataservice/write/StreamLayerClient.h>
 #include <olp/dataservice/write/model/PublishDataRequest.h>
 #include "HttpResponses.h"
@@ -134,7 +135,7 @@ class StreamLayerClientCacheTest : public ::testing::Test {
     SetUpCommonNetworkMockCalls(*network_);
 
     return std::make_shared<StreamLayerClient>(
-        olp::client::HRN{GetTestCatalog()}, client_settings, flush_settings_);
+        olp::client::HRN{GetTestCatalog()}, client_settings);
   }
 
   void SetUpCommonNetworkMockCalls(NetworkMock& network) {
@@ -596,7 +597,8 @@ TEST_F(StreamLayerClientCacheTest, FlushDataMaxEventsDefaultSetting) {
   ASSERT_NO_FATAL_FAILURE(FlushDataOnSettingSuccessAssertions());
 }
 
-TEST_F(StreamLayerClientCacheTest, FlushDataMaxEventsValidCustomSetting) {
+TEST_F(StreamLayerClientCacheTest,
+       DISABLED_FlushDataMaxEventsValidCustomSetting) {
   const int max_events_per_flush = 3;
   disk_cache_->Close();
   flush_settings_.events_per_single_flush = max_events_per_flush;
@@ -618,7 +620,8 @@ TEST_F(StreamLayerClientCacheTest, FlushDataMaxEventsValidCustomSetting) {
       FlushDataOnSettingSuccessAssertions(max_events_per_flush));
 }
 
-TEST_F(StreamLayerClientCacheTest, FlushDataMaxEventsInvalidCustomSetting) {
+TEST_F(StreamLayerClientCacheTest,
+       DISABLED_FlushDataMaxEventsInvalidCustomSetting) {
   const int max_events_per_flush = -3;
   disk_cache_->Close();
   flush_settings_.events_per_single_flush = max_events_per_flush;
@@ -675,7 +678,7 @@ TEST_F(StreamLayerClientCacheTest, DISABLED_FlushSettingsAutoFlushInterval) {
   EXPECT_EQ(0, default_listener->GetNumFlushedRequestsFailed());
 }
 
-TEST_F(StreamLayerClientCacheTest, FlushSettingsMaximumRequests) {
+TEST_F(StreamLayerClientCacheTest, DISABLED_FlushSettingsMaximumRequests) {
   disk_cache_->Close();
   ASSERT_EQ(flush_settings_.maximum_requests, boost::none);
   client_ = CreateStreamLayerClient();


### PR DESCRIPTION
Removed the FlushSettings from StreamLayerClient's ctor and disabled corresponding tests.

Resolves: OLPEDGE-826

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>