### PR TITLE
Add CancellableFuture methods in VolatileLayerClient

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
@@ -112,18 +112,41 @@ class DATASERVICE_READ_API VolatileLayerClient final {
       PartitionsRequest request, Callback<PartitionsResponse> callback);
 
   /**
+   * @brief Fetches a list partitions for given volatile layer asynchronously.
+   * @param request contains the complete set of request parameters.
+   * @return CancellableFuture, which when complete will contain the
+   * PartitionsResponse or an error. Alternatively, the CancellableFuture can be
+   * used to cancel this request.
+   */
+  olp::client::CancellableFuture<PartitionsResponse> GetPartitions(
+      PartitionsRequest request);
+
+  /**
    * @brief GetData fetches data for a partition or data handle asynchronously.
    * If the specified partition or data handle cannot be found in the layer, the
    * callback is invoked with an empty DataResponse (a nullptr result and
    * error). If Partition Id or Data Handle are not set in the request, the
    * callback is invoked with the error ErrorCode::InvalidRequest.
-   * @param request contains a complete set of request parameters.
+   * @param request Contains a complete set of request parameters.
    * @param callback is invoked once the DataResult is available, or an
    * error is encountered.
-   * @return A token that can be used to cancel this request.
+   * @return Token that can be used to cancel this request.
    */
   olp::client::CancellationToken GetData(DataRequest request,
                                          Callback<DataResponse> callback);
+
+  /**
+   * @brief Fetches data for a partition or data handle asynchronously.
+   * If the specified partition or data handle cannot be found in the layer, the
+   * callback is invoked with an empty DataResponse (a nullptr result and
+   * error). If Partition Id or Data Handle are not set in the request, the
+   * callback is invoked with the error ErrorCode::InvalidRequest.
+   * @param request contains a complete set of request parameters.
+   * @return CancellableFuture, which when complete will contain the
+   * PartitionsResponse or an error. Alternatively, the CancellableFuture can be
+   * used to cancel this request.
+   */
+  olp::client::CancellableFuture<DataResponse> GetData(DataRequest request);
 
  private:
   std::unique_ptr<VolatileLayerClientImpl> impl_;

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClient.cpp
@@ -39,9 +39,19 @@ client::CancellationToken VolatileLayerClient::GetPartitions(
   return impl_->GetPartitions(std::move(request), std::move(callback));
 }
 
+olp::client::CancellableFuture<VolatileLayerClient::PartitionsResponse>
+VolatileLayerClient::GetPartitions(PartitionsRequest request) {
+  return impl_->GetPartitions(std::move(request));
+}
+
 client::CancellationToken VolatileLayerClient::GetData(
     DataRequest request, Callback<DataResponse> callback) {
   return impl_->GetData(std::move(request), std::move(callback));
+}
+
+olp::client::CancellableFuture<VolatileLayerClient::DataResponse>
+VolatileLayerClient::GetData(DataRequest request) {
+  return impl_->GetData(std::move(request));
 }
 }  // namespace read
 }  // namespace dataservice

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -22,7 +22,6 @@
 #include <olp/core/cache/DefaultCache.h>
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
-#include <olp/dataservice/read/PartitionsRequest.h>
 
 #include "TaskContext.h"
 #include "repositories/ApiRepository.h"
@@ -100,6 +99,16 @@ client::CancellationToken VolatileLayerClientImpl::GetPartitions(
   return token;
 }
 
+client::CancellableFuture<PartitionsResponse>
+VolatileLayerClientImpl::GetPartitions(PartitionsRequest request) {
+  auto promise = std::make_shared<std::promise<PartitionsResponse> >();
+  auto callback = [=](PartitionsResponse resp) {
+    promise->set_value(std::move(resp));
+  };
+  auto token = GetPartitions(std::move(request), std::move(callback));
+  return olp::client::CancellableFuture<PartitionsResponse>(token, promise);
+}
+
 client::CancellationToken VolatileLayerClientImpl::GetData(
     DataRequest request, Callback<DataResponse> callback) {
   auto add_task = [&](DataRequest& request, Callback<DataResponse> callback) {
@@ -139,6 +148,16 @@ client::CancellationToken VolatileLayerClientImpl::GetData(
   } else {
     return add_task(request, std::move(callback));
   }
+}
+
+client::CancellableFuture<DataResponse> VolatileLayerClientImpl::GetData(
+    DataRequest request) {
+  auto promise = std::make_shared<std::promise<DataResponse> >();
+  auto callback = [=](DataResponse resp) {
+    promise->set_value(std::move(resp));
+  };
+  auto token = GetData(std::move(request), std::move(callback));
+  return olp::client::CancellableFuture<DataResponse>(token, promise);
 }
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
@@ -63,8 +63,13 @@ class VolatileLayerClientImpl {
   client::CancellationToken GetPartitions(
       PartitionsRequest request, Callback<PartitionsResponse> callback);
 
+  client::CancellableFuture<PartitionsResponse> GetPartitions(
+      PartitionsRequest request);
+
   client::CancellationToken GetData(DataRequest request,
                                     Callback<DataResponse> callback);
+
+  client::CancellableFuture<DataResponse> GetData(DataRequest request);
 
  private:
   client::HRN catalog_;


### PR DESCRIPTION
Add GetData and GetPartitions methods to VolatileLayerClient
that return CancellableFuture. Add tests.

Resolves: OLPEDGE-959

Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>