### PR TITLE
Renamed the FlushSettings -> StreamLayerClientSettings

### DIFF
--- a/examples/dataservice-write/example.cpp
+++ b/examples/dataservice-write/example.cpp
@@ -73,8 +73,10 @@ int RunExample() {
   client_settings.authentication_settings = auth_settings;
   client_settings.network_request_handler = std::move(http_client);
 
+  auto stream_client_settings = StreamLayerClientSettings{};
   auto client = std::make_shared<StreamLayerClient>(
-      olp::client::HRN{kCatalogHRN}, std::move(client_settings));
+      olp::client::HRN{kCatalogHRN}, std::move(stream_client_settings),
+      std::move(client_settings));
 
   // Create a publish data request
   auto request = PublishDataRequest().WithData(buffer).WithLayerId(kLayer);

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClient.h
@@ -25,7 +25,7 @@
 #include <olp/core/client/ApiResponse.h>
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/dataservice/write/DataServiceWriteApi.h>
-#include <olp/dataservice/write/FlushSettings.h>
+#include <olp/dataservice/write/StreamLayerClientSettings.h>
 #include <olp/dataservice/write/generated/model/ResponseOk.h>
 #include <olp/dataservice/write/generated/model/ResponseOkSingle.h>
 #include <olp/dataservice/write/model/FlushRequest.h>
@@ -72,13 +72,16 @@ class DATASERVICE_WRITE_API StreamLayerClient {
   /**
    * @brief StreamLayerClient Constructor.
    * @param catalog OLP HRN specifying the catalog this client will write to.
+   * @param client_settings The \c StreamLayerClient settings used to control
+   * the behaviour of flush mechanism and other StreamLayerClient specific
+   * properties.
    * @param settings Client settings used to control behaviour of this
    * StreamLayerClient instance.
-   * @param flush_settings Optional defines settings that effect cached
    * partitions to be flushed. is provided a default in-memory cache is used.
    */
-  StreamLayerClient(client::HRN catalog, client::OlpClientSettings settings,
-                    FlushSettings flush_settings = FlushSettings());
+  StreamLayerClient(client::HRN catalog,
+                    StreamLayerClientSettings client_settings,
+                    client::OlpClientSettings settings);
 
   /**
    * @brief Call to publish data into an OLP Stream Layer.

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClientSettings.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClientSettings.h
@@ -29,7 +29,11 @@ namespace olp {
 namespace dataservice {
 namespace write {
 
-struct DATASERVICE_WRITE_API FlushSettings {
+/**
+ * @brief StreamLayerClientSettings settings class for \c StreamLayerClient. Use
+ * this class to configure the behaviour of \c StreamLayerClient specific logic.
+ */
+struct DATASERVICE_WRITE_API StreamLayerClientSettings {
   /**
     @brief The maximum number of requests that can be stored
     boost::none to store all requests. Must be positive.

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClient.cpp
@@ -35,14 +35,14 @@ std::shared_ptr<cache::KeyValueCache> CreateDefaultCache(
 }
 
 StreamLayerClient::StreamLayerClient(client::HRN catalog,
-                                     client::OlpClientSettings settings,
-                                     FlushSettings flush_settings) {
+                                     StreamLayerClientSettings client_settings,
+                                     client::OlpClientSettings settings) {
   if (!settings.cache) {
     settings.cache = client::OlpClientSettingsFactory::CreateDefaultCache({});
   }
 
   impl_ = std::make_shared<StreamLayerClientImpl>(
-      std::move(catalog), std::move(settings), std::move(flush_settings));
+      std::move(catalog), std::move(client_settings), std::move(settings));
 }
 
 olp::client::CancellableFuture<PublishDataResponse>

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
@@ -74,9 +74,9 @@ void ExecuteOrSchedule(const OlpClientSettings& settings,
 }
 }  // namespace
 
-StreamLayerClientImpl::StreamLayerClientImpl(HRN catalog,
-                                             OlpClientSettings settings,
-                                             FlushSettings flush_settings)
+StreamLayerClientImpl::StreamLayerClientImpl(
+    HRN catalog, StreamLayerClientSettings client_settings,
+    OlpClientSettings settings)
     : catalog_(std::move(catalog)),
       catalog_model_(),
       settings_(std::move(settings)),
@@ -89,7 +89,7 @@ StreamLayerClientImpl::StreamLayerClientImpl(HRN catalog,
       init_inprogress_(false),
       cache_(settings_.cache),
       cache_mutex_(),
-      flush_settings_(std::move(flush_settings)),
+      stream_client_settings_(std::move(client_settings)),
       auto_flush_controller_(new AutoFlushController(AutoFlushSettings{})) {}
 
 CancellationToken StreamLayerClientImpl::InitApiClients(
@@ -286,9 +286,9 @@ boost::optional<std::string> StreamLayerClientImpl::Queue(
         "PublishDataRequest does not contain a Layer ID");
   }
 
-  if (flush_settings_.maximum_requests) {
+  if (stream_client_settings_.maximum_requests) {
     if (!(StreamLayerClientImpl::QueueSize() <
-          *flush_settings_.maximum_requests)) {
+          *stream_client_settings_.maximum_requests)) {
       return boost::make_optional<std::string>(
           "Maximum number of requests has reached");
     }

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.h
@@ -46,8 +46,9 @@ using InitCatalogModelCallback =
 class StreamLayerClientImpl
     : public std::enable_shared_from_this<StreamLayerClientImpl> {
  public:
-  StreamLayerClientImpl(client::HRN catalog, client::OlpClientSettings settings,
-                        FlushSettings flush_settings);
+  StreamLayerClientImpl(client::HRN catalog,
+                        StreamLayerClientSettings client_settings,
+                        client::OlpClientSettings settings);
 
   olp::client::CancellableFuture<PublishDataResponse> PublishData(
       const model::PublishDataRequest& request);
@@ -112,7 +113,7 @@ class StreamLayerClientImpl
 
   std::shared_ptr<cache::KeyValueCache> cache_;
   mutable std::mutex cache_mutex_;
-  FlushSettings flush_settings_;
+  StreamLayerClientSettings stream_client_settings_;
   std::unique_ptr<AutoFlushController> auto_flush_controller_;
 };
 

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientCacheTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientCacheTest.cpp
@@ -155,7 +155,7 @@ class DataserviceWriteStreamLayerClientCacheTest : public ::testing::Test {
     settings.cache = disk_cache_;
 
     return std::make_shared<StreamLayerClient>(
-        olp::client::HRN{GetTestCatalog()}, settings, flush_settings_);
+        olp::client::HRN{GetTestCatalog()}, stream_client_settings_, settings);
   }
 
  private:
@@ -177,7 +177,7 @@ class DataserviceWriteStreamLayerClientCacheTest : public ::testing::Test {
   std::shared_ptr<std::vector<unsigned char>> data_;
 
   std::shared_ptr<olp::cache::DefaultCache> disk_cache_;
-  FlushSettings flush_settings_;
+  StreamLayerClientSettings stream_client_settings_;
 };
 
 // Static network instance is necessary as it needs to outlive any created

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientTest.cpp
@@ -184,7 +184,8 @@ class DataserviceWriteStreamLayerClientTest : public ::testing::Test {
         olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler(1u);
 
     return std::make_shared<StreamLayerClient>(
-        olp::client::HRN{GetTestCatalog()}, settings);
+        olp::client::HRN{GetTestCatalog()}, StreamLayerClientSettings{},
+        settings);
   }
 
  private:

--- a/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
@@ -134,7 +134,7 @@ class StreamLayerClientCacheTest : public ::testing::Test {
     SetUpCommonNetworkMockCalls(*network_);
 
     return std::make_shared<StreamLayerClient>(
-        olp::client::HRN{GetTestCatalog()}, client_settings, flush_settings_);
+        olp::client::HRN{GetTestCatalog()}, stream_client_settings_, client_settings);
   }
 
   void SetUpCommonNetworkMockCalls(NetworkMock& network) {
@@ -282,7 +282,7 @@ class StreamLayerClientCacheTest : public ::testing::Test {
 
  protected:
   std::shared_ptr<olp::cache::DefaultCache> disk_cache_;
-  FlushSettings flush_settings_;
+  StreamLayerClientSettings stream_client_settings_;
   std::shared_ptr<NetworkMock> network_;
   std::shared_ptr<StreamLayerClient> client_;
   std::shared_ptr<std::vector<unsigned char>> data_;
@@ -438,7 +438,7 @@ TEST_F(StreamLayerClientCacheTest, FlushDataMaxEventsInvalidCustomSetting) {
 
 TEST_F(StreamLayerClientCacheTest, FlushSettingsMaximumRequests) {
   disk_cache_->Close();
-  ASSERT_EQ(flush_settings_.maximum_requests, boost::none);
+  ASSERT_EQ(stream_client_settings_.maximum_requests, boost::none);
   client_ = CreateStreamLayerClient();
   {
     testing::InSequence dummy;
@@ -460,14 +460,14 @@ TEST_F(StreamLayerClientCacheTest, FlushSettingsMaximumRequests) {
   for (auto& single_response : response) {
     ASSERT_NO_FATAL_FAILURE(PublishDataSuccessAssertions(single_response));
   }
-  flush_settings_.maximum_requests = 10;
+  stream_client_settings_.maximum_requests = 10;
   client_ = CreateStreamLayerClient();
   ASSERT_NO_FATAL_FAILURE(MaximumRequestsSuccessAssertions(10));
   client_ = CreateStreamLayerClient();
   ASSERT_NO_FATAL_FAILURE(MaximumRequestsSuccessAssertions(10, 13));
   client_ = CreateStreamLayerClient();
   ASSERT_NO_FATAL_FAILURE(MaximumRequestsSuccessAssertions(10, 9));
-  flush_settings_.maximum_requests = 0;
+  stream_client_settings_.maximum_requests = 0;
   client_ = CreateStreamLayerClient();
   ASSERT_NO_FATAL_FAILURE(MaximumRequestsSuccessAssertions(0, 10));
 }

--- a/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientTest.cpp
@@ -149,7 +149,8 @@ class StreamLayerClientTest : public ::testing::Test {
     SetUpCommonNetworkMockCalls(*network_);
 
     return std::make_shared<StreamLayerClient>(
-        olp::client::HRN{GetTestCatalog()}, client_settings);
+        olp::client::HRN{GetTestCatalog()}, StreamLayerClientSettings{},
+        client_settings);
   }
 
   void SetUpCommonNetworkMockCalls(NetworkMock& network) {


### PR DESCRIPTION
Renamed the FlushSettings into StreamLayerClientSettings. Also, changed the order of parameters in StreamLayerClient.

Relates to: OLPEDGE-826

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>