### PR TITLE
Add log when BlockingCancel timeouts

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/PendingRequests.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/PendingRequests.cpp
@@ -18,11 +18,17 @@
  */
 
 #include "PendingRequests.h"
+
+#include <olp/core/logging/Log.h>
 #include "TaskContext.h"
 
 namespace olp {
 namespace dataservice {
 namespace read {
+
+namespace {
+constexpr auto kLogTag = "PendingRequests";
+}
 
 PendingRequests::PendingRequests(){};
 
@@ -40,7 +46,9 @@ bool PendingRequests::CancelPendingRequests() {
   }
 
   for (auto context : contexts) {
-    context.BlockingCancel();
+    if (!context.BlockingCancel()) {
+      OLP_SDK_LOG_WARNING(kLogTag, "Timeout, when waiting on BlockingCancel");
+    }
   }
 
   return true;


### PR DESCRIPTION
Introduce log in PendingRequests' CancelPendingRequests on timeout from
BlockingCancel

Relates-To: OLPEDGE-909
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>