### PR TITLE
Align cache according to requirements, dataservice write.

### DIFF
--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClient.cpp
@@ -17,10 +17,10 @@
  * License-Filename: LICENSE
  */
 
-#include <olp/dataservice/write/StreamLayerClient.h>
+#include "olp/dataservice/write/StreamLayerClient.h"
 
 #include <olp/core/cache/DefaultCache.h>
-
+#include <olp/core/client/OlpClientSettingsFactory.h>
 #include "StreamLayerClientImpl.h"
 
 namespace olp {
@@ -37,10 +37,12 @@ std::shared_ptr<cache::KeyValueCache> CreateDefaultCache(
 StreamLayerClient::StreamLayerClient(client::HRN catalog,
                                      client::OlpClientSettings settings,
                                      FlushSettings flush_settings) {
-  auto cache = settings.cache;
+  if (!settings.cache) {
+    settings.cache = client::OlpClientSettingsFactory::CreateDefaultCache({});
+  }
+
   impl_ = std::make_shared<StreamLayerClientImpl>(
-      std::move(catalog), std::move(settings), std::move(cache),
-      std::move(flush_settings));
+      std::move(catalog), std::move(settings), std::move(flush_settings));
 }
 
 olp::client::CancellableFuture<PublishDataResponse>

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
@@ -74,13 +74,12 @@ void ExecuteOrSchedule(const OlpClientSettings& settings,
 }
 }  // namespace
 
-StreamLayerClientImpl::StreamLayerClientImpl(
-    const HRN& catalog, const OlpClientSettings& settings,
-    const std::shared_ptr<cache::KeyValueCache>& cache,
-    const FlushSettings& flush_settings)
-    : catalog_(catalog),
+StreamLayerClientImpl::StreamLayerClientImpl(HRN catalog,
+                                             OlpClientSettings settings,
+                                             FlushSettings flush_settings)
+    : catalog_(std::move(catalog)),
       catalog_model_(),
-      settings_(settings),
+      settings_(std::move(settings)),
       apiclient_config_(nullptr),
       apiclient_ingest_(nullptr),
       apiclient_blob_(nullptr),
@@ -88,9 +87,9 @@ StreamLayerClientImpl::StreamLayerClientImpl(
       init_mutex_(),
       init_cv_(),
       init_inprogress_(false),
-      cache_(cache),
+      cache_(settings_.cache),
       cache_mutex_(),
-      flush_settings_(flush_settings),
+      flush_settings_(std::move(flush_settings)),
       auto_flush_controller_(new AutoFlushController(flush_settings_)) {}
 
 CancellationToken StreamLayerClientImpl::InitApiClients(

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.h
@@ -46,10 +46,8 @@ using InitCatalogModelCallback =
 class StreamLayerClientImpl
     : public std::enable_shared_from_this<StreamLayerClientImpl> {
  public:
-  StreamLayerClientImpl(const client::HRN& catalog,
-                        const client::OlpClientSettings& settings,
-                        const std::shared_ptr<cache::KeyValueCache>& cache,
-                        const FlushSettings& flush_settings);
+  StreamLayerClientImpl(client::HRN catalog, client::OlpClientSettings settings,
+                        FlushSettings flush_settings);
 
   olp::client::CancellableFuture<PublishDataResponse> PublishData(
       const model::PublishDataRequest& request);


### PR DESCRIPTION
If the user do not provide a default cache, SDK will create a default one.

Resolves: OLPEDGE-873

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>