### PR TITLE
Fixed typo in SendOutcome::IsSuccessful method

### DIFF
--- a/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
@@ -372,7 +372,7 @@ client::CancellationToken AuthenticationClient::Impl::SignInClient(
         }
       });
 
-  if (!send_outcome.IsSuccessfull()) {
+  if (!send_outcome.IsSuccessful()) {
     ExecuteOrSchedule(task_scheduler_, [send_outcome, callback] {
       std::string error_message =
           ErrorCodeToString(send_outcome.GetErrorCode());
@@ -515,7 +515,7 @@ client::CancellationToken AuthenticationClient::Impl::HandleUserRequest(
         }
       });
 
-  if (!send_outcome.IsSuccessfull()) {
+  if (!send_outcome.IsSuccessful()) {
     ExecuteOrSchedule(task_scheduler_, [send_outcome, callback] {
       std::string error_message =
           ErrorCodeToString(send_outcome.GetErrorCode());
@@ -586,7 +586,7 @@ client::CancellationToken AuthenticationClient::Impl::SignUpHereUser(
                        callback(response);
                      });
 
-  if (!send_outcome.IsSuccessfull()) {
+  if (!send_outcome.IsSuccessful()) {
     ExecuteOrSchedule(task_scheduler_, [send_outcome, callback] {
       std::string error_message =
           ErrorCodeToString(send_outcome.GetErrorCode());
@@ -655,7 +655,7 @@ client::CancellationToken AuthenticationClient::Impl::SignOut(
                        callback(response);
                      });
 
-  if (!send_outcome.IsSuccessfull()) {
+  if (!send_outcome.IsSuccessful()) {
     ExecuteOrSchedule(task_scheduler_, [send_outcome, callback] {
       std::string error_message =
           ErrorCodeToString(send_outcome.GetErrorCode());

--- a/olp-cpp-sdk-core/include/olp/core/http/NetworkTypes.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/NetworkTypes.h
@@ -90,11 +90,11 @@ class SendOutcome final {
   explicit SendOutcome(ErrorCode error_code) : error_code_(error_code) {}
 
   /**
-   * @brief Check if network request push was successfull.
+   * @brief Check if network request push was successful.
    * @return \c true in case there is no error and a valid RequestId, \c false
    * otherwise.
    */
-  bool IsSuccessfull() const {
+  bool IsSuccessful() const {
     return error_code_ == ErrorCode::SUCCESS &&
            request_id_ != kInvalidRequestId;
   }

--- a/olp-cpp-sdk-core/src/client/OlpClient.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClient.cpp
@@ -94,7 +94,7 @@ CancellationToken ExecuteSingleRequest(
         callback(result);
       });
 
-  if (!send_outcome.IsSuccessfull()) {
+  if (!send_outcome.IsSuccessful()) {
     std::string error_message = ErrorCodeToString(send_outcome.GetErrorCode());
     HttpResponse result{static_cast<int>(send_outcome.GetErrorCode()),
                         std::move(error_message)};

--- a/tests/functional/olp-cpp-sdk-core/NetworkTest.cpp
+++ b/tests/functional/olp-cpp-sdk-core/NetworkTest.cpp
@@ -49,7 +49,7 @@ TEST(NetworkTest, GetRequest) {
         cv.notify_one();
       });
 
-  ASSERT_TRUE(outcome.IsSuccessfull());
+  ASSERT_TRUE(outcome.IsSuccessful());
 
   std::unique_lock<std::mutex> lock(m);
   ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(1)) ==


### PR DESCRIPTION
Renamed the SendOutcome::IsSuccessfull into SendOutcome::IsSuccessful.

Resolves: OLPEDGE-897

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>