### PR TITLE
Implement Prefetch method for Volatile Layer

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
@@ -28,6 +28,8 @@
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/dataservice/read/DataRequest.h>
 #include <olp/dataservice/read/PartitionsRequest.h>
+#include <olp/dataservice/read/PrefetchTileResult.h>
+#include <olp/dataservice/read/PrefetchTilesRequest.h>
 #include <olp/dataservice/read/Types.h>
 
 namespace olp {
@@ -133,6 +135,26 @@ class DATASERVICE_READ_API VolatileLayerClient final {
    * used to cancel this request.
    */
   olp::client::CancellableFuture<DataResponse> GetData(DataRequest request);
+
+  /**
+   * @brief Pre-fetches a set of tiles asychronously.
+   *
+   * This method recursively downloads all tilekeys from minLevel to maxLevel
+   * specified in the \c PrefetchTilesRequest's properties. This will help to
+   * reduce the network load by using the pre-fetched tiles' data from cache.
+   *
+   * \note - this does not guarantee that all tiles are available offline, as
+   * the cache might overflow and data might be evicted at any point.
+   *
+   * @param request contains the complete set of request parameters.
+   * \note The \c PrefetchTilesRequest's GetLayerId value will be ignored and
+   * the parameter from constructore will be used instead.
+   * @param callback will be invoked once the \c PrefetchTilesResult is
+   * available, or an error is encountered.
+   * @return A token that can be used to cancel this request.
+   */
+  olp::client::CancellationToken PrefetchTiles(
+      PrefetchTilesRequest request, PrefetchTilesResponseCallback callback);
 
  private:
   std::unique_ptr<VolatileLayerClientImpl> impl_;

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClient.cpp
@@ -53,6 +53,11 @@ olp::client::CancellableFuture<DataResponse> VolatileLayerClient::GetData(
     DataRequest request) {
   return impl_->GetData(std::move(request));
 }
+
+olp::client::CancellationToken VolatileLayerClient::PrefetchTiles(
+    PrefetchTilesRequest request, PrefetchTilesResponseCallback callback) {
+  return impl_->PrefetchTiles(std::move(request), std::move(callback));
+}
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -23,12 +23,14 @@
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
 
+#include "PrefetchTilesProvider.h"
 #include "TaskContext.h"
 #include "repositories/ApiRepository.h"
 #include "repositories/CatalogRepository.h"
 #include "repositories/DataRepository.h"
 #include "repositories/ExecuteOrSchedule.inl"
 #include "repositories/PartitionsRepository.h"
+#include "repositories/PrefetchTilesRepository.h"
 
 namespace olp {
 namespace dataservice {
@@ -63,6 +65,16 @@ VolatileLayerClientImpl::VolatileLayerClientImpl(
 
   partition_repo_ = std::make_shared<repository::PartitionsRepository>(
       catalog_, api_repo, catalog_repo, cache);
+
+  auto data_repo = std::make_shared<repository::DataRepository>(
+      catalog_, api_repo, catalog_repo, partition_repo_, settings_->cache);
+
+  auto prefetch_repo = std::make_shared<repository::PrefetchTilesRepository>(
+      catalog_, api_repo, partition_repo_->GetPartitionsCacheRepository(),
+      settings_);
+
+  prefetch_provider_ = std::make_shared<PrefetchTilesProvider>(
+      catalog_, api_repo, catalog_repo, data_repo, prefetch_repo, settings_);
 }
 
 VolatileLayerClientImpl::~VolatileLayerClientImpl() {
@@ -158,6 +170,23 @@ client::CancellableFuture<DataResponse> VolatileLayerClientImpl::GetData(
   };
   auto token = GetData(std::move(request), std::move(callback));
   return olp::client::CancellableFuture<DataResponse>(token, promise);
+}
+
+client::CancellationToken VolatileLayerClientImpl::PrefetchTiles(
+    PrefetchTilesRequest request, PrefetchTilesResponseCallback callback) {
+  const int64_t request_key = pending_requests_->GenerateRequestPlaceholder();
+  auto pending_requests = pending_requests_;
+  auto request_callback = [=](const PrefetchTilesResponse& response) {
+    pending_requests->Remove(request_key);
+    if (callback) {
+      callback(response);
+    }
+  };
+
+  request.WithLayerId(layer_id_);
+  auto token = prefetch_provider_->PrefetchTiles(request, request_callback);
+  pending_requests->Insert(token, request_key);
+  return token;
 }
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
@@ -24,6 +24,8 @@
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/dataservice/read/DataRequest.h>
 #include <olp/dataservice/read/PartitionsRequest.h>
+#include <olp/dataservice/read/PrefetchTileResult.h>
+#include <olp/dataservice/read/PrefetchTilesRequest.h>
 #include <olp/dataservice/read/Types.h>
 
 #include "PendingRequests.h"
@@ -36,6 +38,8 @@ namespace repository {
 class CatalogRepository;
 class PartitionsRepository;
 }  // namespace repository
+
+class PrefetchTilesProvider;
 
 class VolatileLayerClientImpl {
  public:
@@ -55,6 +59,9 @@ class VolatileLayerClientImpl {
 
   virtual client::CancellableFuture<DataResponse> GetData(DataRequest request);
 
+  client::CancellationToken PrefetchTiles(
+      PrefetchTilesRequest request, PrefetchTilesResponseCallback callback);
+
  private:
   client::HRN catalog_;
   std::string layer_id_;
@@ -62,6 +69,7 @@ class VolatileLayerClientImpl {
   std::shared_ptr<thread::TaskScheduler> task_scheduler_;
   std::shared_ptr<PendingRequests> pending_requests_;
   std::shared_ptr<repository::PartitionsRepository> partition_repo_;
+  std::shared_ptr<PrefetchTilesProvider> prefetch_provider_;
 };
 
 }  // namespace read


### PR DESCRIPTION
    Implementation of PrefetchTiles method for volatile layer, based on
    Catalog client. Disabled tests reproduced issues for cache inconsistency
    between GetData of Volatile layer and PrefetchTiles of PrefetchProvider.
    
    Relates-To: OLPEDGE-957
    Relates-To: OLPEDGE-965
    
    Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>
