### PR TITLE
VersionedLayerClient class implementation

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -33,6 +33,7 @@
 namespace olp {
 namespace dataservice {
 namespace read {
+class VersionedLayerClientImpl;
 
 /**
  * @brief The VersionedLayerClient aimed to acquire data from OLP services.
@@ -41,12 +42,10 @@ class DATASERVICE_READ_API VersionedLayerClient final {
  public:
   /// DataResult alias
   using DataResult = model::Data;
-  /// ApiResponse template alias
-  template <typename Result>
-  using CallbackResponse = client::ApiResponse<Result, client::ApiError>;
-  /// Callback template alias
-  template <typename Response>
-  using Callback = std::function<void(CallbackResponse<Response> response)>;
+  /// CallbackResponse alias
+  using CallbackResponse = client::ApiResponse<DataResult, client::ApiError>;
+  /// Callback alias
+  using Callback = std::function<void(CallbackResponse response)>;
 
   /**
    * @brief VersionedLayerClient constructor
@@ -67,16 +66,17 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    * error). If neither Partition Id or Data Handle were set in the request, the
    * callback will be invoked with an error with ErrorCode::InvalidRequest.
    * @param data_request contains the complete set of request parameters.
+   * \note \c DataRequest's GetLayerId value will be ignored and the parameter
+   * from the constructor will be used instead.
    * @param callback will be invoked once the DataResult is available, or an
    * error is encountered.
    * @return A token that can be used to cancel this request.
    */
   olp::client::CancellationToken GetData(DataRequest data_request,
-                                         Callback<DataResult> callback);
+                                         Callback callback);
 
  private:
-  class Impl;
-  std::unique_ptr<Impl> impl_;
+  std::unique_ptr<VersionedLayerClientImpl> impl_;
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "olp/dataservice/read/VersionedLayerClient.h"
+
+#include <olp/core/porting/make_unique.h>
+#include "VersionedLayerClientImpl.h"
+
+namespace olp {
+namespace dataservice {
+namespace read {
+
+VersionedLayerClient::VersionedLayerClient(
+    olp::client::HRN catalog, std::string layer_id,
+    olp::client::OlpClientSettings client_settings)
+    : impl_(std::make_unique<VersionedLayerClientImpl>(
+          std::move(catalog), std::move(layer_id),
+          std::move(client_settings))) {}
+
+VersionedLayerClient::~VersionedLayerClient() = default;
+
+olp::client::CancellationToken VersionedLayerClient::GetData(
+    DataRequest data_request, Callback callback) {
+  return impl_->GetData(std::move(data_request), std::move(callback));
+}
+
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "VersionedLayerClientImpl.h"
+
+#include <olp/core/cache/DefaultCache.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/context/Context.h>
+#include <olp/core/thread/TaskScheduler.h>
+#include "repositories/CatalogRepository.h"
+#include "repositories/DataRepository.h"
+#include "repositories/ExecuteOrSchedule.inl"
+#include "repositories/PartitionsRepository.h"
+
+namespace olp {
+namespace dataservice {
+namespace read {
+
+VersionedLayerClientImpl::VersionedLayerClientImpl(
+    olp::client::HRN catalog, std::string layer_id,
+    olp::client::OlpClientSettings client_settings)
+    : catalog_(std::move(catalog)),
+      layer_id_(std::move(layer_id)),
+      settings_(std::move(client_settings)),
+      pending_requests_(std::make_shared<PendingRequests>()) {
+  if (!settings_.cache) {
+    settings_.cache =
+        olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
+  }
+  // to avoid capturing task scheduler inside a task, we need a copy of settings
+  // without the scheduler
+  task_scheduler_ = std::move(settings_.task_scheduler);
+}
+
+VersionedLayerClientImpl::~VersionedLayerClientImpl() {
+  pending_requests_->CancelPendingRequests();
+}
+
+olp::client::CancellationToken VersionedLayerClientImpl::GetData(
+    DataRequest data_request, Callback callback) const {
+  auto fetch_option = data_request.GetFetchOption();
+  if (fetch_option == CacheWithUpdate) {
+    auto cache_token = AddGetDataTask(data_request.WithFetchOption(CacheOnly),
+                                      std::move(callback));
+    auto online_token =
+        AddGetDataTask(data_request.WithFetchOption(OnlineIfNotFound), nullptr);
+    return client::CancellationToken([cache_token, online_token]() {
+      cache_token.cancel();
+      online_token.cancel();
+    });
+  } else {
+    return AddGetDataTask(data_request, std::move(callback));
+  }
+}
+
+client::CancellationToken VersionedLayerClientImpl::AddGetDataTask(
+    DataRequest data_request, Callback callback) const {
+  auto catalog = catalog_;
+  auto layer_id = layer_id_;
+  auto settings = settings_;
+  auto pending_requests = pending_requests_;
+  auto request_key = pending_requests->GenerateRequestPlaceholder();
+  olp::client::CancellationContext context;
+  olp::client::CancellationToken token(
+      [context]() mutable { context.CancelOperation(); });
+
+  pending_requests->Insert(token, request_key);
+
+  repository::ExecuteOrSchedule(
+      task_scheduler_, [catalog, layer_id, settings, context, data_request,
+                        pending_requests, request_key, callback]() {
+        auto response = repository::DataRepository::GetVersionedData(
+            std::move(catalog), std::move(layer_id), std::move(settings),
+            std::move(data_request), std::move(context));
+        pending_requests->Remove(request_key);
+        if (callback) {
+          callback(std::move(response));
+        }
+      });
+
+  return token;
+}
+
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <PendingRequests.h>
+#include <olp/core/client/ApiError.h>
+#include <olp/core/client/ApiResponse.h>
+#include <olp/core/client/CancellationContext.h>
+#include <olp/core/client/CancellationToken.h>
+#include <olp/core/client/HRN.h>
+#include <olp/core/client/OlpClientSettings.h>
+#include <olp/dataservice/read/DataRequest.h>
+#include <olp/dataservice/read/model/Data.h>
+
+namespace olp {
+namespace thread {
+class TaskScheduler;
+}
+
+namespace dataservice {
+namespace read {
+
+class VersionedLayerClientImpl {
+ public:
+  /// DataResult alias
+  using DataResult = model::Data;
+  /// CallbackResponse alias
+  using CallbackResponse = client::ApiResponse<DataResult, client::ApiError>;
+  /// Callback alias
+  using Callback = std::function<void(CallbackResponse response)>;
+
+  VersionedLayerClientImpl(olp::client::HRN catalog, std::string layer_id,
+                           olp::client::OlpClientSettings client_settings);
+
+  virtual ~VersionedLayerClientImpl();
+
+  virtual olp::client::CancellationToken GetData(DataRequest data_request,
+                                                 Callback callback) const;
+
+ private:
+  olp::client::CancellationToken AddGetDataTask(DataRequest data_request,
+                                                Callback callback) const;
+
+ protected:
+  olp::client::HRN catalog_;
+  std::string layer_id_;
+  olp::client::OlpClientSettings settings_;
+  std::shared_ptr<thread::TaskScheduler> task_scheduler_;
+  std::shared_ptr<PendingRequests> pending_requests_;
+};
+
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
@@ -54,6 +54,11 @@ class DataRepository final {
                const std::string& layerType, const read::DataRequest& request,
                const read::DataResponseCallback& callback);
 
+  static DataResponse GetVersionedData(
+      olp::client::HRN catalog, std::string layer_id,
+      olp::client::OlpClientSettings client_settings, DataRequest data_request,
+      olp::client::CancellationContext context);
+
   static DataResponse GetBlobData(
       const client::HRN& catalog, const std::string& layer,
       const std::string& service, const DataRequest& data_request,

--- a/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ set(OLP_SDK_DATASERVICE_READ_TEST_SOURCES
     SerializerTest.cpp
     VolatileLayerClientImplTest.cpp
     VolatileLayerClientTest.cpp
+    VersionedLayerClientTest.cpp
 )
 
 if (ANDROID OR IOS)

--- a/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientTest.cpp
@@ -1,0 +1,580 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gmock/gmock.h>
+#include <chrono>
+#include <string>
+
+#include <mocks/NetworkMock.h>
+#include <olp/authentication/Settings.h>
+#include <olp/core/client/OlpClientSettings.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/http/NetworkRequest.h>
+#include <olp/core/http/NetworkResponse.h>
+#include <olp/core/logging/Log.h>
+#include <olp/core/porting/make_unique.h>
+#include <olp/dataservice/read/VersionedLayerClient.h>
+
+using namespace olp::dataservice::read;
+using namespace olp::tests::common;
+using namespace testing;
+
+namespace {
+
+constexpr char kHttpResponseLookupQuery[] =
+    R"jsonString([{"api":"query","version":"v1","baseURL":"https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2","parameters":{}}])jsonString";
+
+constexpr char kHttpResponsePartition_269[] =
+    R"jsonString({ "partitions": [{"version":4,"partition":"269","layer":"testlayer","dataHandle":"4eed6ed1-0d32-43b9-ae79-043cb4256432"}]})jsonString";
+
+constexpr char kHttpResponsePartitionsEmpty[] =
+    R"jsonString({ "partitions": []})jsonString";
+
+constexpr char kHttpResponseLookupBlob[] =
+    R"jsonString([{"api":"blob","version":"v1","baseURL":"https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2","parameters":{}}])jsonString";
+
+constexpr char kHttpResponseBlobData_269[] =
+    R"jsonString(DT_2_0031)jsonString";
+
+constexpr char kHttpResponseLatestCatalogVersion[] =
+    R"jsonString({"version":4})jsonString";
+
+constexpr auto kWaitTimeout = std::chrono::seconds(1);
+
+class DataserviceReadVersionedLayerClientTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    network_mock_ = std::make_shared<NetworkMock>();
+
+    settings_ = std::make_shared<olp::client::OlpClientSettings>();
+    settings_->network_request_handler = network_mock_;
+    settings_->task_scheduler =
+        olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler(1);
+  }
+
+  void TearDown() override {
+    testing::Mock::VerifyAndClearExpectations(network_mock_.get());
+    network_mock_.reset();
+    settings_->task_scheduler.reset();
+    settings_.reset();
+  }
+
+  std::string GetArgument(const std::string& name) {
+    if (name == "dataservice_read_test_catalog") {
+      return "hrn:here:data:::here-optimized-map-for-visualization-2";
+    } else if (name == "dataservice_read_test_layer") {
+      return "omv-base-v2";
+    } else if (name == "dataservice_read_test_partition") {
+      return "269";
+    } else if (name == "dataservice_read_test_layer_version") {
+      return "108";
+    }
+    ADD_FAILURE() << "unknown argument!";
+    return "";
+  }
+
+ protected:
+  std::shared_ptr<olp::client::OlpClientSettings> settings_;
+  std::shared_ptr<NetworkMock> network_mock_;
+};
+
+TEST_F(DataserviceReadVersionedLayerClientTest, GetDataFromPartitionAsync) {
+  EXPECT_CALL(*network_mock_, Send(_, _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseLookupQuery))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponsePartition_269))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseLookupBlob))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseBlobData_269));
+
+  auto catalog = olp::client::HRN::FromString(
+      GetArgument("dataservice_read_test_catalog"));
+  auto layer = GetArgument("dataservice_read_test_layer");
+  auto version = std::stoi(GetArgument("dataservice_read_test_layer_version"));
+
+  auto catalog_client =
+      std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+          catalog, layer, *settings_);
+  ASSERT_TRUE(catalog_client);
+
+  std::promise<VersionedLayerClient::CallbackResponse> promise;
+  std::future<VersionedLayerClient::CallbackResponse> future =
+      promise.get_future();
+  auto partition = GetArgument("dataservice_read_test_partition");
+  auto token = catalog_client->GetData(
+      olp::dataservice::read::DataRequest()
+          .WithVersion(version)
+          .WithPartitionId(partition),
+      [&promise](VersionedLayerClient::CallbackResponse response) {
+        promise.set_value(response);
+      });
+
+  ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
+  VersionedLayerClient::CallbackResponse response = future.get();
+
+  ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
+  ASSERT_NE(response.GetResult(), nullptr);
+  ASSERT_NE(response.GetResult()->size(), 0u);
+}
+
+TEST_F(DataserviceReadVersionedLayerClientTest, GetDataFromPartitionSync) {
+  EXPECT_CALL(*network_mock_, Send(_, _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseLookupQuery))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponsePartition_269))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseLookupBlob))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseBlobData_269));
+
+  auto catalog = olp::client::HRN::FromString(
+      GetArgument("dataservice_read_test_catalog"));
+  auto layer = GetArgument("dataservice_read_test_layer");
+  auto version = 0;
+
+  auto sync_settings = *settings_;
+  sync_settings.task_scheduler.reset();
+  auto catalog_client =
+      std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+          catalog, layer, sync_settings);
+  ASSERT_TRUE(catalog_client);
+
+  VersionedLayerClient::CallbackResponse response;
+
+  auto partition = GetArgument("dataservice_read_test_partition");
+  auto token = catalog_client->GetData(
+      olp::dataservice::read::DataRequest()
+          .WithVersion(version)
+          .WithPartitionId(partition),
+      [&response](VersionedLayerClient::CallbackResponse resp) {
+        response = std::move(resp);
+      });
+  ASSERT_TRUE(response.IsSuccessful());
+  ASSERT_TRUE(response.GetResult() != nullptr);
+  ASSERT_NE(response.GetResult()->size(), 0u);
+}
+
+TEST_F(DataserviceReadVersionedLayerClientTest,
+       GetDataFromPartitionSyncLatestVersionOk) {
+  EXPECT_CALL(*network_mock_, Send(_, _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseLookupQuery))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseLatestCatalogVersion))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseLookupQuery))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponsePartition_269))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseLookupBlob))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseBlobData_269));
+
+  auto catalog = olp::client::HRN::FromString(
+      GetArgument("dataservice_read_test_catalog"));
+  auto layer = GetArgument("dataservice_read_test_layer");
+
+  auto sync_settings = *settings_;
+  sync_settings.task_scheduler.reset();
+  auto catalog_client =
+      std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+          catalog, layer, sync_settings);
+  ASSERT_TRUE(catalog_client);
+
+  VersionedLayerClient::CallbackResponse response;
+
+  auto partition = GetArgument("dataservice_read_test_partition");
+  auto token = catalog_client->GetData(
+      olp::dataservice::read::DataRequest()
+          .WithVersion(boost::none)
+          .WithPartitionId(partition),
+      [&response](VersionedLayerClient::CallbackResponse resp) {
+        response = std::move(resp);
+      });
+  ASSERT_TRUE(response.IsSuccessful());
+  ASSERT_TRUE(response.GetResult() != nullptr);
+  ASSERT_NE(response.GetResult()->size(), 0u);
+}
+
+TEST_F(DataserviceReadVersionedLayerClientTest,
+       GetDataFromPartitionSyncLatestVersionInvalid) {
+  EXPECT_CALL(*network_mock_, Send(_, _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseLookupQuery))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::FORBIDDEN),
+                                   kHttpResponseLatestCatalogVersion));
+
+  auto catalog = olp::client::HRN::FromString(
+      GetArgument("dataservice_read_test_catalog"));
+  auto layer = GetArgument("dataservice_read_test_layer");
+
+  auto sync_settings = *settings_;
+  sync_settings.task_scheduler.reset();
+  auto catalog_client =
+      std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+          catalog, layer, sync_settings);
+  ASSERT_TRUE(catalog_client);
+
+  VersionedLayerClient::CallbackResponse response;
+
+  auto partition = GetArgument("dataservice_read_test_partition");
+  auto token = catalog_client->GetData(
+      olp::dataservice::read::DataRequest()
+          .WithVersion(boost::none)
+          .WithPartitionId(partition),
+      [&response](VersionedLayerClient::CallbackResponse resp) {
+        response = std::move(resp);
+      });
+  ASSERT_FALSE(response.IsSuccessful());
+  ASSERT_FALSE(response.GetResult() != nullptr);
+}
+
+TEST_F(DataserviceReadVersionedLayerClientTest,
+       GetDataFromPartitionCacheAndUpdateSync) {
+  EXPECT_CALL(*network_mock_, Send(_, _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseLookupQuery))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponsePartition_269))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseLookupBlob))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseBlobData_269));
+
+  auto catalog = olp::client::HRN::FromString(
+      GetArgument("dataservice_read_test_catalog"));
+  auto layer = GetArgument("dataservice_read_test_layer");
+  auto version = 0;
+
+  auto sync_settings = *settings_;
+  sync_settings.task_scheduler.reset();
+  auto catalog_client =
+      std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+          catalog, layer, sync_settings);
+  ASSERT_TRUE(catalog_client);
+
+  VersionedLayerClient::CallbackResponse response;
+
+  auto partition = GetArgument("dataservice_read_test_partition");
+  auto token = catalog_client->GetData(
+      olp::dataservice::read::DataRequest()
+          .WithVersion(version)
+          .WithPartitionId(partition)
+          .WithFetchOption(FetchOptions::CacheWithUpdate),
+      [&response](VersionedLayerClient::CallbackResponse resp) {
+        response = std::move(resp);
+      });
+  ASSERT_FALSE(response.IsSuccessful());
+  ASSERT_FALSE(response.GetResult() != nullptr);
+
+  token = catalog_client->GetData(
+      olp::dataservice::read::DataRequest()
+          .WithVersion(version)
+          .WithPartitionId(partition)
+          .WithFetchOption(FetchOptions::CacheOnly),
+      [&response](VersionedLayerClient::CallbackResponse resp) {
+        response = std::move(resp);
+      });
+  ASSERT_TRUE(response.IsSuccessful());
+  ASSERT_TRUE(response.GetResult() != nullptr);
+  ASSERT_NE(response.GetResult()->size(), 0u);
+}
+
+TEST_F(DataserviceReadVersionedLayerClientTest, GetDataEmptyPartitionsSync) {
+  EXPECT_CALL(*network_mock_, Send(_, _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseLookupQuery))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponsePartitionsEmpty));
+
+  auto catalog = olp::client::HRN::FromString(
+      GetArgument("dataservice_read_test_catalog"));
+  auto layer = GetArgument("dataservice_read_test_layer");
+  auto version = 0;
+
+  auto sync_settings = *settings_;
+  sync_settings.task_scheduler.reset();
+  auto catalog_client =
+      std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+          catalog, layer, sync_settings);
+  ASSERT_TRUE(catalog_client);
+
+  VersionedLayerClient::CallbackResponse response;
+
+  auto partition = GetArgument("dataservice_read_test_partition");
+  auto token = catalog_client->GetData(
+      olp::dataservice::read::DataRequest()
+          .WithVersion(version)
+          .WithPartitionId(partition),
+      [&response](VersionedLayerClient::CallbackResponse resp) {
+        response = std::move(resp);
+      });
+  ASSERT_FALSE(response.IsSuccessful());
+  ASSERT_FALSE(response.GetResult() != nullptr);
+}
+
+TEST_F(DataserviceReadVersionedLayerClientTest,
+       GetDataFromPartitionCancelLookup) {
+  auto wait_for_cancel = std::make_shared<std::promise<void>>();
+  auto pause_for_cancel = std::make_shared<std::promise<void>>();
+
+  olp::http::RequestId request_id;
+  NetworkCallback send_mock;
+  CancelCallback cancel_mock;
+  std::tie(request_id, send_mock, cancel_mock) = GenerateNetworkMockActions(
+      wait_for_cancel, pause_for_cancel,
+      {olp::http::HttpStatusCode::OK, kHttpResponseLookupQuery});
+
+  EXPECT_CALL(*network_mock_, Send(_, _, _, _, _))
+      .WillOnce(testing::Invoke(std::move(send_mock)));
+
+  EXPECT_CALL(*network_mock_, Cancel(_))
+      .WillOnce(testing::Invoke(std::move(cancel_mock)));
+
+  auto catalog = olp::client::HRN::FromString(
+      GetArgument("dataservice_read_test_catalog"));
+  auto layer = GetArgument("dataservice_read_test_layer");
+  auto version = std::stoi(GetArgument("dataservice_read_test_layer_version"));
+
+  auto catalog_client =
+      std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+          catalog, layer, *settings_);
+  ASSERT_TRUE(catalog_client);
+
+  std::promise<VersionedLayerClient::CallbackResponse> promise;
+  std::future<VersionedLayerClient::CallbackResponse> future =
+      promise.get_future();
+  auto partition = GetArgument("dataservice_read_test_partition");
+  auto token = catalog_client->GetData(
+      olp::dataservice::read::DataRequest()
+          .WithVersion(version)
+          .WithPartitionId(partition),
+      [&promise](VersionedLayerClient::CallbackResponse response) {
+        promise.set_value(response);
+      });
+
+  wait_for_cancel->get_future().get();
+  token.cancel();
+  pause_for_cancel->set_value();
+
+  ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
+  VersionedLayerClient::CallbackResponse response = future.get();
+
+  ASSERT_FALSE(response.IsSuccessful()) << response.GetError().GetMessage();
+  ASSERT_TRUE(response.GetResult() == nullptr);
+}
+
+TEST_F(DataserviceReadVersionedLayerClientTest,
+       GetDataFromPartitionCancelPartition) {
+  auto wait_for_cancel = std::make_shared<std::promise<void>>();
+  auto pause_for_cancel = std::make_shared<std::promise<void>>();
+
+  olp::http::RequestId request_id;
+  NetworkCallback send_mock;
+  CancelCallback cancel_mock;
+  std::tie(request_id, send_mock, cancel_mock) = GenerateNetworkMockActions(
+      wait_for_cancel, pause_for_cancel,
+      {olp::http::HttpStatusCode::OK, kHttpResponsePartition_269});
+
+  EXPECT_CALL(*network_mock_, Send(_, _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseLookupQuery))
+      .WillOnce(testing::Invoke(std::move(send_mock)));
+
+  EXPECT_CALL(*network_mock_, Cancel(_))
+      .WillOnce(testing::Invoke(std::move(cancel_mock)));
+
+  auto catalog = olp::client::HRN::FromString(
+      GetArgument("dataservice_read_test_catalog"));
+  auto layer = GetArgument("dataservice_read_test_layer");
+  auto version = std::stoi(GetArgument("dataservice_read_test_layer_version"));
+
+  auto catalog_client =
+      std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+          catalog, layer, *settings_);
+  ASSERT_TRUE(catalog_client);
+
+  std::promise<VersionedLayerClient::CallbackResponse> promise;
+  std::future<VersionedLayerClient::CallbackResponse> future =
+      promise.get_future();
+  auto partition = GetArgument("dataservice_read_test_partition");
+  auto token = catalog_client->GetData(
+      olp::dataservice::read::DataRequest()
+          .WithVersion(version)
+          .WithPartitionId(partition),
+      [&promise](VersionedLayerClient::CallbackResponse response) {
+        promise.set_value(response);
+      });
+
+  wait_for_cancel->get_future().get();
+  token.cancel();
+  pause_for_cancel->set_value();
+
+  ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
+  VersionedLayerClient::CallbackResponse response = future.get();
+
+  ASSERT_FALSE(response.IsSuccessful()) << response.GetError().GetMessage();
+  ASSERT_TRUE(response.GetResult() == nullptr);
+}
+
+TEST_F(DataserviceReadVersionedLayerClientTest,
+       GetDataFromPartitionCancelLookupBlob) {
+  auto wait_for_cancel = std::make_shared<std::promise<void>>();
+  auto pause_for_cancel = std::make_shared<std::promise<void>>();
+
+  olp::http::RequestId request_id;
+  NetworkCallback send_mock;
+  CancelCallback cancel_mock;
+  std::tie(request_id, send_mock, cancel_mock) = GenerateNetworkMockActions(
+      wait_for_cancel, pause_for_cancel,
+      {olp::http::HttpStatusCode::OK, kHttpResponseLookupBlob});
+
+  EXPECT_CALL(*network_mock_, Send(_, _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseLookupQuery))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponsePartition_269))
+      .WillOnce(testing::Invoke(std::move(send_mock)));
+
+  EXPECT_CALL(*network_mock_, Cancel(_))
+      .WillOnce(testing::Invoke(std::move(cancel_mock)));
+
+  auto catalog = olp::client::HRN::FromString(
+      GetArgument("dataservice_read_test_catalog"));
+  auto layer = GetArgument("dataservice_read_test_layer");
+  auto version = std::stoi(GetArgument("dataservice_read_test_layer_version"));
+
+  auto catalog_client =
+      std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+          catalog, layer, *settings_);
+  ASSERT_TRUE(catalog_client);
+
+  std::promise<VersionedLayerClient::CallbackResponse> promise;
+  std::future<VersionedLayerClient::CallbackResponse> future =
+      promise.get_future();
+  auto partition = GetArgument("dataservice_read_test_partition");
+  auto token = catalog_client->GetData(
+      olp::dataservice::read::DataRequest()
+          .WithVersion(version)
+          .WithPartitionId(partition),
+      [&promise](VersionedLayerClient::CallbackResponse response) {
+        promise.set_value(response);
+      });
+
+  wait_for_cancel->get_future().get();
+  token.cancel();
+  pause_for_cancel->set_value();
+
+  ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
+  VersionedLayerClient::CallbackResponse response = future.get();
+
+  ASSERT_FALSE(response.IsSuccessful()) << response.GetError().GetMessage();
+  ASSERT_TRUE(response.GetResult() == nullptr);
+}
+
+TEST_F(DataserviceReadVersionedLayerClientTest,
+       GetDataFromPartitionCancelBlobData) {
+  auto wait_for_cancel = std::make_shared<std::promise<void>>();
+  auto pause_for_cancel = std::make_shared<std::promise<void>>();
+
+  olp::http::RequestId request_id;
+  NetworkCallback send_mock;
+  CancelCallback cancel_mock;
+  std::tie(request_id, send_mock, cancel_mock) = GenerateNetworkMockActions(
+      wait_for_cancel, pause_for_cancel,
+      {olp::http::HttpStatusCode::OK, kHttpResponseBlobData_269});
+
+  EXPECT_CALL(*network_mock_, Send(_, _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseLookupQuery))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponsePartition_269))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseLookupBlob))
+      .WillOnce(testing::Invoke(std::move(send_mock)));
+
+  EXPECT_CALL(*network_mock_, Cancel(_))
+      .WillOnce(testing::Invoke(std::move(cancel_mock)));
+
+  auto catalog = olp::client::HRN::FromString(
+      GetArgument("dataservice_read_test_catalog"));
+  auto layer = GetArgument("dataservice_read_test_layer");
+  auto version = std::stoi(GetArgument("dataservice_read_test_layer_version"));
+
+  auto catalog_client =
+      std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+          catalog, layer, *settings_);
+  ASSERT_TRUE(catalog_client);
+
+  std::promise<VersionedLayerClient::CallbackResponse> promise;
+  std::future<VersionedLayerClient::CallbackResponse> future =
+      promise.get_future();
+  auto partition = GetArgument("dataservice_read_test_partition");
+  auto token = catalog_client->GetData(
+      olp::dataservice::read::DataRequest()
+          .WithVersion(version)
+          .WithPartitionId(partition)
+          .WithFetchOption(FetchOptions::CacheWithUpdate),
+      [&promise](VersionedLayerClient::CallbackResponse response) {
+        promise.set_value(response);
+      });
+
+  wait_for_cancel->get_future().get();
+  token.cancel();
+  pause_for_cancel->set_value();
+
+  ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
+  VersionedLayerClient::CallbackResponse response = future.get();
+
+  ASSERT_FALSE(response.IsSuccessful()) << response.GetError().GetMessage();
+  ASSERT_TRUE(response.GetResult() == nullptr);
+}
+
+}  // namespace

--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -22,6 +22,7 @@ set(OLP_SDK_FUNCTIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-core/OlpClientDefaultAsyncHttpTest.cpp
     ./olp-cpp-sdk-dataservice-read/ApiTest.cpp
     ./olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
+    ./olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
     ./olp-cpp-sdk-dataservice-write/DataserviceWriteIndexLayerClientTest.cpp
     ./olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientCacheTest.cpp
     ./olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientTest.cpp

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gmock/gmock.h>
+#include <chrono>
+#include <string>
+
+#include <olp/authentication/AuthenticationCredentials.h>
+#include <olp/authentication/Settings.h>
+#include <olp/authentication/TokenProvider.h>
+#include <olp/core/client/OlpClientSettings.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/logging/Log.h>
+#include <olp/core/porting/make_unique.h>
+#include <olp/dataservice/read/VersionedLayerClient.h>
+#include <testutils/CustomParameters.hpp>
+
+using namespace olp::dataservice::read;
+using namespace testing;
+
+namespace {
+
+constexpr auto kWaitTimeout = std::chrono::seconds(10);
+
+class DataserviceReadVersionedLayerClientTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto network = olp::client::OlpClientSettingsFactory::
+        CreateDefaultNetworkRequestHandler();
+
+    auto appid = CustomParameters::getArgument("dataservice_read_test_appid");
+    auto secret = CustomParameters::getArgument("dataservice_read_test_secret");
+    olp::authentication::Settings auth_settings({appid, secret});
+    auth_settings.network_request_handler = network;
+
+    olp::client::AuthenticationSettings auth_client_settings;
+
+    settings_ = std::make_shared<olp::client::OlpClientSettings>();
+    settings_->network_request_handler = network;
+    settings_->authentication_settings = auth_client_settings;
+  }
+
+  void TearDown() override {
+    auto network = std::move(settings_->network_request_handler);
+    settings_.reset();
+    // when test ends we must be sure that network pointer is not captured
+    // anywhere
+    ASSERT_EQ(network.use_count(), 1);
+  }
+
+ protected:
+  std::shared_ptr<olp::client::OlpClientSettings> settings_;
+};
+
+TEST_F(DataserviceReadVersionedLayerClientTest, GetDataFromPartitionAsync) {
+  settings_->task_scheduler =
+      olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler(1);
+
+  auto catalog = olp::client::HRN::FromString(
+      CustomParameters::getArgument("dataservice_read_test_catalog"));
+  auto layer = CustomParameters::getArgument("dataservice_read_test_layer");
+  auto version = std::stoi(
+      CustomParameters::getArgument("dataservice_read_test_layer_version"));
+
+  auto catalog_client =
+      std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+          catalog, layer, *settings_);
+  ASSERT_TRUE(catalog_client);
+
+  std::promise<VersionedLayerClient::CallbackResponse> promise;
+  std::future<VersionedLayerClient::CallbackResponse> future =
+      promise.get_future();
+  auto partition =
+      CustomParameters::getArgument("dataservice_read_test_partition");
+  auto token = catalog_client->GetData(
+      olp::dataservice::read::DataRequest()
+          .WithVersion(version)
+          .WithPartitionId(partition),
+      [&promise](VersionedLayerClient::CallbackResponse response) {
+        promise.set_value(response);
+      });
+
+  ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
+  VersionedLayerClient::CallbackResponse response = future.get();
+
+  ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
+  ASSERT_TRUE(response.GetResult() != nullptr);
+  ASSERT_NE(response.GetResult()->size(), 0u);
+}
+
+TEST_F(DataserviceReadVersionedLayerClientTest,
+       GetDataFromPartitionLatestVersionAsync) {
+  settings_->task_scheduler =
+      olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler(1);
+
+  auto catalog = olp::client::HRN::FromString(
+      CustomParameters::getArgument("dataservice_read_test_catalog"));
+  auto layer = CustomParameters::getArgument("dataservice_read_test_layer");
+
+  auto catalog_client =
+      std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+          catalog, layer, *settings_);
+  ASSERT_TRUE(catalog_client);
+
+  std::promise<VersionedLayerClient::CallbackResponse> promise;
+  std::future<VersionedLayerClient::CallbackResponse> future =
+      promise.get_future();
+  auto partition =
+      CustomParameters::getArgument("dataservice_read_test_partition");
+  auto token = catalog_client->GetData(
+      olp::dataservice::read::DataRequest().WithPartitionId(partition),
+      [&promise](VersionedLayerClient::CallbackResponse response) {
+        promise.set_value(response);
+      });
+
+  ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
+  VersionedLayerClient::CallbackResponse response = future.get();
+
+  ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
+  ASSERT_TRUE(response.GetResult() != nullptr);
+  ASSERT_NE(response.GetResult()->size(), 0u);
+}
+
+TEST_F(DataserviceReadVersionedLayerClientTest, GetDataFromPartitionSync) {
+  auto catalog = olp::client::HRN::FromString(
+      CustomParameters::getArgument("dataservice_read_test_catalog"));
+  auto layer = CustomParameters::getArgument("dataservice_read_test_layer");
+  auto version = 0;
+
+  auto catalog_client =
+      std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+          catalog, layer, *settings_);
+  ASSERT_TRUE(catalog_client);
+
+  VersionedLayerClient::CallbackResponse response;
+  auto partition =
+      CustomParameters::getArgument("dataservice_read_test_partition");
+  auto token = catalog_client->GetData(
+      olp::dataservice::read::DataRequest()
+          .WithVersion(version)
+          .WithPartitionId(partition),
+      [&response](VersionedLayerClient::CallbackResponse resp) {
+        response = std::move(resp);
+      });
+  ASSERT_TRUE(response.IsSuccessful());
+  ASSERT_TRUE(response.GetResult() != nullptr);
+  ASSERT_NE(response.GetResult()->size(), 0u);
+}
+
+}  // namespace


### PR DESCRIPTION
The class' GetData method is introduced.
It fetches data from a layer using a partition id or data handle.
The data is fetched asynchronously if the task scheduler is set
properly. The synchronous implementation of the logic is placed to
DataRepository::GetData() as it fits better from an architectural
point of view.

Resolves: OLPEDGE-759

Signed-off-by: Sergii Vostrikov <ext-sergii.vostrikov@here.com>