### PR TITLE
Add GetPartitions with CancellableFuture in VersionedLayerClient

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -150,6 +150,20 @@ class DATASERVICE_READ_API VersionedLayerClient final {
                                           PartitionsResponseCallback callback);
 
   /**
+   * @brief Fetches a list of partitions for the given generic layer
+   * asynchronously.
+   * @param partitions_request Contains the complete set of the request
+   * parameters.
+   * @note GetLayerId value of the \c PartitionsRequest is ignored, and the
+   * parameter from the constructor is used instead.
+   * @return \c CancellableFuture of type \c PartitionsResponse, which when
+   * complete will contain the data or an error. Alternatively, the
+   * \c CancellableFuture can be used to cancel this request.
+   */
+  client::CancellableFuture<PartitionsResponse> GetPartitions(
+      PartitionsRequest partitions_request);
+
+  /**
    * @brief Pre-fetches a set of tiles asychronously.
    *
    * This method recursively downloads all tilekeys from the minLevel to

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
@@ -50,6 +50,11 @@ client::CancellationToken VersionedLayerClient::GetPartitions(
                               std::move(callback));
 }
 
+client::CancellableFuture<PartitionsResponse>
+VersionedLayerClient::GetPartitions(PartitionsRequest partitions_request) {
+  return impl_->GetPartitions(std::move(partitions_request));
+}
+
 client::CancellationToken VersionedLayerClient::PrefetchTiles(
     PrefetchTilesRequest request, PrefetchTilesResponseCallback callback) {
   return impl_->PrefetchTiles(std::move(request), std::move(callback));

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -106,6 +106,17 @@ client::CancellationToken VersionedLayerClientImpl::GetPartitions(
   return token;
 }
 
+client::CancellableFuture<PartitionsResponse>
+VersionedLayerClientImpl::GetPartitions(PartitionsRequest partitions_request) {
+  auto promise = std::make_shared<std::promise<PartitionsResponse>>();
+  auto cancel_token = GetPartitions(std::move(partitions_request),
+                                    [promise](PartitionsResponse response) {
+                                      promise->set_value(std::move(response));
+                                    });
+  return client::CancellableFuture<PartitionsResponse>(std::move(cancel_token),
+                                                       std::move(promise));
+}
+
 client::CancellationToken VersionedLayerClientImpl::GetData(
     DataRequest request, DataResponseCallback callback) {
   auto add_task = [&](DataRequest& request, DataResponseCallback callback) {

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -62,6 +62,9 @@ class VersionedLayerClientImpl {
       PartitionsRequest partitions_request,
       PartitionsResponseCallback callback);
 
+  virtual client::CancellableFuture<PartitionsResponse> GetPartitions(
+      PartitionsRequest partitions_request);
+
   virtual client::CancellationToken PrefetchTiles(
       PrefetchTilesRequest request, PrefetchTilesResponseCallback callback);
 


### PR DESCRIPTION
Add the GetPartitions method which returns CancellableFuture in
the dataservice-read VersionedLayerClient class.
Also, added integration tests.

Relates-To: OLPEDGE-958
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>