### PR TITLE
Crash of versioned layer test fix

### DIFF
--- a/scripts/linux/fv/olp-common.variables
+++ b/scripts/linux/fv/olp-common.variables
@@ -5,6 +5,10 @@ export layer_sdii="olp-cpp-sdk-ingestion-test-stream-layer-sdii"
 export versioned_layer="olp-cpp-sdk-ingestion-test-versioned-layer"
 export volatile_layer="olp-cpp-sdk-ingestion-test-volatile-layer"
 export index_layer="olp-cpp-sdk-ingestion-test-index-layer"
+export dataservice_read_test_catalog="hrn:here:data:::here-optimized-map-for-visualization-2"
+export dataservice_read_test_layer="omv-base-v2"
+export dataservice_read_test_partition="269"
+export dataservice_read_test_layer_version="108"
 ###
 #variables below are defined previously as protected value on Gitlab
 ###
@@ -21,3 +25,4 @@ export arcgis_app_id="${arcgis_app_id}"
 export arcgis_access_token="${arcgis_access_token}"
 export integration_production_service_id="${integration_production_service_id}"
 export integration_production_service_secret="${integration_production_service_secret}"
+

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 #include <chrono>
 #include <string>
 
@@ -49,7 +49,9 @@ class DataserviceReadVersionedLayerClientTest : public ::testing::Test {
     olp::authentication::Settings auth_settings({appid, secret});
     auth_settings.network_request_handler = network;
 
+    olp::authentication::TokenProviderDefault provider(auth_settings);
     olp::client::AuthenticationSettings auth_client_settings;
+    auth_client_settings.provider = provider;
 
     settings_ = std::make_shared<olp::client::OlpClientSettings>();
     settings_->network_request_handler = network;


### PR DESCRIPTION
Added missing initialization of auth settings to
DataserviceReadVersionedLayerClientTest

Relates-to: OLPEDGE-903

Signed-off-by: Sergii Vostrikov <ext-sergii.vostrikov@here.com>