### PR TITLE
Fixed the VersionedClient's Prefetch functional test on FV

### DIFF
--- a/scripts/linux/fv/olp-cpp-sdk-functional-test.variables
+++ b/scripts/linux/fv/olp-cpp-sdk-functional-test.variables
@@ -12,3 +12,8 @@ export dataservice_read_test_versioned_layer="omv-base-v2"
 export dataservice_read_test_versioned_partition="269"
 export dataservice_read_test_versioned_layer_version="108"
 
+export dataservice_read_test_versioned_prefetch_catalog="hrn:here:data:::hereos-internal-test-v2"
+export dataservice_read_test_versioned_prefetch_layer="hype-test-prefetch"
+export dataservice_read_test_versioned_prefetch_tile="5904591"
+export dataservice_read_test_versioned_prefetch_subpartition1="23618365"
+export dataservice_read_test_versioned_prefetch_subpartition2="1476147"

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
@@ -171,10 +171,13 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataFromPartitionSync) {
 }
 
 TEST_F(DataserviceReadVersionedLayerClientTest, Prefetch) {
-  const auto catalog = olp::client::HRN::FromString(
-      CustomParameters::getArgument("dataservice_read_test_versioned_catalog"));
-  constexpr auto kLayerId = "hype-test-prefetch";
-  constexpr auto kTileId = "5904591";
+  const auto catalog =
+      olp::client::HRN::FromString(CustomParameters::getArgument(
+          "dataservice_read_test_versioned_prefetch_catalog"));
+  const auto kLayerId = CustomParameters::getArgument(
+      "dataservice_read_test_versioned_prefetch_layer");
+  const auto kTileId = CustomParameters::getArgument(
+      "dataservice_read_test_versioned_prefetch_tile");
 
   auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
       catalog, kLayerId, *settings_);
@@ -230,10 +233,12 @@ TEST_F(DataserviceReadVersionedLayerClientTest, Prefetch) {
 
   {
     SCOPED_TRACE("Read cached data from pre-fetched sub-partition #1");
+    const auto kSubPartitionId1 = CustomParameters::getArgument(
+        "dataservice_read_test_versioned_prefetch_subpartition1");
     VersionedLayerClient::CallbackResponse response;
     auto token = client->GetData(
         olp::dataservice::read::DataRequest()
-            .WithPartitionId("23618365")
+            .WithPartitionId(kSubPartitionId1)
             .WithFetchOption(CacheOnly),
         [&response](VersionedLayerClient::CallbackResponse resp) {
           response = std::move(resp);
@@ -245,10 +250,12 @@ TEST_F(DataserviceReadVersionedLayerClientTest, Prefetch) {
 
   {
     SCOPED_TRACE("Read cached data from pre-fetched sub-partition #2");
+    const auto kSubPartitionId2 = CustomParameters::getArgument(
+        "dataservice_read_test_versioned_prefetch_subpartition2");
     VersionedLayerClient::CallbackResponse response;
     auto token = client->GetData(
         olp::dataservice::read::DataRequest()
-            .WithPartitionId("1476147")
+            .WithPartitionId(kSubPartitionId2)
             .WithFetchOption(CacheOnly),
         [&response](VersionedLayerClient::CallbackResponse resp) {
           response = std::move(resp);


### PR DESCRIPTION
Fixed the DataserviceReadVersionedLayerClientTest.Prefetch functional test on FV job by providing the additional prefetch variables.
Also, updated the olp-cpp-sdk-functional-test.variables with new prefetch values.

Fixes: OLPEDGE-964

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>