### PR TITLE
Dataservice-read's test variables arrangement

### DIFF
--- a/scripts/linux/fv/olp-common.variables
+++ b/scripts/linux/fv/olp-common.variables
@@ -5,10 +5,6 @@ export layer_sdii="olp-cpp-sdk-ingestion-test-stream-layer-sdii"
 export versioned_layer="olp-cpp-sdk-ingestion-test-versioned-layer"
 export volatile_layer="olp-cpp-sdk-ingestion-test-volatile-layer"
 export index_layer="olp-cpp-sdk-ingestion-test-index-layer"
-export dataservice_read_test_catalog="hrn:here:data:::here-optimized-map-for-visualization-2"
-export dataservice_read_test_layer="omv-base-v2"
-export dataservice_read_test_partition="269"
-export dataservice_read_test_layer_version="108"
 ###
 #variables below are defined previously as protected value on Gitlab
 ###

--- a/scripts/linux/fv/olp-cpp-sdk-functional-test.variables
+++ b/scripts/linux/fv/olp-cpp-sdk-functional-test.variables
@@ -4,3 +4,11 @@ export dataservice_read_test_catalog="hrn:here:data:::hereos-internal-test-v2"
 export dataservice_write_test_secret="${dataservice_write_test_secret}" #defined previously as protected value on Gitlab
 export dataservice_write_test_appid="${dataservice_write_test_appid}" #defined previously as protected value on Gitlab
 export dataservice_write_test_catalog="hrn:here:data:::olp-cpp-sdk-ingestion-test-catalog"
+
+export dataservice_read_test_versioned_secret="${dataservice_read_test_secret}" #defined previously as protected value on Gitlab
+export dataservice_read_test_versioned_appid="${dataservice_read_test_appid}" #defined previously as protected value on Gitlab
+export dataservice_read_test_versioned_catalog="hrn:here:data:::here-optimized-map-for-visualization-2"
+export dataservice_read_test_versioned_layer="omv-base-v2"
+export dataservice_read_test_versioned_partition="269"
+export dataservice_read_test_versioned_layer_version="108"
+

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
@@ -44,8 +44,10 @@ class DataserviceReadVersionedLayerClientTest : public ::testing::Test {
     auto network = olp::client::OlpClientSettingsFactory::
         CreateDefaultNetworkRequestHandler();
 
-    auto appid = CustomParameters::getArgument("dataservice_read_test_appid");
-    auto secret = CustomParameters::getArgument("dataservice_read_test_secret");
+    auto appid =
+        CustomParameters::getArgument("dataservice_read_test_versioned_appid");
+    auto secret =
+        CustomParameters::getArgument("dataservice_read_test_versioned_secret");
     olp::authentication::Settings auth_settings({appid, secret});
     auth_settings.network_request_handler = network;
 
@@ -75,10 +77,11 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataFromPartitionAsync) {
       olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler(1);
 
   auto catalog = olp::client::HRN::FromString(
-      CustomParameters::getArgument("dataservice_read_test_catalog"));
-  auto layer = CustomParameters::getArgument("dataservice_read_test_layer");
-  auto version = std::stoi(
-      CustomParameters::getArgument("dataservice_read_test_layer_version"));
+      CustomParameters::getArgument("dataservice_read_test_versioned_catalog"));
+  auto layer =
+      CustomParameters::getArgument("dataservice_read_test_versioned_layer");
+  auto version = std::stoi(CustomParameters::getArgument(
+      "dataservice_read_test_versioned_layer_version"));
 
   auto catalog_client =
       std::make_unique<olp::dataservice::read::VersionedLayerClient>(
@@ -88,8 +91,8 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataFromPartitionAsync) {
   std::promise<VersionedLayerClient::CallbackResponse> promise;
   std::future<VersionedLayerClient::CallbackResponse> future =
       promise.get_future();
-  auto partition =
-      CustomParameters::getArgument("dataservice_read_test_partition");
+  auto partition = CustomParameters::getArgument(
+      "dataservice_read_test_versioned_partition");
   auto token = catalog_client->GetData(
       olp::dataservice::read::DataRequest()
           .WithVersion(version)
@@ -112,8 +115,9 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
       olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler(1);
 
   auto catalog = olp::client::HRN::FromString(
-      CustomParameters::getArgument("dataservice_read_test_catalog"));
-  auto layer = CustomParameters::getArgument("dataservice_read_test_layer");
+      CustomParameters::getArgument("dataservice_read_test_versioned_catalog"));
+  auto layer =
+      CustomParameters::getArgument("dataservice_read_test_versioned_layer");
 
   auto catalog_client =
       std::make_unique<olp::dataservice::read::VersionedLayerClient>(
@@ -123,8 +127,8 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
   std::promise<VersionedLayerClient::CallbackResponse> promise;
   std::future<VersionedLayerClient::CallbackResponse> future =
       promise.get_future();
-  auto partition =
-      CustomParameters::getArgument("dataservice_read_test_partition");
+  auto partition = CustomParameters::getArgument(
+      "dataservice_read_test_versioned_partition");
   auto token = catalog_client->GetData(
       olp::dataservice::read::DataRequest().WithPartitionId(partition),
       [&promise](VersionedLayerClient::CallbackResponse response) {
@@ -141,8 +145,9 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
 
 TEST_F(DataserviceReadVersionedLayerClientTest, GetDataFromPartitionSync) {
   auto catalog = olp::client::HRN::FromString(
-      CustomParameters::getArgument("dataservice_read_test_catalog"));
-  auto layer = CustomParameters::getArgument("dataservice_read_test_layer");
+      CustomParameters::getArgument("dataservice_read_test_versioned_catalog"));
+  auto layer =
+      CustomParameters::getArgument("dataservice_read_test_versioned_layer");
   auto version = 0;
 
   auto catalog_client =
@@ -151,8 +156,8 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataFromPartitionSync) {
   ASSERT_TRUE(catalog_client);
 
   VersionedLayerClient::CallbackResponse response;
-  auto partition =
-      CustomParameters::getArgument("dataservice_read_test_partition");
+  auto partition = CustomParameters::getArgument(
+      "dataservice_read_test_versioned_partition");
   auto token = catalog_client->GetData(
       olp::dataservice::read::DataRequest()
           .WithVersion(version)


### PR DESCRIPTION
All related environment variables required for
DataserviceReadVersionedLayerClientTest are now placed to
olp-dataservice-read-test.variables CI script.
Also these vars now has a unique prefix to avoid possible collisions
with other tests in 'read' suite.

Relates-to: OLPEDGE-907

Signed-off-by: Sergii Vostrikov <ext-sergii.vostrikov@here.com>