### PR TITLE
Implemented the GetData with CancellableFuture in versioned client

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -121,6 +121,21 @@ class DATASERVICE_READ_API VersionedLayerClient final {
                                     DataResponseCallback callback);
 
   /**
+   * @brief Fetches data for a partition or data handle asynchronously. If the
+   * specified partition or data handle cannot be found in the layer, the
+   * callback will be invoked with an empty DataResponse (nullptr for result and
+   * error). If neither Partition Id or Data Handle were set in the request, the
+   * callback will be invoked with an error with ErrorCode::InvalidRequest.
+   * @param data_request contains the complete set of request parameters.
+   * \note \c DataRequest's GetLayerId value will be ignored and the parameter
+   * from the constructor will be used instead.
+   * @return \c CancellableFuture of type \c DataResponse, which when
+   * complete will contain the data or an error. Alternatively, the
+   * \c CancellableFuture can be used to cancel this request.
+   */
+  client::CancellableFuture<DataResponse> GetData(DataRequest data_request);
+
+  /**
    * @brief Fetches a list of partitions for the given generic layer
    * asynchronously.
    * @param partitions_request Contains the complete set of the request

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
@@ -39,6 +39,11 @@ client::CancellationToken VersionedLayerClient::GetData(
   return impl_->GetData(std::move(data_request), std::move(callback));
 }
 
+client::CancellableFuture<DataResponse> VersionedLayerClient::GetData(
+    DataRequest data_request) {
+  return impl_->GetData(std::move(data_request));
+}
+
 client::CancellationToken VersionedLayerClient::GetPartitions(
     PartitionsRequest partitions_request, PartitionsResponseCallback callback) {
   return impl_->GetPartitions(std::move(partitions_request),

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -147,6 +147,17 @@ client::CancellationToken VersionedLayerClientImpl::GetData(
   }
 }
 
+client::CancellableFuture<DataResponse> VersionedLayerClientImpl::GetData(
+    DataRequest data_request) {
+  auto promise = std::make_shared<std::promise<DataResponse>>();
+  auto cancel_token =
+      GetData(std::move(data_request), [promise](DataResponse response) {
+        promise->set_value(std::move(response));
+      });
+  return client::CancellableFuture<DataResponse>(std::move(cancel_token),
+                                                 std::move(promise));
+}
+
 client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
     PrefetchTilesRequest request, PrefetchTilesResponseCallback callback) {
   const int64_t request_key = pending_requests_->GenerateRequestPlaceholder();

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -55,6 +55,9 @@ class VersionedLayerClientImpl {
   virtual client::CancellationToken GetData(DataRequest data_request,
                                             DataResponseCallback callback);
 
+  virtual client::CancellableFuture<DataResponse> GetData(
+      DataRequest data_request);
+
   virtual client::CancellationToken GetPartitions(
       PartitionsRequest partitions_request,
       PartitionsResponseCallback callback);


### PR DESCRIPTION
Implemented the GetData method which returns CancellableFuture in the dataservice-read VersionedLayerClient class.
Also, added integration tests.

Relates to: OLPEDGE-958

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>