### PR TITLE
Implemented VolatileLayerClient::GetPartitions() method

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
@@ -27,7 +27,9 @@
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/dataservice/read/DataRequest.h>
+#include <olp/dataservice/read/PartitionsRequest.h>
 #include <olp/dataservice/read/model/Data.h>
+#include <olp/dataservice/read/model/Partitions.h>
 
 namespace olp {
 namespace dataservice {
@@ -77,6 +79,11 @@ class DATASERVICE_READ_API VolatileLayerClient final {
   using DataResult = model::Data;
   /// CallbackResponse alias
   using DataResponse = client::ApiResponse<DataResult, client::ApiError>;
+  /// PartitionResult alias
+  using PartitionsResult = model::Partitions;
+  /// CallbackResponse
+  using PartitionsResponse =
+      client::ApiResponse<PartitionsResult, client::ApiError>;
   /// Callback alias
   template <class Response>
   using Callback = std::function<void(Response response)>;
@@ -93,6 +100,16 @@ class DATASERVICE_READ_API VolatileLayerClient final {
                       client::OlpClientSettings settings);
 
   ~VolatileLayerClient();
+
+  /**
+   * @brief Fetches a list partitions for given volatile layer asynchronously.
+   * @param request contains the complete set of request parameters.
+   * @param callback will be invoked once the list of partitions is available,
+   * or an error is encountered.
+   * @return A token that can be used to cancel this request
+   */
+  client::CancellationToken GetPartitions(
+      PartitionsRequest request, Callback<PartitionsResponse> callback);
 
   /**
    * @brief GetData fetches data for a partition or data handle asynchronously.

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClient.cpp
@@ -17,9 +17,9 @@
  * License-Filename: LICENSE
  */
 
+#include <olp/core/porting/make_unique.h>
 #include <olp/dataservice/read/VolatileLayerClient.h>
 
-#include <olp/core/porting/make_unique.h>
 #include "VolatileLayerClientImpl.h"
 
 namespace olp {
@@ -33,6 +33,11 @@ VolatileLayerClient::VolatileLayerClient(client::HRN catalog,
           std::move(catalog), std::move(layer_id), std::move(settings))) {}
 
 VolatileLayerClient::~VolatileLayerClient() = default;
+
+client::CancellationToken VolatileLayerClient::GetPartitions(
+    PartitionsRequest request, Callback<PartitionsResponse> callback) {
+  return impl_->GetPartitions(std::move(request), std::move(callback));
+}
 
 client::CancellationToken VolatileLayerClient::GetData(
     DataRequest request, Callback<DataResponse> callback) {

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
@@ -19,20 +19,26 @@
 
 #pragma once
 
-#include <memory>
-
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/dataservice/read/DataRequest.h>
+#include <olp/dataservice/read/PartitionsRequest.h>
 #include <olp/dataservice/read/model/Data.h>
+#include <olp/dataservice/read/model/Partitions.h>
+
 #include "PendingRequests.h"
 
 namespace olp {
 namespace dataservice {
 namespace read {
+
+namespace repository {
+class CatalogRepository;
+class PartitionsRepository;
+}  // namespace repository
 
 class VolatileLayerClientImpl {
  public:
@@ -40,6 +46,11 @@ class VolatileLayerClientImpl {
   using DataResult = model::Data;
   /// CallbackResponse alias
   using DataResponse = client::ApiResponse<DataResult, client::ApiError>;
+  /// PartitionResult alias
+  using PartitionsResult = model::Partitions;
+  /// CallbackResponse
+  using PartitionsResponse =
+      client::ApiResponse<PartitionsResult, client::ApiError>;
   /// Callback alias
   template <class Response>
   using Callback = std::function<void(Response response)>;
@@ -49,15 +60,19 @@ class VolatileLayerClientImpl {
 
   ~VolatileLayerClientImpl();
 
+  client::CancellationToken GetPartitions(
+      PartitionsRequest request, Callback<PartitionsResponse> callback);
+
   client::CancellationToken GetData(DataRequest request,
                                     Callback<DataResponse> callback);
 
  private:
   client::HRN catalog_;
   std::string layer_id_;
-  client::OlpClientSettings settings_;
+  std::shared_ptr<client::OlpClientSettings> settings_;
   std::shared_ptr<thread::TaskScheduler> task_scheduler_;
   std::shared_ptr<PendingRequests> pending_requests_;
+  std::shared_ptr<repository::PartitionsRepository> partition_repo_;
 };
 
 }  // namespace read

--- a/scripts/linux/fv/olp-cpp-sdk-functional-test.variables
+++ b/scripts/linux/fv/olp-cpp-sdk-functional-test.variables
@@ -17,3 +17,5 @@ export dataservice_read_test_versioned_prefetch_layer="hype-test-prefetch"
 export dataservice_read_test_versioned_prefetch_tile="5904591"
 export dataservice_read_test_versioned_prefetch_subpartition1="23618365"
 export dataservice_read_test_versioned_prefetch_subpartition2="1476147"
+
+export dataservice_read_volatile_layer="testlayer"

--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -23,6 +23,7 @@ set(OLP_SDK_FUNCTIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-dataservice-read/ApiTest.cpp
     ./olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
     ./olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
+    ./olp-cpp-sdk-dataservice-read/DataserviceReadVolatileLayerClientTest.cpp
     ./olp-cpp-sdk-dataservice-write/DataserviceWriteIndexLayerClientTest.cpp
     ./olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientCacheTest.cpp
     ./olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientTest.cpp

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVolatileLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVolatileLayerClientTest.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <chrono>
+#include <iostream>
+#include <string>
+
+#include <gtest/gtest.h>
+#include <olp/authentication/Settings.h>
+#include <olp/authentication/TokenProvider.h>
+#include <olp/core/cache/DefaultCache.h>
+#include <olp/core/client/CancellationToken.h>
+#include <olp/core/client/Condition.h>
+#include <olp/core/client/HRN.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/logging/Log.h>
+#include <olp/core/porting/make_unique.h>
+#include <testutils/CustomParameters.hpp>
+
+#include "olp/dataservice/read/PartitionsRequest.h"
+#include "olp/dataservice/read/VolatileLayerClient.h"
+
+using namespace olp::dataservice::read;
+using namespace testing;
+
+namespace {
+
+const auto kAppIdEnvName = "dataservice_read_test_appid";
+const auto kAppSecretEnvName = "dataservice_read_test_secret";
+const auto kCatalogEnvName = "dataservice_read_test_catalog";
+const auto kLayerEnvName = "dataservice_read_volatile_layer";
+const auto kTimeout = std::chrono::seconds(5);
+
+class VolatileLayerClientTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto network = olp::client::OlpClientSettingsFactory::
+        CreateDefaultNetworkRequestHandler();
+
+    const auto key_id = CustomParameters::getArgument(kAppIdEnvName);
+    const auto secret = CustomParameters::getArgument(kAppSecretEnvName);
+
+    olp::authentication::Settings authentication_settings({key_id, secret});
+    authentication_settings.network_request_handler = network;
+
+    olp::authentication::TokenProviderDefault provider(authentication_settings);
+    olp::client::AuthenticationSettings auth_client_settings;
+    auth_client_settings.provider = provider;
+    settings_ = olp::client::OlpClientSettings();
+    settings_.network_request_handler = network;
+    settings_.authentication_settings = auth_client_settings;
+    olp::cache::CacheSettings cache_settings;
+    settings_.cache = olp::client::OlpClientSettingsFactory::CreateDefaultCache(
+        cache_settings);
+  }
+
+  void TearDown() override {
+    auto network = std::move(settings_.network_request_handler);
+    // when test ends we must be sure that network pointer is not captured
+    // anywhere
+    EXPECT_EQ(network.use_count(), 1);
+  }
+
+  std::string GetTestCatalog() {
+    return CustomParameters::getArgument(kCatalogEnvName);
+  }
+
+  std::string GetTestLayer() {
+    return CustomParameters::getArgument(kLayerEnvName);
+  }
+
+ protected:
+  olp::client::OlpClientSettings settings_;
+};
+
+TEST_F(VolatileLayerClientTest, GetPartitions) {
+  olp::client::HRN hrn(GetTestCatalog());
+  {
+    SCOPED_TRACE("Get Partitions Test");
+
+    VolatileLayerClient client(hrn, GetTestLayer(), settings_);
+
+    olp::client::Condition condition;
+    VolatileLayerClient::PartitionsResponse
+        partitions_response;
+
+    auto callback =
+        [&](VolatileLayerClient::PartitionsResponse
+                response) {
+          partitions_response = std::move(response);
+          condition.Notify();
+        };
+    client.GetPartitions(PartitionsRequest(),
+                         std::move(callback));
+    ASSERT_TRUE(condition.Wait(kTimeout));
+    EXPECT_TRUE(partitions_response.IsSuccessful());
+  }
+
+  {
+    SCOPED_TRACE("Get Partitions Test With CacheAndUpdate option");
+
+    VolatileLayerClient client(hrn, GetTestLayer(), settings_);
+
+    olp::client::Condition condition;
+    VolatileLayerClient::PartitionsResponse
+        partitions_response;
+
+    auto callback =
+        [&](VolatileLayerClient::PartitionsResponse
+                response) {
+          partitions_response = std::move(response);
+          condition.Notify();
+        };
+    client.GetPartitions(
+        PartitionsRequest().WithFetchOption(
+            FetchOptions::CacheWithUpdate),
+        std::move(callback));
+    ASSERT_TRUE(condition.Wait(kTimeout));
+    EXPECT_TRUE(partitions_response.IsSuccessful());
+  }
+
+  {
+    SCOPED_TRACE("Get Partitions Invalid Layer Test");
+
+    VolatileLayerClient client(hrn, "InvalidLayer", settings_);
+
+    olp::client::Condition condition;
+    VolatileLayerClient::PartitionsResponse
+        partitions_response;
+
+    auto callback =
+        [&](VolatileLayerClient::PartitionsResponse
+                response) {
+          partitions_response = std::move(response);
+          condition.Notify();
+        };
+    client.GetPartitions(PartitionsRequest(),
+                         std::move(callback));
+    ASSERT_TRUE(condition.Wait(kTimeout));
+    EXPECT_FALSE(partitions_response.IsSuccessful());
+  }
+
+  {
+    SCOPED_TRACE("Get Partitions Invalid HRN Test");
+
+    VolatileLayerClient client(olp::client::HRN("Invalid"), GetTestLayer(),
+                               settings_);
+
+    olp::client::Condition condition;
+    VolatileLayerClient::PartitionsResponse
+        partitions_response;
+
+    auto callback =
+        [&](VolatileLayerClient::PartitionsResponse
+                response) {
+          partitions_response = std::move(response);
+          condition.Notify();
+        };
+    client.GetPartitions(PartitionsRequest(),
+                         std::move(callback));
+    ASSERT_TRUE(condition.Wait(kTimeout));
+    EXPECT_FALSE(partitions_response.IsSuccessful());
+  }
+}
+
+TEST_F(VolatileLayerClientTest, GetPartitionsDifferentFethOptions) {
+  olp::client::HRN hrn(GetTestCatalog());
+  {
+    SCOPED_TRACE("Get Partitions Online Only");
+
+    VolatileLayerClient client(hrn, GetTestLayer(), settings_);
+
+    olp::client::Condition condition;
+    VolatileLayerClient::PartitionsResponse
+        partitions_response;
+
+    auto callback =
+        [&](VolatileLayerClient::PartitionsResponse
+                response) {
+          partitions_response = std::move(response);
+          condition.Notify();
+        };
+    client.GetPartitions(
+        PartitionsRequest().WithFetchOption(FetchOptions::OnlineOnly),
+        std::move(callback));
+    ASSERT_TRUE(condition.Wait(kTimeout));
+    EXPECT_TRUE(partitions_response.IsSuccessful());
+  }
+  {
+    SCOPED_TRACE("Get Partitions Cache Only");
+
+    VolatileLayerClient client(hrn, GetTestLayer(), settings_);
+
+    olp::client::Condition condition;
+    VolatileLayerClient::PartitionsResponse
+        partitions_response;
+
+    auto callback =
+        [&](VolatileLayerClient::PartitionsResponse
+                response) {
+          partitions_response = std::move(response);
+          condition.Notify();
+        };
+    client.GetPartitions(
+        PartitionsRequest().WithFetchOption(FetchOptions::CacheOnly),
+        std::move(callback));
+    ASSERT_TRUE(condition.Wait(kTimeout));
+    EXPECT_TRUE(partitions_response.IsSuccessful());
+  }
+}
+
+}  // namespace

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -25,6 +25,7 @@ set(OLP_SDK_INTEGRATIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
     ./olp-cpp-sdk-dataservice-read/HttpResponses.h
     ./olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+    ./olp-cpp-sdk-dataservice-read/VolatileLayerClientTest.cpp
     ./olp-cpp-sdk-dataservice-write/HttpResponses.h
     ./olp-cpp-sdk-dataservice-write/IndexLayerClientTest.cpp
     ./olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientTest.cpp
@@ -1,0 +1,835 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gmock/gmock.h>
+#include <matchers/NetworkUrlMatchers.h>
+#include <mocks/NetworkMock.h>
+#include <olp/core/cache/DefaultCache.h>
+#include <olp/core/client/Condition.h>
+#include <olp/core/client/HRN.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/http/Network.h>
+#include <olp/core/logging/Log.h>
+#include <olp/core/porting/make_unique.h>
+#include <olp/dataservice/read/PartitionsRequest.h>
+#include <olp/dataservice/read/VolatileLayerClient.h>
+
+#include "HttpResponses.h"
+
+namespace {
+
+using namespace olp::dataservice::read;
+using namespace testing;
+using namespace olp::tests::common;
+
+const auto kTimeout = std::chrono::seconds(5);
+
+class DataserviceReadVolatileLayerClientTest : public ::testing::Test {
+ protected:
+  DataserviceReadVolatileLayerClientTest();
+  ~DataserviceReadVolatileLayerClientTest();
+  std::string GetTestCatalog();
+  static std::string ApiErrorToString(const olp::client::ApiError& error);
+
+  void SetUp() override;
+  void TearDown() override;
+
+ private:
+  void SetUpCommonNetworkMockCalls();
+
+ protected:
+  olp::client::OlpClientSettings settings_;
+  std::shared_ptr<olp::tests::common::NetworkMock> network_mock_;
+};
+
+DataserviceReadVolatileLayerClientTest::DataserviceReadVolatileLayerClientTest() = default;
+
+DataserviceReadVolatileLayerClientTest::~DataserviceReadVolatileLayerClientTest() = default;
+
+std::string DataserviceReadVolatileLayerClientTest::GetTestCatalog() {
+  return "hrn:here:data:::hereos-internal-test-v2";
+}
+
+std::string DataserviceReadVolatileLayerClientTest::ApiErrorToString(
+    const olp::client::ApiError& error) {
+  std::ostringstream result_stream;
+  result_stream << "ERROR: code: " << static_cast<int>(error.GetErrorCode())
+                << ", status: " << error.GetHttpStatusCode()
+                << ", message: " << error.GetMessage();
+  return result_stream.str();
+}
+
+void DataserviceReadVolatileLayerClientTest::SetUp() {
+  network_mock_ = std::make_shared<NetworkMock>();
+  settings_ = olp::client::OlpClientSettings();
+  settings_.network_request_handler = network_mock_;
+  olp::cache::CacheSettings cache_settings;
+  settings_.cache =
+      olp::client::OlpClientSettingsFactory::CreateDefaultCache(cache_settings);
+
+  SetUpCommonNetworkMockCalls();
+}
+
+void DataserviceReadVolatileLayerClientTest::TearDown() {
+  ::testing::Mock::VerifyAndClearExpectations(network_mock_.get());
+  network_mock_.reset();
+}
+
+void DataserviceReadVolatileLayerClientTest::SetUpCommonNetworkMockCalls() {
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_LOOKUP_CONFIG));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_CONFIG), _, _, _, _))
+      .WillByDefault(ReturnHttpResponse(
+          olp::http::NetworkResponse().WithStatus(200), HTTP_RESPONSE_CONFIG));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_METADATA), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_LOOKUP_METADATA));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_LATEST_CATALOG_VERSION), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_LATEST_CATALOG_VERSION));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_LAYER_VERSIONS), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_LAYER_VERSIONS));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_PARTITIONS));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_QUERY), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_LOOKUP_QUERY));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_QUERY_PARTITION_269), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_PARTITION_269));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_LOOKUP_BLOB));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_BLOB_DATA_269));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITION_3), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_PARTITION_3));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_LOOKUP_VOLATILE_BLOB), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_LOOKUP_VOLATILE_BLOB));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_LAYER_VERSIONS_V2), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_LAYER_VERSIONS_V2));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS_V2), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_PARTITIONS_V2));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_QUERY_PARTITION_269_V2), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_PARTITION_269_V2));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269_V2), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_BLOB_DATA_269_V2));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_QUERY_PARTITION_269_V10), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(400),
+                             HTTP_RESPONSE_INVALID_VERSION_V10));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_QUERY_PARTITION_269_VN1), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(400),
+                             HTTP_RESPONSE_INVALID_VERSION_VN1));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_LAYER_VERSIONS_V10), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(400),
+                             HTTP_RESPONSE_INVALID_VERSION_V10));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_LAYER_VERSIONS_VN1), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(400),
+                             HTTP_RESPONSE_INVALID_VERSION_VN1));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_CONFIG_V2), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_CONFIG_V2));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_QUADKEYS_23618364), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_QUADKEYS_23618364));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_QUADKEYS_1476147), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_QUADKEYS_1476147));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_QUADKEYS_5904591), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_QUADKEYS_5904591));
+
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_QUADKEYS_369036), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_QUADKEYS_369036));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_1), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_BLOB_DATA_PREFETCH_1));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_2), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_BLOB_DATA_PREFETCH_2));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_3), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_BLOB_DATA_PREFETCH_3));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_4), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_BLOB_DATA_PREFETCH_4));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_5), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_BLOB_DATA_PREFETCH_5));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_6), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_BLOB_DATA_PREFETCH_6));
+
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_7), _, _, _, _))
+      .WillByDefault(
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                             HTTP_RESPONSE_BLOB_DATA_PREFETCH_7));
+
+  // Catch any non-interesting network calls that don't need to be verified
+  EXPECT_CALL(*network_mock_, Send(_, _, _, _, _)).Times(testing::AtLeast(0));
+}
+
+TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitions) {
+  olp::client::HRN hrn(GetTestCatalog());
+
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_CONFIG), _, _, _, _))
+      .Times(1);
+
+  olp::dataservice::read::VolatileLayerClient client(hrn, "testlayer",
+                                                     settings_);
+
+  auto request = olp::dataservice::read::PartitionsRequest();
+  VolatileLayerClient::PartitionsResponse partitions_response;
+  olp::client::Condition condition;
+  client.GetPartitions(request,
+                       [&](VolatileLayerClient::PartitionsResponse response) {
+                         partitions_response = std::move(response);
+                         condition.Notify();
+                       });
+
+  ASSERT_TRUE(condition.Wait(kTimeout));
+
+  ASSERT_TRUE(partitions_response.IsSuccessful())
+      << ApiErrorToString(partitions_response.GetError());
+  ASSERT_EQ(4u, partitions_response.GetResult().GetPartitions().size());
+}
+
+TEST_F(DataserviceReadVolatileLayerClientTest, GetEmptyPartitions) {
+  olp::client::HRN hrn(GetTestCatalog());
+
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                                   HTTP_RESPONSE_EMPTY_PARTITIONS));
+
+  olp::dataservice::read::VolatileLayerClient client(hrn, "testlayer",
+                                                     settings_);
+
+  auto request = olp::dataservice::read::PartitionsRequest();
+  VolatileLayerClient::PartitionsResponse partitions_response;
+  olp::client::Condition condition;
+  client.GetPartitions(request,
+                       [&](VolatileLayerClient::PartitionsResponse response) {
+                         partitions_response = std::move(response);
+                         condition.Notify();
+                       });
+
+  ASSERT_TRUE(condition.Wait(kTimeout));
+
+  ASSERT_TRUE(partitions_response.IsSuccessful())
+      << ApiErrorToString(partitions_response.GetError());
+  ASSERT_EQ(0u, partitions_response.GetResult().GetPartitions().size());
+}
+
+TEST_F(DataserviceReadVolatileLayerClientTest, GetVolatilePartitions) {
+  olp::client::HRN hrn(GetTestCatalog());
+
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(URL_LATEST_CATALOG_VERSION), _, _, _, _))
+      .Times(0);
+
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest("https://metadata.data.api.platform.here.com/"
+                                "metadata/v1/catalogs/hereos-internal-test-v2/"
+                                "layers/testlayer_volatile/partitions"),
+                   _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                                   HTTP_RESPONSE_PARTITIONS_V2));
+
+  olp::dataservice::read::VolatileLayerClient client(hrn, "testlayer_volatile",
+                                                     settings_);
+
+  auto request = olp::dataservice::read::PartitionsRequest();
+  VolatileLayerClient::PartitionsResponse partitions_response;
+  olp::client::Condition condition;
+  client.GetPartitions(request,
+                       [&](VolatileLayerClient::PartitionsResponse response) {
+                         partitions_response = std::move(response);
+                         condition.Notify();
+                       });
+
+  ASSERT_TRUE(condition.Wait(kTimeout));
+
+  ASSERT_TRUE(partitions_response.IsSuccessful())
+      << ApiErrorToString(partitions_response.GetError());
+  ASSERT_EQ(1u, partitions_response.GetResult().GetPartitions().size());
+}
+
+TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitions429Error) {
+  olp::client::HRN hrn(GetTestCatalog());
+
+  {
+    testing::InSequence s;
+
+    EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
+        .Times(2)
+        .WillRepeatedly(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(429),
+                               "Server busy at the moment."));
+
+    EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
+        .Times(1);
+  }
+
+  olp::client::RetrySettings retry_settings;
+  retry_settings.retry_condition =
+      [](const olp::client::HttpResponse& response) {
+        return 429 == response.status;
+      };
+  settings_.retry_settings = retry_settings;
+  olp::dataservice::read::VolatileLayerClient client(hrn, "testlayer",
+                                                     settings_);
+
+  auto request = olp::dataservice::read::PartitionsRequest();
+  VolatileLayerClient::PartitionsResponse partitions_response;
+  olp::client::Condition condition;
+  client.GetPartitions(request,
+                       [&](VolatileLayerClient::PartitionsResponse response) {
+                         partitions_response = std::move(response);
+                         condition.Notify();
+                       });
+
+  ASSERT_TRUE(condition.Wait(kTimeout));
+
+  ASSERT_TRUE(partitions_response.IsSuccessful())
+      << ApiErrorToString(partitions_response.GetError());
+  ASSERT_EQ(4u, partitions_response.GetResult().GetPartitions().size());
+}
+
+TEST_F(DataserviceReadVolatileLayerClientTest, ApiLookup429) {
+  olp::client::HRN hrn(GetTestCatalog());
+
+  {
+    testing::InSequence s;
+
+    EXPECT_CALL(*network_mock_,
+                Send(IsGetRequest(URL_LOOKUP_METADATA), _, _, _, _))
+        .Times(2)
+        .WillRepeatedly(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(429),
+                               "Server busy at the moment."));
+
+    EXPECT_CALL(*network_mock_,
+                Send(IsGetRequest(URL_LOOKUP_METADATA), _, _, _, _))
+        .Times(1);
+  }
+
+  olp::client::RetrySettings retry_settings;
+  retry_settings.retry_condition =
+      [](const olp::client::HttpResponse& response) {
+        return 429 == response.status;
+      };
+  settings_.retry_settings = retry_settings;
+  olp::dataservice::read::VolatileLayerClient client(hrn, "testlayer",
+                                                     settings_);
+
+  auto request = olp::dataservice::read::PartitionsRequest();
+  VolatileLayerClient::PartitionsResponse partitions_response;
+  olp::client::Condition condition;
+  client.GetPartitions(request,
+                       [&](VolatileLayerClient::PartitionsResponse response) {
+                         partitions_response = std::move(response);
+                         condition.Notify();
+                       });
+
+  ASSERT_TRUE(condition.Wait(kTimeout));
+
+  ASSERT_TRUE(partitions_response.IsSuccessful())
+      << ApiErrorToString(partitions_response.GetError());
+  ASSERT_EQ(4u, partitions_response.GetResult().GetPartitions().size());
+}
+
+TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitionsForInvalidLayer) {
+  olp::client::HRN hrn(GetTestCatalog());
+
+  olp::dataservice::read::VolatileLayerClient client(hrn, "InvalidLayer",
+                                                     settings_);
+
+  auto request = olp::dataservice::read::PartitionsRequest();
+  VolatileLayerClient::PartitionsResponse partitions_response;
+  olp::client::Condition condition;
+  client.GetPartitions(request,
+                       [&](VolatileLayerClient::PartitionsResponse response) {
+                         partitions_response = std::move(response);
+                         condition.Notify();
+                       });
+
+  ASSERT_TRUE(condition.Wait(kTimeout));
+
+  ASSERT_FALSE(partitions_response.IsSuccessful())
+      << ApiErrorToString(partitions_response.GetError());
+  ASSERT_EQ(olp::client::ErrorCode::InvalidArgument,
+            partitions_response.GetError().GetErrorCode());
+}
+
+TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitionsGarbageResponse) {
+  olp::client::HRN hrn(GetTestCatalog());
+
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(URL_LOOKUP_METADATA), _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
+                                   R"jsonString(kd3sdf\)jsonString"));
+
+  olp::dataservice::read::VolatileLayerClient client(hrn, "testlayer",
+                                                     settings_);
+
+  auto request = olp::dataservice::read::PartitionsRequest();
+  VolatileLayerClient::PartitionsResponse partitions_response;
+  olp::client::Condition condition;
+  client.GetPartitions(request,
+                       [&](VolatileLayerClient::PartitionsResponse response) {
+                         partitions_response = std::move(response);
+                         condition.Notify();
+                       });
+
+  ASSERT_TRUE(condition.Wait(kTimeout));
+
+  ASSERT_FALSE(partitions_response.IsSuccessful());
+  ASSERT_EQ(olp::client::ErrorCode::ServiceUnavailable,
+            partitions_response.GetError().GetErrorCode());
+}
+
+TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitionsCancelLookupMetadata) {
+  olp::client::HRN hrn(GetTestCatalog());
+
+  // Setup the expected calls :
+  auto wait_for_cancel = std::make_shared<std::promise<void>>();
+  auto pause_for_cancel = std::make_shared<std::promise<void>>();
+
+  olp::http::RequestId request_id;
+  NetworkCallback send_mock;
+  CancelCallback cancel_mock;
+
+  std::tie(request_id, send_mock, cancel_mock) = GenerateNetworkMockActions(
+      wait_for_cancel, pause_for_cancel, {200, HTTP_RESPONSE_LOOKUP_METADATA});
+
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(URL_LOOKUP_METADATA), _, _, _, _))
+      .Times(1)
+      .WillOnce(testing::Invoke(std::move(send_mock)));
+
+  EXPECT_CALL(*network_mock_, Cancel(request_id))
+      .WillOnce(testing::Invoke(std::move(cancel_mock)));
+
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(URL_LATEST_CATALOG_VERSION), _, _, _, _))
+      .Times(0);
+
+  std::promise<VolatileLayerClient::PartitionsResponse> promise;
+  auto callback = [&promise](VolatileLayerClient::PartitionsResponse response) {
+    promise.set_value(response);
+  };
+
+  VolatileLayerClient client(hrn, "testlayer", settings_);
+
+  auto request = olp::dataservice::read::PartitionsRequest();
+  auto cancel_token = client.GetPartitions(request, callback);
+
+  wait_for_cancel->get_future().get();  // wait for handler to get the request
+  cancel_token.cancel();
+  pause_for_cancel->set_value();  // unblock the handler
+  VolatileLayerClient::PartitionsResponse partitions_response =
+      promise.get_future().get();
+
+  ASSERT_FALSE(partitions_response.IsSuccessful())
+      << ApiErrorToString(partitions_response.GetError());
+  ASSERT_EQ(static_cast<int>(olp::http::ErrorCode::CANCELLED_ERROR),
+            partitions_response.GetError().GetHttpStatusCode());
+  ASSERT_EQ(olp::client::ErrorCode::Cancelled,
+            partitions_response.GetError().GetErrorCode());
+}
+
+TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitionsCancelLatestCatalogVersion) {
+  olp::client::HRN hrn(GetTestCatalog());
+
+  // Setup the expected calls :
+  auto wait_for_cancel = std::make_shared<std::promise<void>>();
+  auto pause_for_cancel = std::make_shared<std::promise<void>>();
+
+  olp::http::RequestId request_id;
+  NetworkCallback send_mock;
+  CancelCallback cancel_mock;
+
+  std::tie(request_id, send_mock, cancel_mock) =
+      GenerateNetworkMockActions(wait_for_cancel, pause_for_cancel,
+                                 {200, HTTP_RESPONSE_LATEST_CATALOG_VERSION});
+
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(URL_LATEST_CATALOG_VERSION), _, _, _, _))
+      .Times(1)
+      .WillOnce(testing::Invoke(std::move(send_mock)));
+
+  EXPECT_CALL(*network_mock_, Cancel(request_id))
+      .WillOnce(testing::Invoke(std::move(cancel_mock)));
+
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(URL_LAYER_VERSIONS), _, _, _, _))
+      .Times(0);
+
+  std::promise<VolatileLayerClient::PartitionsResponse> promise;
+  auto callback = [&promise](VolatileLayerClient::PartitionsResponse response) {
+    promise.set_value(response);
+  };
+
+  VolatileLayerClient client(hrn, "testlayer", settings_);
+
+  auto request = olp::dataservice::read::PartitionsRequest();
+  auto cancel_token = client.GetPartitions(request, callback);
+
+  wait_for_cancel->get_future().get();  // wait for handler to get the request
+  cancel_token.cancel();
+  pause_for_cancel->set_value();  // unblock the handler
+  VolatileLayerClient::PartitionsResponse partitions_response =
+      promise.get_future().get();
+
+  ASSERT_FALSE(partitions_response.IsSuccessful())
+      << ApiErrorToString(partitions_response.GetError());
+  ASSERT_EQ(static_cast<int>(olp::http::ErrorCode::CANCELLED_ERROR),
+            partitions_response.GetError().GetHttpStatusCode())
+      << ApiErrorToString(partitions_response.GetError());
+  ASSERT_EQ(olp::client::ErrorCode::Cancelled,
+            partitions_response.GetError().GetErrorCode())
+      << ApiErrorToString(partitions_response.GetError());
+}
+
+TEST_F(DataserviceReadVolatileLayerClientTest, DISABLED_GetPartitionsCancelLayerVersions) {
+  olp::client::HRN hrn(GetTestCatalog());
+
+  // Setup the expected calls :
+  auto wait_for_cancel = std::make_shared<std::promise<void>>();
+  auto pause_for_cancel = std::make_shared<std::promise<void>>();
+
+  olp::http::RequestId request_id;
+  NetworkCallback send_mock;
+  CancelCallback cancel_mock;
+
+  std::tie(request_id, send_mock, cancel_mock) = GenerateNetworkMockActions(
+      wait_for_cancel, pause_for_cancel, {200, HTTP_RESPONSE_LAYER_VERSIONS});
+
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(URL_LAYER_VERSIONS), _, _, _, _))
+      .Times(1)
+      .WillOnce(testing::Invoke(std::move(send_mock)));
+
+  EXPECT_CALL(*network_mock_, Cancel(request_id))
+      .WillOnce(testing::Invoke(std::move(cancel_mock)));
+
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
+      .Times(0);
+
+  std::promise<VolatileLayerClient::PartitionsResponse> promise;
+  auto callback = [&promise](VolatileLayerClient::PartitionsResponse response) {
+    promise.set_value(response);
+  };
+
+  VolatileLayerClient client(hrn, "testlayer", settings_);
+
+  auto request = olp::dataservice::read::PartitionsRequest();
+  auto cancel_token = client.GetPartitions(request, callback);
+
+  wait_for_cancel->get_future().get();  // wait for handler to get the request
+  cancel_token.cancel();
+  pause_for_cancel->set_value();  // unblock the handler
+  VolatileLayerClient::PartitionsResponse partitions_response =
+      promise.get_future().get();
+
+  ASSERT_FALSE(partitions_response.IsSuccessful())
+      << ApiErrorToString(partitions_response.GetError());
+  ASSERT_EQ(static_cast<int>(olp::http::ErrorCode::CANCELLED_ERROR),
+            partitions_response.GetError().GetHttpStatusCode())
+      << ApiErrorToString(partitions_response.GetError());
+  ASSERT_EQ(olp::client::ErrorCode::Cancelled,
+            partitions_response.GetError().GetErrorCode())
+      << ApiErrorToString(partitions_response.GetError());
+}
+
+TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitionsCacheOnly) {
+  olp::client::HRN hrn(GetTestCatalog());
+
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
+      .Times(0);
+
+  olp::dataservice::read::VolatileLayerClient client(hrn, "testlayer_volatile",
+                                                     settings_);
+
+  auto request = olp::dataservice::read::PartitionsRequest().WithFetchOption(
+      FetchOptions::CacheOnly);
+  VolatileLayerClient::PartitionsResponse partitions_response;
+  olp::client::Condition condition;
+  client.GetPartitions(request,
+                       [&](VolatileLayerClient::PartitionsResponse response) {
+                         partitions_response = std::move(response);
+                         condition.Notify();
+                       });
+
+  ASSERT_TRUE(condition.Wait(kTimeout));
+
+  ASSERT_FALSE(partitions_response.IsSuccessful())
+      << ApiErrorToString(partitions_response.GetError());
+}
+
+TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitionsOnlineOnly) {
+  olp::client::HRN hrn(GetTestCatalog());
+
+  {
+    testing::InSequence s;
+
+    EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_CONFIG), _, _, _, _))
+        .Times(1);
+
+    EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_CONFIG), _, _, _, _))
+        .WillOnce(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(429),
+                               "Server busy at the moment."));
+  }
+
+  olp::dataservice::read::VolatileLayerClient client(hrn, "testlayer",
+                                                     settings_);
+
+  auto request = olp::dataservice::read::PartitionsRequest().WithFetchOption(
+      FetchOptions::OnlineOnly);
+  {
+    VolatileLayerClient::PartitionsResponse partitions_response;
+    olp::client::Condition condition;
+    client.GetPartitions(request,
+                         [&](VolatileLayerClient::PartitionsResponse response) {
+                           partitions_response = std::move(response);
+                           condition.Notify();
+                         });
+
+    ASSERT_TRUE(condition.Wait(kTimeout));
+
+    ASSERT_TRUE(partitions_response.IsSuccessful())
+        << ApiErrorToString(partitions_response.GetError());
+    ASSERT_EQ(4u, partitions_response.GetResult().GetPartitions().size());
+  }
+
+  {
+    VolatileLayerClient::PartitionsResponse partitions_response;
+    olp::client::Condition condition;
+    client.GetPartitions(request,
+                         [&](VolatileLayerClient::PartitionsResponse response) {
+                           partitions_response = std::move(response);
+                           condition.Notify();
+                         });
+
+    ASSERT_TRUE(condition.Wait(kTimeout));
+    // Should fail despite valid cache entry
+    ASSERT_FALSE(partitions_response.IsSuccessful())
+        << ApiErrorToString(partitions_response.GetError());
+  }
+}
+
+TEST_F(DataserviceReadVolatileLayerClientTest, DISABLED_GetPartitionsCacheWithUpdate) {
+  olp::logging::Log::setLevel(olp::logging::Level::Trace);
+
+  olp::client::HRN hrn(GetTestCatalog());
+
+  auto wait_to_start_signal = std::make_shared<std::promise<void>>();
+  auto pre_callback_wait = std::make_shared<std::promise<void>>();
+  pre_callback_wait->set_value();
+  auto wait_for_end_signal = std::make_shared<std::promise<void>>();
+
+  olp::http::RequestId request_id;
+  NetworkCallback send_mock;
+  CancelCallback cancel_mock;
+
+  std::tie(request_id, send_mock, cancel_mock) = GenerateNetworkMockActions(
+      wait_to_start_signal, pre_callback_wait, {200, HTTP_RESPONSE_PARTITIONS},
+      wait_for_end_signal);
+
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
+      .Times(1)
+      .WillOnce(testing::Invoke(std::move(send_mock)));
+
+  EXPECT_CALL(*network_mock_, Cancel(request_id))
+      .WillOnce(testing::Invoke(std::move(cancel_mock)));
+
+  olp::dataservice::read::VolatileLayerClient client(hrn, "testlayer",
+                                                     settings_);
+  auto request = olp::dataservice::read::PartitionsRequest().WithFetchOption(
+      FetchOptions::CacheWithUpdate);
+  {
+    VolatileLayerClient::PartitionsResponse partitions_response;
+    olp::client::Condition condition;
+    client.GetPartitions(request,
+                         [&](VolatileLayerClient::PartitionsResponse response) {
+                           partitions_response = std::move(response);
+                           condition.Notify();
+                         });
+
+    ASSERT_TRUE(condition.Wait(kTimeout));
+
+    // Request 1 return. Cached value (nothing)
+    ASSERT_FALSE(partitions_response.IsSuccessful())
+        << ApiErrorToString(partitions_response.GetError());
+  }
+
+  {
+    // Request 2 to check there is a cached value.
+    wait_for_end_signal->get_future().get();
+    request.WithFetchOption(CacheOnly);
+    VolatileLayerClient::PartitionsResponse partitions_response;
+    olp::client::Condition condition;
+    client.GetPartitions(request,
+                         [&](VolatileLayerClient::PartitionsResponse response) {
+                           partitions_response = std::move(response);
+                           condition.Notify();
+                         });
+
+    ASSERT_TRUE(condition.Wait(kTimeout));
+    // Cache should be available here.
+    ASSERT_TRUE(partitions_response.IsSuccessful())
+        << ApiErrorToString(partitions_response.GetError());
+  }
+}
+
+TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitions403CacheClear) {
+  olp::client::HRN hrn(GetTestCatalog());
+  olp::dataservice::read::VolatileLayerClient client(hrn, "testlayer",
+                                                     settings_);
+  {
+    testing::InSequence s;
+    EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
+        .Times(1);
+    EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(403), HTTP_RESPONSE_403));
+  }
+
+  // Populate cache
+  auto request = olp::dataservice::read::PartitionsRequest();
+  VolatileLayerClient::PartitionsResponse partitions_response;
+  olp::client::Condition condition;
+  client.GetPartitions(request,
+                       [&](VolatileLayerClient::PartitionsResponse response) {
+                         partitions_response = std::move(response);
+                         condition.Notify();
+                       });
+
+  ASSERT_TRUE(condition.Wait(kTimeout));
+  ASSERT_TRUE(partitions_response.IsSuccessful());
+
+  // Receive 403
+  request.WithFetchOption(OnlineOnly);
+  client.GetPartitions(request,
+                       [&](VolatileLayerClient::PartitionsResponse response) {
+                         partitions_response = std::move(response);
+                         condition.Notify();
+                       });
+  ASSERT_TRUE(condition.Wait(kTimeout));
+  ASSERT_FALSE(partitions_response.IsSuccessful());
+  ASSERT_EQ(403, partitions_response.GetError().GetHttpStatusCode());
+
+  // Check for cached response
+  request.WithFetchOption(CacheOnly);
+  client.GetPartitions(request,
+                       [&](VolatileLayerClient::PartitionsResponse response) {
+                         partitions_response = std::move(response);
+                         condition.Notify();
+                       });
+  ASSERT_TRUE(condition.Wait(kTimeout));
+  ASSERT_FALSE(partitions_response.IsSuccessful());
+}
+
+}  // namespace


### PR DESCRIPTION
Added functional tests for VolatileLayerClient::GetPartitions()

Resolves: OLPEDGE-792

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>