### PR TITLE
Added VersionedLayerClient::PrefetchTiles method

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogClient.h
@@ -28,6 +28,7 @@
 #include <olp/core/client/ApiResponse.h>
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/core/geo/tiling/TileKey.h>
+#include "olp/dataservice/read/PrefetchTileResult.h"
 #include "olp/dataservice/read/model/Catalog.h"
 #include "olp/dataservice/read/model/Data.h"
 #include "olp/dataservice/read/model/Partitions.h"
@@ -41,6 +42,8 @@ class HRN;
 
 namespace dataservice {
 namespace read {
+
+class PrefetchTilesRequest;
 
 namespace model {
 class Partition;
@@ -78,52 +81,6 @@ class DataRequest;
 using DataResult = model::Data;
 using DataResponse = client::ApiResponse<DataResult, client::ApiError>;
 using DataResponseCallback = std::function<void(DataResponse response)>;
-
-class PrefetchTilesRequest;
-class DATASERVICE_READ_API PrefetchTileNoError {
- public:
-  PrefetchTileNoError() = default;
-  PrefetchTileNoError(const PrefetchTileNoError& other) = default;
-  ~PrefetchTileNoError() = default;
-};
-
-class DATASERVICE_READ_API PrefetchTileResult
-    : public client::ApiResponse<PrefetchTileNoError, client::ApiError> {
- public:
-  PrefetchTileResult()
-      : client::ApiResponse<PrefetchTileNoError, client::ApiError>() {}
-
-  /**
-   * @brief PrefetchTileResult Constructor for a successfully executed request.
-   */
-  PrefetchTileResult(const geo::TileKey& tile,
-                     const PrefetchTileNoError& result)
-      : client::ApiResponse<PrefetchTileNoError, client::ApiError>(result),
-        tile_key_(tile) {}
-
-  /**
-   * @brief PrefetchTileResult Constructor if request unsuccessfully executed
-   */
-  PrefetchTileResult(const geo::TileKey& tile, const client::ApiError& error)
-      : client::ApiResponse<PrefetchTileNoError, client::ApiError>(error),
-        tile_key_(tile) {}
-
-  /**
-   * @brief PrefetchTileResult Copy constructor.
-   */
-  PrefetchTileResult(const PrefetchTileResult& r)
-      : client::ApiResponse<PrefetchTileNoError, client::ApiError>(r),
-        tile_key_(r.tile_key_) {}
-
-  /**
-   * @brief ApiResponse Constructor if request unsuccessfully executed
-   */
-  PrefetchTileResult(const client::ApiError& error)
-      : client::ApiResponse<PrefetchTileNoError, client::ApiError>(error) {}
-
- public:
-  geo::TileKey tile_key_;
-};
 
 /**
  * @brief The PrefetchTilesResponse class encapsulates the result of a prefetch

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTileResult.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTileResult.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <olp/core/client/ApiError.h>
+#include <olp/core/client/ApiResponse.h>
+#include <olp/core/geo/tiling/TileKey.h>
+#include <olp/dataservice/read/DataServiceReadApi.h>
+
+namespace olp {
+namespace dataservice {
+namespace read {
+
+class DATASERVICE_READ_API PrefetchTileNoError {
+ public:
+  PrefetchTileNoError() = default;
+  PrefetchTileNoError(const PrefetchTileNoError& other) = default;
+  ~PrefetchTileNoError() = default;
+};
+
+/**
+ * @brif Class representing the result of pre-fetch operation.
+ * It will contain either a successful result represented as \c geo::TileKey
+ * object or will contain the failure error.
+ */
+class DATASERVICE_READ_API PrefetchTileResult
+    : public client::ApiResponse<PrefetchTileNoError, client::ApiError> {
+ public:
+  PrefetchTileResult()
+      : client::ApiResponse<PrefetchTileNoError, client::ApiError>() {}
+
+  /**
+   * @brief PrefetchTileResult Constructor for a successfully executed request.
+   */
+  PrefetchTileResult(const geo::TileKey& tile,
+                     const PrefetchTileNoError& result)
+      : client::ApiResponse<PrefetchTileNoError, client::ApiError>(result),
+        tile_key_(tile) {}
+
+  /**
+   * @brief PrefetchTileResult Constructor if request unsuccessfully executed
+   */
+  PrefetchTileResult(const geo::TileKey& tile, const client::ApiError& error)
+      : client::ApiResponse<PrefetchTileNoError, client::ApiError>(error),
+        tile_key_(tile) {}
+
+  /**
+   * @brief PrefetchTileResult Copy constructor.
+   */
+  PrefetchTileResult(const PrefetchTileResult& r)
+      : client::ApiResponse<PrefetchTileNoError, client::ApiError>(r),
+        tile_key_(r.tile_key_) {}
+
+  /**
+   * @brief ApiResponse Constructor if request unsuccessfully executed
+   */
+  PrefetchTileResult(const client::ApiError& error)
+      : client::ApiResponse<PrefetchTileNoError, client::ApiError>(error) {}
+
+ public:
+  /// The pre-fetched tile key.
+  geo::TileKey tile_key_;
+};
+
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
@@ -249,7 +249,7 @@ client::CancellationToken CatalogClientImpl::PrefetchTiles(
     callback(response);
   };
 
-  auto token = prefetch_provider_->PrefetchTiles(request, callback);
+  auto token = prefetch_provider_->PrefetchTiles(request, request_callback);
 
   pending_requests_->Insert(token, request_key);
   return token;

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
@@ -46,6 +46,11 @@ client::CancellationToken VersionedLayerClient::GetPartitions(
                               std::move(callback));
 }
 
+olp::client::CancellationToken VersionedLayerClient::PrefetchTiles(
+    PrefetchTilesRequest request, PrefetchTilesResponseCallback callback) {
+  return impl_->PrefetchTiles(std::move(request), std::move(callback));
+}
+
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -30,6 +30,8 @@
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/dataservice/read/DataRequest.h>
 #include <olp/dataservice/read/PartitionsRequest.h>
+#include <olp/dataservice/read/PrefetchTileResult.h>
+#include <olp/dataservice/read/PrefetchTilesRequest.h>
 #include <olp/dataservice/read/model/Data.h>
 #include <olp/dataservice/read/model/Partitions.h>
 
@@ -42,6 +44,8 @@ namespace read {
 namespace repository {
 class PartitionsRepository;
 }
+
+class PrefetchTilesProvider;
 
 class VersionedLayerClientImpl {
  public:
@@ -57,6 +61,15 @@ class VersionedLayerClientImpl {
       client::ApiResponse<PartitionsResult, client::ApiError>;
   using PartitionsCallback = std::function<void(PartitionsResponse response)>;
 
+  /// PrefetchTileResult alias
+  using PrefetchTilesResult = std::vector<std::shared_ptr<PrefetchTileResult>>;
+  /// Alias for the response to the \c PrefetchTileRequest
+  using PrefetchTilesResponse =
+      client::ApiResponse<PrefetchTilesResult, client::ApiError>;
+  /// Alias for the callback  to the results of PrefetchTilesResponse
+  using PrefetchTilesResponseCallback =
+      std::function<void(const PrefetchTilesResponse& response)>;
+
   VersionedLayerClientImpl(olp::client::HRN catalog, std::string layer_id,
                            olp::client::OlpClientSettings client_settings);
 
@@ -67,6 +80,9 @@ class VersionedLayerClientImpl {
 
   virtual client::CancellationToken GetPartitions(
       PartitionsRequest partitions_request, PartitionsCallback callback) const;
+
+  virtual olp::client::CancellationToken PrefetchTiles(
+      PrefetchTilesRequest request, PrefetchTilesResponseCallback callback);
 
  private:
   olp::client::CancellationToken AddGetDataTask(DataRequest data_request,
@@ -79,6 +95,7 @@ class VersionedLayerClientImpl {
   std::shared_ptr<thread::TaskScheduler> task_scheduler_;
   std::shared_ptr<PendingRequests> pending_requests_;
   std::shared_ptr<repository::PartitionsRepository> partition_repo_;
+  std::shared_ptr<PrefetchTilesProvider> prefetch_provider_;
 };
 
 }  // namespace read

--- a/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
@@ -2146,7 +2146,7 @@ TEST_P(CatalogClientTest, PrefetchEmbedded) {
   }
 }
 
-TEST_P(CatalogClientTest, DISABLED_PrefetchBusy) {
+TEST_P(CatalogClientTest, PrefetchBusy) {
   olp::client::HRN hrn(GetTestCatalog());
 
   auto catalog_client =
@@ -2179,9 +2179,6 @@ TEST_P(CatalogClientTest, DISABLED_PrefetchBusy) {
               Send(IsGetRequest(URL_QUADKEYS_5904591), _, _, _, _))
       .Times(1)
       .WillOnce(testing::Invoke(std::move(send_mock)));
-
-  EXPECT_CALL(*network_mock_, Cancel(request_id))
-      .WillOnce(testing::Invoke(std::move(cancel_mock)));
 
   // Issue the first request
   auto future1 = catalog_client->PrefetchTiles(request1);

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -26,9 +26,6 @@
 #include <olp/authentication/Settings.h>
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
-#include <olp/core/http/NetworkRequest.h>
-#include <olp/core/http/NetworkResponse.h>
-#include <olp/core/logging/Log.h>
 #include <olp/core/porting/make_unique.h>
 #include <olp/dataservice/read/VersionedLayerClient.h>
 #include "HttpResponses.h"
@@ -55,6 +52,14 @@ std::string GetArgument(const std::string& name) {
 
 std::string GetTestCatalog() {
   return GetArgument("dataservice_read_test_catalog");
+}
+
+std::string ApiErrorToString(const olp::client::ApiError& error) {
+  std::ostringstream result_stream;
+  result_stream << "ERROR: code: " << static_cast<int>(error.GetErrorCode())
+                << ", status: " << error.GetHttpStatusCode()
+                << ", message: " << error.GetMessage();
+  return result_stream.str();
 }
 
 constexpr char kHttpResponseLookupQuery[] =
@@ -966,8 +971,6 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetPartitionsForInvalidLayer) {
 }
 
 TEST_F(DataserviceReadVersionedLayerClientTest, GetPartitionsCacheWithUpdate) {
-  olp::logging::Log::setLevel(olp::logging::Level::Trace);
-
   auto catalog = olp::client::HRN::FromString(
       GetArgument("dataservice_read_test_catalog"));
   auto layer = GetArgument("dataservice_read_test_layer");
@@ -1449,6 +1452,287 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetPartitionsOnlineOnly) {
     // Should fail despite valid cache entry
     ASSERT_FALSE(response.IsSuccessful()) << response.GetError().GetMessage();
   }
+}
+
+TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesWithCache) {
+  olp::client::HRN catalog(GetTestCatalog());
+  constexpr auto kLayerId = "hype-test-prefetch";
+
+  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+      catalog, kLayerId, *settings_);
+  ASSERT_TRUE(client);
+
+  {
+    SCOPED_TRACE("Prefetch tiles online and store them in memory cache");
+    std::vector<olp::geo::TileKey> tile_keys = {
+        olp::geo::TileKey::FromHereTile("5904591")};
+
+    auto request = olp::dataservice::read::PrefetchTilesRequest()
+                       .WithTileKeys(tile_keys)
+                       .WithMinLevel(10)
+                       .WithMaxLevel(12);
+
+    std::promise<VersionedLayerClient::PrefetchTilesResponse> promise;
+    std::future<VersionedLayerClient::PrefetchTilesResponse> future =
+        promise.get_future();
+    auto token = client->PrefetchTiles(
+        request,
+        [&promise](VersionedLayerClient::PrefetchTilesResponse response) {
+          promise.set_value(response);
+        });
+
+    ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
+    VersionedLayerClient::PrefetchTilesResponse response = future.get();
+    ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
+    ASSERT_FALSE(response.GetResult().empty());
+
+    const auto& result = response.GetResult();
+
+    for (auto tile_result : result) {
+      ASSERT_TRUE(tile_result->IsSuccessful());
+      ASSERT_TRUE(tile_result->tile_key_.IsValid());
+    }
+  }
+
+  {
+    SCOPED_TRACE("Read cached data from pre-fetched sub-partition #1");
+    std::promise<VersionedLayerClient::CallbackResponse> promise;
+    std::future<VersionedLayerClient::CallbackResponse> future =
+        promise.get_future();
+    auto token = client->GetData(
+        olp::dataservice::read::DataRequest()
+            .WithPartitionId("23618365")
+            .WithFetchOption(CacheOnly),
+        [&promise](VersionedLayerClient::CallbackResponse response) {
+          promise.set_value(std::move(response));
+        });
+    ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
+
+    auto response = future.get();
+    ASSERT_TRUE(response.IsSuccessful())
+        << ApiErrorToString(response.GetError());
+    ASSERT_TRUE(response.GetResult() != nullptr);
+    ASSERT_NE(response.GetResult()->size(), 0u);
+  }
+
+  {
+    SCOPED_TRACE("Read cached data from pre-fetched sub-partition #2");
+    std::promise<VersionedLayerClient::CallbackResponse> promise;
+    std::future<VersionedLayerClient::CallbackResponse> future =
+        promise.get_future();
+
+    auto token = client->GetData(
+        olp::dataservice::read::DataRequest()
+            .WithPartitionId("1476147")
+            .WithFetchOption(CacheOnly),
+        [&promise](VersionedLayerClient::CallbackResponse response) {
+          promise.set_value(std::move(response));
+        });
+    ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
+
+    auto response = future.get();
+    ASSERT_TRUE(response.IsSuccessful())
+        << ApiErrorToString(response.GetError());
+    ASSERT_TRUE(response.GetResult() != nullptr);
+    ASSERT_NE(response.GetResult()->size(), 0u);
+  }
+}
+
+TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesBusy) {
+  olp::client::HRN catalog{GetTestCatalog()};
+  constexpr auto kLayerId = "hype-test-prefetch";
+
+  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+      catalog, kLayerId, *settings_);
+  ASSERT_TRUE(client);
+
+  // Prepare the first request
+  std::vector<olp::geo::TileKey> tile_keys1 = {
+      olp::geo::TileKey::FromHereTile("5904591")};
+
+  auto request1 = olp::dataservice::read::PrefetchTilesRequest()
+                      .WithTileKeys(tile_keys1)
+                      .WithMinLevel(10)
+                      .WithMaxLevel(12);
+
+  // Prepare to delay the response of URL_QUADKEYS_5904591 until we've issued
+  // the second request
+  auto wait_for_quad_key_request = std::make_shared<std::promise<void>>();
+  auto pause_for_second_request = std::make_shared<std::promise<void>>();
+
+  olp::http::RequestId request_id;
+  NetworkCallback send_mock;
+  CancelCallback cancel_mock;
+
+  std::tie(request_id, send_mock, cancel_mock) = GenerateNetworkMockActions(
+      wait_for_quad_key_request, pause_for_second_request,
+      {olp::http::HttpStatusCode::OK, HTTP_RESPONSE_QUADKEYS_5904591});
+
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(URL_QUADKEYS_5904591), _, _, _, _))
+      .Times(1)
+      .WillOnce(testing::Invoke(std::move(send_mock)));
+
+  // Issue the first request
+  std::promise<VersionedLayerClient::PrefetchTilesResponse> promise1;
+  std::future<VersionedLayerClient::PrefetchTilesResponse> future1 =
+      promise1.get_future();
+  auto token1 = client->PrefetchTiles(
+      request1,
+      [&promise1](VersionedLayerClient::PrefetchTilesResponse response) {
+        promise1.set_value(response);
+      });
+
+  // Wait for QuadKey request
+  wait_for_quad_key_request->get_future().get();
+
+  // Prepare the second request
+  std::vector<olp::geo::TileKey> tile_keys2;
+  tile_keys2.emplace_back(olp::geo::TileKey::FromHereTile("369036"));
+
+  auto request2 = olp::dataservice::read::PrefetchTilesRequest()
+                      .WithTileKeys(tile_keys2)
+                      .WithMinLevel(9)
+                      .WithMaxLevel(9);
+
+  // Issue the second request
+  std::promise<VersionedLayerClient::PrefetchTilesResponse> promise2;
+  std::future<VersionedLayerClient::PrefetchTilesResponse> future2 =
+      promise2.get_future();
+  auto token2 = client->PrefetchTiles(
+      request2,
+      [&promise2](VersionedLayerClient::PrefetchTilesResponse response) {
+        promise2.set_value(response);
+      });
+
+  // Unblock the QuadKey request
+  pause_for_second_request->set_value();
+
+  // Validate that the second request failed
+  auto response2 = future2.get();
+  ASSERT_FALSE(response2.IsSuccessful());
+
+  auto& error = response2.GetError();
+  ASSERT_EQ(olp::client::ErrorCode::SlowDown, error.GetErrorCode());
+
+  // Get and validate the first request
+  auto response1 = future1.get();
+  ASSERT_TRUE(response1.IsSuccessful());
+
+  auto& result1 = response1.GetResult();
+
+  for (auto tile_result : result1) {
+    ASSERT_TRUE(tile_result->IsSuccessful());
+    ASSERT_TRUE(tile_result->tile_key_.IsValid());
+  }
+  ASSERT_EQ(6u, result1.size());
+}
+
+TEST_F(DataserviceReadVersionedLayerClientTest,
+       PrefetchTilesCancelOnClientDeletion) {
+  auto wait_for_cancel = std::make_shared<std::promise<void>>();
+  auto pause_for_cancel = std::make_shared<std::promise<void>>();
+
+  olp::http::RequestId request_id;
+  NetworkCallback send_mock;
+  CancelCallback cancel_mock;
+  std::tie(request_id, send_mock, cancel_mock) = GenerateNetworkMockActions(
+      wait_for_cancel, pause_for_cancel,
+      {olp::http::HttpStatusCode::OK, HTTP_RESPONSE_LOOKUP_QUERY});
+
+  EXPECT_CALL(*network_mock_, Send(_, _, _, _, _))
+      .WillOnce(testing::Invoke(std::move(send_mock)));
+
+  EXPECT_CALL(*network_mock_, Cancel(_))
+      .WillOnce(testing::Invoke(std::move(cancel_mock)));
+
+  std::promise<VersionedLayerClient::PrefetchTilesResponse> promise;
+  std::future<VersionedLayerClient::PrefetchTilesResponse> future =
+      promise.get_future();
+
+  const olp::client::HRN catalog(GetTestCatalog());
+  constexpr auto kLayerId = "prefetch-catalog";
+  constexpr auto kParitionId = "prefetch-partition";
+
+  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+      catalog, kLayerId, *settings_);
+  ASSERT_TRUE(client);
+
+  std::vector<olp::geo::TileKey> tile_keys = {
+      olp::geo::TileKey::FromHereTile(kParitionId)};
+  auto request = olp::dataservice::read::PrefetchTilesRequest()
+                     .WithTileKeys(tile_keys)
+                     .WithMinLevel(10)
+                     .WithMaxLevel(12);
+
+  auto token = client->PrefetchTiles(
+      request,
+      [&promise](VersionedLayerClient::PrefetchTilesResponse response) {
+        promise.set_value(response);
+      });
+
+  wait_for_cancel->get_future().get();
+  client.reset();
+  pause_for_cancel->set_value();
+
+  ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
+  VersionedLayerClient::PrefetchTilesResponse response = future.get();
+  ASSERT_FALSE(response.IsSuccessful()) << response.GetError().GetMessage();
+  ASSERT_EQ(response.GetError().GetErrorCode(),
+            olp::client::ErrorCode::Cancelled);
+}
+
+TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesCancelOnLookup) {
+  auto wait_for_cancel = std::make_shared<std::promise<void>>();
+  auto pause_for_cancel = std::make_shared<std::promise<void>>();
+
+  olp::http::RequestId request_id;
+  NetworkCallback send_mock;
+  CancelCallback cancel_mock;
+  std::tie(request_id, send_mock, cancel_mock) = GenerateNetworkMockActions(
+      wait_for_cancel, pause_for_cancel,
+      {olp::http::HttpStatusCode::OK, HTTP_RESPONSE_LOOKUP_QUERY});
+
+  EXPECT_CALL(*network_mock_, Send(_, _, _, _, _))
+      .WillOnce(testing::Invoke(std::move(send_mock)));
+
+  EXPECT_CALL(*network_mock_, Cancel(_))
+      .WillOnce(testing::Invoke(std::move(cancel_mock)));
+
+  std::promise<VersionedLayerClient::PrefetchTilesResponse> promise;
+  std::future<VersionedLayerClient::PrefetchTilesResponse> future =
+      promise.get_future();
+
+  const olp::client::HRN catalog(GetTestCatalog());
+  constexpr auto kLayerId = "prefetch-catalog";
+  constexpr auto kParitionId = "prefetch-partition";
+
+  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+      catalog, kLayerId, *settings_);
+  ASSERT_TRUE(client);
+
+  std::vector<olp::geo::TileKey> tile_keys = {
+      olp::geo::TileKey::FromHereTile(kParitionId)};
+  auto request = olp::dataservice::read::PrefetchTilesRequest()
+                     .WithTileKeys(tile_keys)
+                     .WithMinLevel(10)
+                     .WithMaxLevel(12);
+
+  auto token = client->PrefetchTiles(
+      request,
+      [&promise](VersionedLayerClient::PrefetchTilesResponse response) {
+        promise.set_value(response);
+      });
+
+  wait_for_cancel->get_future().get();
+  token.cancel();
+  pause_for_cancel->set_value();
+
+  ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
+  VersionedLayerClient::PrefetchTilesResponse response = future.get();
+  ASSERT_FALSE(response.IsSuccessful()) << response.GetError().GetMessage();
+  ASSERT_EQ(response.GetError().GetErrorCode(),
+            olp::client::ErrorCode::Cancelled);
 }
 
 }  // namespace


### PR DESCRIPTION
Implemented the VersionedLayerClient::PrefetchTiles method in dataservice-read component, which is based on the CatalogClient::PrefetchTiles implementation.

Also, moved the integration and functional tests regarding the pre-fetch functionality from CatalogClientTest with following changes:
- added DataserviceReadVersionedLayerClientTest.cpp file to integration tests target;
- removed the PrefetchEmbedded integration test from tests in DataserviceReadVersionedLayerClientTest test suite (see OLPEDGE-906);
- re-enabled the PrefetchBusy test in both CatalogClientTest and DataserviceReadVersionedLayerClientTest.

Relates to: OLPEDGE-795

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>