### PR TITLE
Implemented the PrefetchTiles with CancellableFuture in versioned client

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -126,7 +126,28 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    * @return A token that can be used to cancel this request.
    */
   client::CancellationToken PrefetchTiles(
-      PrefetchTilesRequest request, PrefetchTilesResponseCallback callback);
+      PrefetchTilesRequest request,
+      PrefetchTilesResponseCallback callback) const;
+
+  /**
+   * @brief Pre-fetches a set of tiles asychronously.
+   *
+   * This method recursively downloads all tilekeys from minLevel to maxLevel
+   * specified in the \c PrefetchTilesRequest's properties. This will help to
+   * reduce the network load by using the pre-fetched tiles' data from cache.
+   *
+   * \note - this does not guarantee that all tiles are available offline, as
+   * the cache might overflow and data might be evicted at any point.
+   *
+   * @param request contains the complete set of request parameters.
+   * \note The \c PrefetchTilesRequest's GetLayerId value will be ignored and
+   * the parameter from constructore will be used instead.
+   * @return CancellableFuture of type \c PrefetchTilesResponse, which when
+   * complete will contain the data or an error. Alternatively, the
+   * \c CancellableFuture can be used to cancel this request.
+   */
+  client::CancellableFuture<PrefetchTilesResponse> PrefetchTiles(
+      PrefetchTilesRequest request) const;
 
  private:
   std::unique_ptr<VersionedLayerClientImpl> impl_;

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
@@ -46,8 +46,14 @@ client::CancellationToken VersionedLayerClient::GetPartitions(
 }
 
 client::CancellationToken VersionedLayerClient::PrefetchTiles(
-    PrefetchTilesRequest request, PrefetchTilesResponseCallback callback) {
+    PrefetchTilesRequest request,
+    PrefetchTilesResponseCallback callback) const {
   return impl_->PrefetchTiles(std::move(request), std::move(callback));
+}
+
+client::CancellableFuture<VersionedLayerClient::PrefetchTilesResponse>
+VersionedLayerClient::PrefetchTiles(PrefetchTilesRequest request) const {
+  return impl_->PrefetchTiles(std::move(request));
 }
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -82,7 +82,11 @@ class VersionedLayerClientImpl {
       PartitionsRequest partitions_request, PartitionsCallback callback) const;
 
   virtual client::CancellationToken PrefetchTiles(
-      PrefetchTilesRequest request, PrefetchTilesResponseCallback callback);
+      PrefetchTilesRequest request,
+      PrefetchTilesResponseCallback callback) const;
+
+  virtual client::CancellableFuture<PrefetchTilesResponse> PrefetchTiles(
+      PrefetchTilesRequest request) const;
 
  protected:
   client::HRN catalog_;


### PR DESCRIPTION
- Implemented the PrefetchTiles method which returns CancellableFuture in the dataservice-read VersionedLayerClient class.
- aligned the API of PrefetchTiles methods with other methods;
- used the move semantics for the PrefetchTiles responses;

Relates to: OLPEDGE-958

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>