### PR TITLE
Align VersionedLayerClient with VolatileLayerClient

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -68,13 +68,14 @@ class DATASERVICE_READ_API VersionedLayerClient final {
 
   /**
    * @brief VersionedLayerClient constructor
-   * @param catalog this versioned layer client uses during requests.
-   * @param layer_id this versioned layer client uses during requests.
-   * @param settings the settings used to control behaviour of the client
-   * instance.
+   * @param catalog a catalog that the versioned layer client uses during
+   * requests.
+   * @param layer_id a layer id that the versioned layer client uses during
+   * requests.
+   * @param settings settings used to control the client instance behavior.
    */
-  VersionedLayerClient(olp::client::HRN catalog, std::string layer_id,
-                       olp::client::OlpClientSettings client_settings);
+  VersionedLayerClient(client::HRN catalog, std::string layer_id,
+                       client::OlpClientSettings settings);
 
   ~VersionedLayerClient();
 
@@ -91,8 +92,8 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    * error is encountered.
    * @return A token that can be used to cancel this request.
    */
-  olp::client::CancellationToken GetData(DataRequest data_request,
-                                         Callback callback);
+  client::CancellationToken GetData(DataRequest data_request,
+                                    Callback callback);
 
   /**
    * @brief fetches a list partitions for given generic layer asynchronously.
@@ -123,7 +124,7 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    * available, or an error is encountered.
    * @return A token that can be used to cancel this request.
    */
-  olp::client::CancellationToken PrefetchTiles(
+  client::CancellationToken PrefetchTiles(
       PrefetchTilesRequest request, PrefetchTilesResponseCallback callback);
 
  private:

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
@@ -87,8 +87,7 @@ class DATASERVICE_READ_API VolatileLayerClient final {
    * requests.
    * @param layer_id a layer id that the volatile layer client uses during
    * requests.
-   * @param client_settings settings used to control the client instance
-   * behavior.
+   * @param settings settings used to control the client instance behavior.
    */
   VolatileLayerClient(client::HRN catalog, std::string layer_id,
                       client::OlpClientSettings settings);

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
@@ -26,16 +26,15 @@ namespace olp {
 namespace dataservice {
 namespace read {
 
-VersionedLayerClient::VersionedLayerClient(
-    olp::client::HRN catalog, std::string layer_id,
-    olp::client::OlpClientSettings client_settings)
+VersionedLayerClient::VersionedLayerClient(client::HRN catalog,
+                                           std::string layer_id,
+                                           client::OlpClientSettings settings)
     : impl_(std::make_unique<VersionedLayerClientImpl>(
-          std::move(catalog), std::move(layer_id),
-          std::move(client_settings))) {}
+          std::move(catalog), std::move(layer_id), std::move(settings))) {}
 
 VersionedLayerClient::~VersionedLayerClient() = default;
 
-olp::client::CancellationToken VersionedLayerClient::GetData(
+client::CancellationToken VersionedLayerClient::GetData(
     DataRequest data_request, Callback callback) {
   return impl_->GetData(std::move(data_request), std::move(callback));
 }
@@ -46,7 +45,7 @@ client::CancellationToken VersionedLayerClient::GetPartitions(
                               std::move(callback));
 }
 
-olp::client::CancellationToken VersionedLayerClient::PrefetchTiles(
+client::CancellationToken VersionedLayerClient::PrefetchTiles(
     PrefetchTilesRequest request, PrefetchTilesResponseCallback callback) {
   return impl_->PrefetchTiles(std::move(request), std::move(callback));
 }

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -70,28 +70,24 @@ class VersionedLayerClientImpl {
   using PrefetchTilesResponseCallback =
       std::function<void(const PrefetchTilesResponse& response)>;
 
-  VersionedLayerClientImpl(olp::client::HRN catalog, std::string layer_id,
-                           olp::client::OlpClientSettings client_settings);
+  VersionedLayerClientImpl(client::HRN catalog, std::string layer_id,
+                           client::OlpClientSettings settings);
 
   virtual ~VersionedLayerClientImpl();
 
-  virtual olp::client::CancellationToken GetData(DataRequest data_request,
-                                                 Callback callback) const;
+  virtual client::CancellationToken GetData(DataRequest data_request,
+                                            Callback callback) const;
 
   virtual client::CancellationToken GetPartitions(
       PartitionsRequest partitions_request, PartitionsCallback callback) const;
 
-  virtual olp::client::CancellationToken PrefetchTiles(
+  virtual client::CancellationToken PrefetchTiles(
       PrefetchTilesRequest request, PrefetchTilesResponseCallback callback);
 
- private:
-  olp::client::CancellationToken AddGetDataTask(DataRequest data_request,
-                                                Callback callback) const;
-
  protected:
-  olp::client::HRN catalog_;
+  client::HRN catalog_;
   std::string layer_id_;
-  std::shared_ptr<olp::client::OlpClientSettings> settings_;
+  std::shared_ptr<client::OlpClientSettings> settings_;
   std::shared_ptr<thread::TaskScheduler> task_scheduler_;
   std::shared_ptr<PendingRequests> pending_requests_;
   std::shared_ptr<repository::PartitionsRepository> partition_repo_;

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClient.cpp
@@ -26,16 +26,15 @@ namespace olp {
 namespace dataservice {
 namespace read {
 
-VolatileLayerClient::VolatileLayerClient(
-    olp::client::HRN catalog, std::string layer_id,
-    olp::client::OlpClientSettings settings)
+VolatileLayerClient::VolatileLayerClient(client::HRN catalog,
+                                         std::string layer_id,
+                                         client::OlpClientSettings settings)
     : impl_(std::make_unique<VolatileLayerClientImpl>(
-          std::move(catalog), std::move(layer_id),
-          std::move(settings))) {}
+          std::move(catalog), std::move(layer_id), std::move(settings))) {}
 
 VolatileLayerClient::~VolatileLayerClient() = default;
 
-olp::client::CancellationToken VolatileLayerClient::GetData(
+client::CancellationToken VolatileLayerClient::GetData(
     DataRequest request, Callback<DataResponse> callback) {
   return impl_->GetData(std::move(request), std::move(callback));
 }

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -92,9 +92,9 @@ client::CancellationToken VolatileLayerClientImpl::GetData(
       cache_token.cancel();
       online_token.cancel();
     });
+  } else {
+    return add_task(request, std::move(callback));
   }
-
-  return add_task(request, std::move(callback));
 }
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
@@ -54,10 +54,11 @@ class DataRepository final {
                const std::string& layerType, const read::DataRequest& request,
                const read::DataResponseCallback& callback);
 
-  static DataResponse GetVersionedData(
-      olp::client::HRN catalog, std::string layer_id,
-      olp::client::OlpClientSettings client_settings, DataRequest data_request,
-      olp::client::CancellationContext context);
+  static DataResponse GetVersionedData(const client::HRN& catalog,
+                                       const std::string& layer_id,
+                                       DataRequest data_request,
+                                       client::CancellationContext context,
+                                       client::OlpClientSettings settings);
 
   static DataResponse GetVolatileData(const client::HRN& catalog,
                                       const std::string& layer_id,


### PR DESCRIPTION
Remove olp namespace for parameters.
Align GetData implementation.
Align the order of parameters in DataRepository.

Relates-To: OLPEDGE-957

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>