### PR TITLE
Improve Android build process on PSV

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,11 +43,11 @@ matrix:
       - google-gdk-license-.+
       - patcher
       - ndk-bundle
-    before_install:
+    install:
     - echo y | sdkmanager "ndk-bundle"
     before_script:
-    - wget https://dl.google.com/android/repository/android-ndk-r20-linux-x86_64.zip
-    - unzip -qq android-ndk-r20-linux-x86_64.zip
+    - export ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle
+    - ls -la $ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake # for verification that needed script exist
     script: $WORKSPACE/scripts/android/build.sh
   - os: osx
     osx_image: xcode10.2

--- a/scripts/android/build.sh
+++ b/scripts/android/build.sh
@@ -1,14 +1,14 @@
 #!/bin/bash -e
-mv android-9 android-9_source && mkdir -p android-9/platforms/android-28 && cp -r android-9_source/* android-9/platforms/android-28/ && rm -rf android-9_source
+
 mkdir -p build && cd build
-cmake .. -DCMAKE_TOOLCHAIN_FILE="$WORKSPACE/android-ndk-r20/build/cmake/android.toolchain.cmake" \
+cmake .. -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake" \
 	-DANDROID_PLATFORM=android-28 \
 	-DANDROID_ABI=arm64-v8a \
 	-DOLP_SDK_ENABLE_TESTING=NO \
-	-DOLP_SDK_BUILD_EXAMPLES=ON 
+	-DOLP_SDK_BUILD_EXAMPLES=ON
 
-#cmake --build .
-sudo make install -j16
+#cmake --build . # this is alternative option for build
+sudo make install -j
 cd $WORKSPACE/build/examples/dataservice-read/android
 sudo ./gradlew assemble
 cd $WORKSPACE/build/examples/dataservice-write/android


### PR DESCRIPTION
Added build-in NDK instead of downloading full archive every time.
Documented by Google Travis build there: https://github.com/googlesamples/android-ndk/blob/master/.travis.yml
and https://stackoverflow.com/questions/47782349/ndk-cmake-and-android-in-travisci

Relates-To: OLPEDGE-784

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>