### PR TITLE
Configurable max requests count for Curl

### DIFF
--- a/olp-cpp-sdk-core/src/http/Network.cpp
+++ b/olp-cpp-sdk-core/src/http/Network.cpp
@@ -38,7 +38,7 @@ CORE_API std::shared_ptr<Network> CreateDefaultNetwork(
     size_t max_requests_count) {
   CORE_UNUSED(max_requests_count);
 #ifdef NETWORK_HAS_CURL
-  return std::make_shared<NetworkCurl>();
+  return std::make_shared<NetworkCurl>(max_requests_count);
 #elif NETWORK_HAS_ANDROID
   return std::make_shared<NetworkAndroid>();
 #elif NETWORK_HAS_IOS

--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.h
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.h
@@ -50,7 +50,7 @@ class NetworkCurl : public olp::http::Network,
   /**
    * @brief NetworkCurl constructor.
    */
-  NetworkCurl();
+  explicit NetworkCurl(size_t max_requests_count);
 
   /**
    * @brief ~NetworkCurl destructor.
@@ -80,8 +80,7 @@ class NetworkCurl : public olp::http::Network,
   /**
    * @brief Implementation of Send method from Network abstract class.
    */
-  SendOutcome Send(NetworkRequest request,
-                   Payload payload, Callback callback,
+  SendOutcome Send(NetworkRequest request, Payload payload, Callback callback,
                    HeaderCallback header_callback = nullptr,
                    DataCallback data_callback = nullptr) override;
 
@@ -148,12 +147,6 @@ class NetworkCurl : public olp::http::Network,
     /// Associated request context.
     RequestHandle* handle{};
   };
-
-  /// Number of CURL easy handles that are always opened.
-  static constexpr int kStaticHandleCount = 8;
-
-  /// Maximum allowed number of CURL easy handles.
-  static constexpr int kTotalHandleCount = 32;
 
   /**
    * @brief Actual routine that sends network request.
@@ -288,7 +281,10 @@ class NetworkCurl : public olp::http::Network,
   inline bool IsStarted() const;
 
   /// Contexts for every network request.
-  RequestHandle handles_[kTotalHandleCount] = {};
+  std::vector<RequestHandle> handles_;
+
+  /// Number of CURL easy handles that are always opened.
+  const size_t static_handle_count_;
 
   /// Condition variable used to notify worker thread on event.
   std::condition_variable event_condition_;


### PR DESCRIPTION
NetworkCurl now has a configurable parameter in constructor for maximum
allowed requests. Any additional queued request produces
NETWORK_OVERLOAD_ERROR

Resolves: OLPEDGE-778

Signed-off-by: Sergii Vostrikov <ext-sergii.vostrikov@here.com>