### PR TITLE
Add a task context class.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/ApiResponse.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/ApiResponse.h
@@ -36,6 +36,9 @@ namespace client {
 template <typename Result, typename Error>
 class ApiResponse {
  public:
+  using ResultType = Result;
+  using ErrorType = Error;
+
   /**
    * @brief ApiResponse Default constructor.
    */
@@ -44,12 +47,12 @@ class ApiResponse {
   /**
    * @brief ApiResponse Constructor for a successfully executed request.
    */
-  ApiResponse(const Result& result) : result_(result), success_(true) {}
+  ApiResponse(const ResultType& result) : result_(result), success_(true) {}
 
   /**
    * @brief ApiResponse Constructor if request unsuccessfully executed
    */
-  ApiResponse(const Error& error) : error_(error), success_(false) {}
+  ApiResponse(const ErrorType& error) : error_(error), success_(false) {}
 
   /**
    * @brief ApiResponse Copy constructor.
@@ -68,18 +71,18 @@ class ApiResponse {
    * @return A valid Result if IsSuccessful() returns true. Undefined,
    * otherwise.
    */
-  inline const Result& GetResult() const { return result_; }
+  inline const ResultType& GetResult() const { return result_; }
 
   /**
    * @brief GetError Gets the error for an unsucccessful request attempt.
    * @return A valid Error if IsSuccessful() returns false. Undefined,
    * otherwise.
    */
-  inline const Error& GetError() const { return error_; }
+  inline const ErrorType& GetError() const { return error_; }
 
  private:
-  Result result_ {};
-  Error error_ {};
+  ResultType result_{};
+  ErrorType error_{};
   bool success_ {false};
 };
 

--- a/olp-cpp-sdk-core/include/olp/core/client/Condition.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/Condition.h
@@ -33,8 +33,7 @@ namespace client {
  */
 class Condition final {
  public:
-  Condition(std::chrono::milliseconds timeout = std::chrono::seconds(60))
-      : timeout_{timeout} {}
+  Condition() = default;
 
   /**
    * @brief Should be called by task's callback to notify \c Wait to unblock the
@@ -51,18 +50,19 @@ class Condition final {
   /**
    * @brief Waits a task for a \c Notify or \c CancellationContext to be
    * cancelled by the user.
+   * @param timeout milliseconds to wait on condition
+   * @return True on notified wake, False on timeout
    */
-  bool Wait() {
+  bool Wait(std::chrono::milliseconds timeout = std::chrono::seconds(60)) {
     std::unique_lock<std::mutex> lock(mutex_);
-    bool triggered = condition_.wait_for(
-        lock, timeout_, [&] { return signaled_; });
+    bool triggered =
+        condition_.wait_for(lock, timeout, [&] { return signaled_; });
 
     signaled_ = false;
     return triggered;
   }
 
  private:
-  const std::chrono::milliseconds timeout_;
   std::condition_variable condition_;
   std::mutex mutex_;
   bool signaled_{false};

--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(OLP_CPP_SDK_CORE_TESTS_SOURCES
     ./cache/InMemoryCacheTest.cpp
 
     ./client/CancellationContextTest.cpp
+    ./client/ConditionTest.cpp
 
     ./geo/coordinates/GeoCoordinates3dTest.cpp
     ./geo/coordinates/GeoCoordinatesTest.cpp

--- a/olp-cpp-sdk-core/tests/client/ConditionTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/ConditionTest.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <olp/core/client/Condition.h>
+
+#include <gtest/gtest.h>
+#include <future>
+
+using olp::client::Condition;
+
+namespace {
+TEST(ConditionTest, NotifyBeforeWaitRespected) {
+  Condition condition{};
+  condition.Notify();
+  EXPECT_TRUE(condition.Wait());
+}
+
+TEST(ConditionTest, WaitClearsTriggered) {
+  Condition condition{};
+  condition.Notify();
+  EXPECT_TRUE(condition.Wait());
+  EXPECT_FALSE(condition.Wait(std::chrono::seconds(0)));
+}
+
+TEST(ConditionTest, Timeouted) {
+  Condition condition{};
+  EXPECT_FALSE(condition.Wait(std::chrono::seconds(0)));
+}
+
+TEST(ConditionTest, WakeUp) {
+  Condition condition{};
+  auto wait_future =
+      std::async(std::launch::async, [&]() { return condition.Wait(); });
+  EXPECT_EQ(wait_future.wait_for(std::chrono::milliseconds(10)),
+            std::future_status::timeout);
+  condition.Notify();
+  EXPECT_EQ(wait_future.wait_for(std::chrono::milliseconds(10)),
+            std::future_status::ready);
+  EXPECT_TRUE(wait_future.get());
+}
+}  // namespace

--- a/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.cpp
@@ -152,8 +152,7 @@ ApiClientLookup::ApiClientResponse ApiClientLookup::LookupApi(
     }
   }
 
-  client::Condition condition(
-      std::chrono::seconds(settings.retry_settings.timeout));
+  client::Condition condition{};
 
   auto client = std::make_shared<client::OlpClient>();
   client->SetSettings(std::move(settings));
@@ -190,7 +189,7 @@ ApiClientLookup::ApiClientResponse ApiClientLookup::LookupApi(
         condition.Notify();
       });
 
-  if (!condition.Wait()) {
+  if (!condition.Wait(std::chrono::seconds(settings.retry_settings.timeout))) {
     cancellation_context.CancelOperation();
     return client::ApiError(client::ErrorCode::RequestTimeout,
                             "Network request timed out.");

--- a/olp-cpp-sdk-dataservice-read/src/PendingRequests.h
+++ b/olp-cpp-sdk-dataservice-read/src/PendingRequests.h
@@ -19,11 +19,14 @@
 
 #pragma once
 
-#include <unordered_map>
+#include <memory>
 #include <mutex>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <olp/core/client/CancellationToken.h>
+#include "TaskContext.h"
 
 namespace olp {
 namespace dataservice {
@@ -57,15 +60,28 @@ class PendingRequests final {
   bool Insert(const client::CancellationToken& token, int64_t key);
 
   /**
+   * @brief Inserts task context into the requests container.
+   * @param task_context Task context.
+   */
+  void Insert(TaskContext task_context);
+
+  /**
    * @brief Removes a pending request and placholder.
    * @param key Internal request key to remove
    * @return True on success
    */
   bool Remove(int64_t key);
 
+  /**
+   * @brief Removes a task context.
+   * @param task_context Task context.
+   */
+  void Remove(TaskContext task_context);
+
  private:
   int64_t key_ = 0;
   std::unordered_map<int64_t, client::CancellationToken> requests_map_;
+  std::unordered_set<TaskContext, TaskContextHash> task_contexts_;
   std::mutex requests_lock_;
 };
 

--- a/olp-cpp-sdk-dataservice-read/src/TaskContext.h
+++ b/olp-cpp-sdk-dataservice-read/src/TaskContext.h
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <atomic>
+#include <mutex>
+
+#include <olp/core/client/Condition.h>
+#include "olp/core/client/ApiError.h"
+#include "olp/core/client/ApiResponse.h"
+#include "olp/core/client/CancellationContext.h"
+#include "olp/core/client/CancellationToken.h"
+
+namespace olp {
+namespace dataservice {
+namespace read {
+
+class TaskContext {
+ public:
+  template <typename Exec, typename Callback>
+  static TaskContext Create(Exec execute_func, Callback callback) {
+    TaskContext context;
+    context.SetExecutors(std::move(execute_func), std::move(callback));
+    return context;
+  }
+
+  void Execute() const { impl_->Execute(); }
+
+  void BlockingCancel(
+      std::chrono::milliseconds timeout = std::chrono::seconds(60)) const {
+    impl_->BlockingCancel(timeout);
+  }
+
+  client::CancellationToken CancelToken() const { return impl_->CancelToken(); }
+
+  bool operator==(const TaskContext& other) const {
+    return impl_ == other.impl_;
+  }
+
+ protected:
+  friend struct TaskContextHash;
+
+  TaskContext() = default;
+
+  template <typename Exec, typename Callback,
+            typename ExecResult = typename std::result_of<
+                Exec(client::CancellationContext)>::type>
+  void SetExecutors(Exec execute_func, Callback callback) {
+    impl_ = std::make_shared<TaskContextImpl<typename ExecResult::ResultType>>(
+        std::move(execute_func), std::move(callback));
+  }
+
+  class Impl {
+   public:
+    virtual ~Impl() = default;
+    virtual void Execute() = 0;
+    virtual void BlockingCancel(std::chrono::milliseconds timeout) = 0;
+    virtual client::CancellationToken CancelToken() = 0;
+  };
+
+  template <typename T>
+  class TaskContextImpl : public Impl {
+   public:
+    using Response = client::ApiResponse<T, client::ApiError>;
+    using ExecuteFunc = std::function<Response(client::CancellationContext)>;
+    using UserCallback = std::function<void(Response)>;
+
+    TaskContextImpl(ExecuteFunc execute_func, UserCallback callback)
+        : execute_func_(std::move(execute_func)),
+          callback_(std::move(callback)),
+          state_{State::PENDING} {}
+
+    ~TaskContextImpl() {}
+
+    void Execute() override {
+      State expected_state = State::PENDING;
+
+      if (!state_.compare_exchange_strong(expected_state, State::IN_PROGRESS)) {
+        return;
+      }
+
+      // Moving the user callback and function guarantee that they will be
+      // executed exactly once
+      ExecuteFunc function = nullptr;
+      UserCallback callback = nullptr;
+
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        function = std::move(execute_func_);
+        callback = std::move(callback_);
+      }
+
+      Response user_response =
+          client::ApiError(client::ErrorCode::Cancelled, "Cancelled");
+
+      if (function && !context_.IsCancelled()) {
+        auto response = function(context_);
+        // Cancel could occur during function execution, in that case we ignore
+        // the response.
+        if (!context_.IsCancelled()) {
+          user_response = std::move(response);
+        }
+      }
+
+      if (callback) {
+        callback(std::move(user_response));
+      }
+
+      condition_.Notify();
+
+      state_.store(State::COMPLETED);
+    }
+
+    void BlockingCancel(std::chrono::milliseconds timeout) override {
+      if (state_.load() == State::COMPLETED) {
+        return;
+      }
+
+      // Cancel operation and wait for notification
+      context_.CancelOperation();
+
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        execute_func_ = nullptr;
+      }
+
+      condition_.Wait(timeout);
+    }
+
+    client::CancellationToken CancelToken() override {
+      auto context = context_;
+      return client::CancellationToken(
+          [context]() mutable { context.CancelOperation(); });
+    }
+
+    enum class State { PENDING, IN_PROGRESS, COMPLETED };
+
+    std::mutex mutex_;
+    ExecuteFunc execute_func_;
+    UserCallback callback_;
+    client::CancellationContext context_;
+    client::Condition condition_;
+    std::atomic<State> state_;
+  };
+
+  std::shared_ptr<Impl> impl_;
+};
+
+struct TaskContextHash {
+  size_t operator()(const TaskContext& task_context) const {
+    return std::hash<std::shared_ptr<TaskContext::Impl>>()(task_context.impl_);
+  }
+};
+
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.cpp
@@ -275,7 +275,7 @@ MetadataApi::CatalogVersionResponse CatalogRepository::GetLatestVersion(
 
   const client::OlpClient& client = metadata_api.GetResult();
 
-  Condition condition{std::chrono::seconds{timeout}};
+  Condition condition{};
 
   // when the network operation took too much time we cancel it and exit
   // execution, to make sure that network callback will not access dangling
@@ -303,7 +303,7 @@ MetadataApi::CatalogVersionResponse CatalogRepository::GetLatestVersion(
       },
       [&condition]() { condition.Notify(); });
 
-  if (!condition.Wait()) {
+  if (!condition.Wait(std::chrono::seconds{timeout})) {
     cancellation_context.CancelOperation();
     return ApiError(ErrorCode::RequestTimeout, "Network request timed out.");
   }

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
@@ -509,7 +509,7 @@ QueryApi::PartitionsResponse PartitionsRepository::GetPartitionById(
 
   const client::OlpClient& client = query_api.GetResult();
 
-  Condition condition(timeout);
+  Condition condition{};
 
   // when the network operation took too much time we cancel it and exit
   // execution, to make sure that network callback will not access dangling
@@ -539,7 +539,7 @@ QueryApi::PartitionsResponse PartitionsRepository::GetPartitionById(
       },
       [&]() { condition.Notify(); });
 
-  if (!condition.Wait()) {
+  if (!condition.Wait(timeout)) {
     cancellation_context.CancelOperation();
     return client::ApiError(client::ErrorCode::RequestTimeout,
                             "Network request timed out.");

--- a/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ set(OLP_SDK_DATASERVICE_READ_TEST_SOURCES
     PartitionsRepositoryTest.cpp
     PendingRequestsTest.cpp
     SerializerTest.cpp
+    TaskContextTest.cpp
     VolatileLayerClientImplTest.cpp
     VolatileLayerClientTest.cpp
     VersionedLayerClientTest.cpp

--- a/olp-cpp-sdk-dataservice-read/tests/TaskContextTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/TaskContextTest.cpp
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "TaskContext.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using namespace olp::client;
+using namespace olp::dataservice::read;
+
+using ResponseType = std::string;
+using Response = ApiResponse<ResponseType, ApiError>;
+using ExecuteFunc = std::function<Response(CancellationContext)>;
+using Callback = std::function<void(Response)>;
+
+class TaskContextTestable : public TaskContext {
+ public:
+  std::function<void(void)> notify;
+
+  template <typename Exec, typename Callback>
+  static TaskContextTestable Create(Exec execute_func, Callback callback) {
+    TaskContextTestable context;
+    context.SetExecutors(std::move(execute_func), std::move(callback));
+    return context;
+  }
+
+  template <typename Exec, typename Callback,
+            typename ExecResult = typename std::result_of<
+                Exec(olp::client::CancellationContext)>::type>
+  void SetExecutors(Exec execute_func, Callback callback) {
+    auto impl =
+        std::make_shared<TaskContextImpl<typename ExecResult::ResultType>>(
+            std::move(execute_func), std::move(callback));
+    notify = [=]() { impl->condition_.Notify(); };
+    impl_ = impl;
+  }
+};
+
+TEST(TaskContextTest, ExecuteSimple) {
+  int response_received = 0;
+
+  ExecuteFunc func = [](CancellationContext) -> Response {
+    return ApiError(ErrorCode::InvalidArgument, "test");
+  };
+
+  Response response;
+
+  Callback callback = [&](Response r) -> void {
+    response = std::move(r);
+    response_received++;
+  };
+
+  {
+    SCOPED_TRACE("Single execute");
+    TaskContext context = TaskContext::Create(func, callback);
+    context.Execute();
+    EXPECT_EQ(response_received, 1);
+
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(), ErrorCode::InvalidArgument);
+  }
+  response_received = 0;
+  {
+    SCOPED_TRACE("Multiple execute");
+    TaskContext context = TaskContext::Create(func, callback);
+    context.Execute();
+    context.Execute();
+    context.Execute();
+    EXPECT_EQ(response_received, 1);
+
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(), ErrorCode::InvalidArgument);
+  }
+  {
+    SCOPED_TRACE("Cancel after execution");
+    TaskContext context = TaskContext::Create(func, callback);
+    context.Execute();
+    context.BlockingCancel();
+
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(), ErrorCode::InvalidArgument);
+  }
+  response_received = 0;
+  {
+    SCOPED_TRACE("Cancel before execution");
+
+    TaskContext context = TaskContext::Create(func, callback);
+
+    context.BlockingCancel(std::chrono::milliseconds{0});
+
+    context.Execute();
+
+    EXPECT_EQ(response_received, 1);
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(), ErrorCode::Cancelled);
+  }
+}
+
+TEST(TaskContextTest, BlockingCancel) {
+  std::mutex execution_mutex, cancelation_mutex;
+  std::condition_variable execution_cv, cancelation_cv;
+
+  auto execution_wait = [&]() {
+    std::unique_lock<std::mutex> lock(execution_mutex);
+    EXPECT_EQ(execution_cv.wait_for(lock, std::chrono::seconds(2)),
+              std::cv_status::no_timeout);
+  };
+
+  auto cancelation_wait = [&]() {
+    std::unique_lock<std::mutex> lock(cancelation_mutex);
+    EXPECT_EQ(cancelation_cv.wait_for(lock, std::chrono::seconds(2)),
+              std::cv_status::no_timeout);
+  };
+
+  ExecuteFunc func = [&](CancellationContext c) -> Response {
+    execution_wait();
+    EXPECT_TRUE(c.IsCancelled());
+    return std::string("Success");
+  };
+
+  Response response;
+
+  Callback callback = [&](Response r) { response = std::move(r); };
+
+  TaskContext context = TaskContext::Create(func, callback);
+
+  std::thread execute_thread([&]() { context.Execute(); });
+
+  std::thread cancel_thread([&]() {
+    cancelation_wait();
+    context.BlockingCancel();
+  });
+
+  // wait threads to start and reach the task execution
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  // reach cancel
+  cancelation_cv.notify_one();
+  // wait till execution starts
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  // check for conditions and continue execution
+  execution_cv.notify_one();
+
+  execute_thread.join();
+  cancel_thread.join();
+
+  EXPECT_FALSE(response.IsSuccessful());
+  EXPECT_EQ(response.GetError().GetErrorCode(), ErrorCode::Cancelled);
+}
+
+TEST(TaskContextTest, BlockingCancelIsWaiting) {
+  std::future<void> cancel_finished;
+  std::function<void()> release_wait;
+  int response_received = 0;
+
+  ExecuteFunc func = [&](CancellationContext) -> Response {
+    EXPECT_EQ(cancel_finished.wait_for(std::chrono::milliseconds(0)),
+              std::future_status::timeout);
+    release_wait();
+    cancel_finished.wait();
+    return ApiError(ErrorCode::InvalidArgument, "test");
+  };
+
+  Response response;
+
+  Callback callback = [&](Response r) {
+    response = std::move(r);
+    response_received++;
+  };
+
+  TaskContextTestable context = TaskContextTestable::Create(func, callback);
+
+  cancel_finished =
+      std::async(std::launch::async, [&]() { context.BlockingCancel(); });
+
+  release_wait = [&]() { context.notify(); };
+
+  context.Execute();
+
+  EXPECT_EQ(response_received, 1);
+  EXPECT_FALSE(response.IsSuccessful());
+  EXPECT_EQ(cancel_finished.wait_for(std::chrono::milliseconds(0)),
+            std::future_status::ready);
+  EXPECT_EQ(response.GetError().GetErrorCode(), ErrorCode::Cancelled);
+}
+
+TEST(TaskContextTest, CancelToken) {
+  std::mutex execution_mutex;
+  std::condition_variable execution_cv;
+
+  auto execution_wait = [&]() {
+    std::unique_lock<std::mutex> lock(execution_mutex);
+    EXPECT_EQ(execution_cv.wait_for(lock, std::chrono::seconds(2)),
+              std::cv_status::no_timeout);
+  };
+
+  ExecuteFunc func = [&](CancellationContext c) -> Response {
+    execution_wait();
+    EXPECT_TRUE(c.IsCancelled());
+    return std::string("Success");
+  };
+
+  Response response;
+
+  Callback callback = [&](Response r) { response = std::move(r); };
+
+  TaskContext context = TaskContext::Create(func, callback);
+
+  std::thread execute_thread([&]() { context.Execute(); });
+
+  auto token = context.CancelToken();
+
+  // wait till execution starts
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  // cancel operation
+  token.cancel();
+  // check for conditions and continue execution
+  execution_cv.notify_one();
+
+  execute_thread.join();
+
+  EXPECT_FALSE(response.IsSuccessful());
+  EXPECT_EQ(response.GetError().GetErrorCode(), ErrorCode::Cancelled);
+}
+
+}  // namespace


### PR DESCRIPTION
Class take care of users callbacks, and make sure that client
callback is called exactly 1 time.
VolatileLayerClientImpl::GetData adapted to TaskContext usage
VersionedLayerClientImpl::GetData adapted to TaskContext usage

Resolves: OLPEDGE-909

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>