### PR TITLE
Changed the type of StreamLayerClientSettings.maximum_requests

### DIFF
--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClientSettings.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClientSettings.h
@@ -20,8 +20,7 @@
 #pragma once
 
 #include <string>
-
-#include <boost/optional.hpp>
+#include <limits>
 
 #include <olp/dataservice/write/DataServiceWriteApi.h>
 
@@ -35,10 +34,9 @@ namespace write {
  */
 struct DATASERVICE_WRITE_API StreamLayerClientSettings {
   /**
-    @brief The maximum number of requests that can be stored
-    boost::none to store all requests. Must be positive.
-  */
-  boost::optional<size_t> maximum_requests = boost::none;
+   * @brief The maximum number of requests that can be stored. Must be positive.
+   */
+  size_t maximum_requests = std::numeric_limits<size_t>::max();
 };
 
 }  // namespace write

--- a/olp-cpp-sdk-dataservice-write/src/AutoFlushSettings.h
+++ b/olp-cpp-sdk-dataservice-write/src/AutoFlushSettings.h
@@ -36,9 +36,9 @@ struct AutoFlushSettings {
   int auto_flush_interval = 0;
 
   /**
-    @brief The maximum number of partitions to be flushed each time.Set
-    0 to flush all partitions. Non-positive number will flush nothing.
-  */
+   * @brief The maximum number of partitions to be flushed each time.Set
+   *  0 to flush all partitions. Non-positive number will flush nothing.
+   */
   int events_per_single_flush = 0;
 };
 

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
@@ -285,12 +285,10 @@ boost::optional<std::string> StreamLayerClientImpl::Queue(
         "PublishDataRequest does not contain a Layer ID");
   }
 
-  if (stream_client_settings_.maximum_requests) {
-    if (!(StreamLayerClientImpl::QueueSize() <
-          *stream_client_settings_.maximum_requests)) {
-      return boost::make_optional<std::string>(
-          "Maximum number of requests has reached");
-    }
+  if (!(StreamLayerClientImpl::QueueSize() <
+        stream_client_settings_.maximum_requests)) {
+    return boost::make_optional<std::string>(
+        "Maximum number of requests has reached");
   }
 
   {

--- a/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
@@ -437,7 +437,8 @@ TEST_F(StreamLayerClientCacheTest, FlushDataMaxEventsInvalidCustomSetting) {
 
 TEST_F(StreamLayerClientCacheTest, FlushSettingsMaximumRequests) {
   disk_cache_->Close();
-  ASSERT_EQ(stream_client_settings_.maximum_requests, boost::none);
+  const auto kMaxRequests = std::numeric_limits<size_t>::max();
+  ASSERT_EQ(stream_client_settings_.maximum_requests, kMaxRequests);
   client_ = CreateStreamLayerClient();
   {
     testing::InSequence dummy;


### PR DESCRIPTION
Changed the type of StreamLayerClientSettings's maximum_requests property type from boost::optional to size_t.

Relates to: OLPEDGE-826

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>