### PR TITLE
Update FV test scripts. Add extra error logs into console of crashed test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@ image: ${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${DOCKER_IMAGE_VERSION}
 
 variables:
   LD_PRELOAD: "/lib/x86_64-linux-gnu/libSegFault.so"
+  SEGFAULT_SIGNALS: "all"
 
 stages:
   - build

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: xenial
 env:
   global:
   - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
+  - SEGFAULT_SIGNALS=all
   - WORKSPACE=$TRAVIS_BUILD_DIR
 addons:
   apt:

--- a/scripts/linux/fv/gitlab_build_fv.sh
+++ b/scripts/linux/fv/gitlab_build_fv.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 mkdir -p build && cd build
 cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -OLP_SDK_BUILD_EXAMPLES=ON -DOLP_SDK_BUILD_DOC=ON -DBUILD_SHARED_LIBS=ON ..
-make -j8
+make -j$(nproc)
 make docs
 cd ..

--- a/scripts/linux/psv/travis_build_psv.sh
+++ b/scripts/linux/psv/travis_build_psv.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -xe
+#for core dump backtrace
+ulimit -c unlimited
+
 mkdir -p build
 cd build
 cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
@@ -7,6 +10,5 @@ cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
     ..
 
-make -j8
-cd ..
+make -j$(nproc)
 ccache -s

--- a/scripts/linux/psv/travis_test_psv.sh
+++ b/scripts/linux/psv/travis_test_psv.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -e
+#for core dump backtrace
+ulimit -c unlimited
+
 CPP_TEST_SOURCE_AUTHENTICATION=build/olp-cpp-sdk-authentication/tests
 CPP_TEST_SOURCE_CORE=build/olp-cpp-sdk-core/tests
 CPP_TEST_SOURCE_DARASERVICE_READ=build/olp-cpp-sdk-dataservice-read/tests


### PR DESCRIPTION
For more crash backtraces in case of signal Aborted add SEGFAULT_SIGNALS = all for linux builds.
Tested and reproduced crash on Gitlab.

Relates-To: OLPEDGE-473, OLPEDGE-903, OLPEDGE-917

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>