### PR TITLE
HttpResponse now holds data as a stream

### DIFF
--- a/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
@@ -344,7 +344,7 @@ client::CancellationToken AuthenticationClient::Impl::SignInClient(
         }
 
         auto document = std::make_shared<rapidjson::Document>();
-        rapidjson::IStreamWrapper stream(*payload.get());
+        rapidjson::IStreamWrapper stream(*payload);
         document->ParseStream(stream);
 
         std::shared_ptr<SignInResultImpl> resp_impl =
@@ -487,7 +487,7 @@ client::CancellationToken AuthenticationClient::Impl::HandleUserRequest(
         }
 
         auto document = std::make_shared<rapidjson::Document>();
-        rapidjson::IStreamWrapper stream(*payload.get());
+        rapidjson::IStreamWrapper stream(*payload);
         document->ParseStream(stream);
 
         std::shared_ptr<SignInUserResultImpl> resp_impl =
@@ -645,7 +645,7 @@ client::CancellationToken AuthenticationClient::Impl::SignOut(
                        }
 
                        auto document = std::make_shared<rapidjson::Document>();
-                       rapidjson::IStreamWrapper stream(*payload.get());
+                       rapidjson::IStreamWrapper stream(*payload);
                        document->ParseStream(stream);
 
                        std::shared_ptr<SignOutResultImpl> resp_impl =

--- a/olp-cpp-sdk-core/include/olp/core/client/HttpResponse.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/HttpResponse.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include <string>
+#include <sstream>
 
 #include <olp/core/CoreApi.h>
 #include <olp/core/http/NetworkTypes.h>
@@ -35,6 +35,8 @@ class CORE_API HttpResponse {
   HttpResponse() = default;
   HttpResponse(int status, std::string response = std::string())
       : status(status), response(std::move(response)) {}
+  HttpResponse(int status, std::stringstream&& response)
+      : status(status), response(std::move(response)) {}
 
   /**
    * @brief status Status of the HTTP request.
@@ -42,7 +44,7 @@ class CORE_API HttpResponse {
    * @see olp::network::HttpStatusCode for positive status numbers
    */
   int status{static_cast<int>(olp::http::ErrorCode::UNKNOWN_ERROR)};
-  std::string response;
+  std::stringstream response;
 };
 
 }  // namespace client

--- a/olp-cpp-sdk-core/include/olp/core/generated/parser/JsonParser.h
+++ b/olp-cpp-sdk-core/include/olp/core/generated/parser/JsonParser.h
@@ -19,7 +19,11 @@
 
 #pragma once
 
+#include <sstream>
+
 #include <rapidjson/document.h>
+#include <rapidjson/istreamwrapper.h>
+
 #include "ParserWrapper.h"
 
 namespace olp {
@@ -28,7 +32,19 @@ template <typename T>
 inline T parse(const std::string& json) {
   rapidjson::Document doc;
   doc.Parse(json.c_str());
-  T result = T();
+  T result{};
+  if (doc.IsObject() || doc.IsArray()) {
+    from_json(doc, result);
+  }
+  return result;
+}
+
+template <typename T>
+inline T parse(std::stringstream& json_stream) {
+  rapidjson::Document doc;
+  rapidjson::IStreamWrapper stream(json_stream);
+  doc.ParseStream(stream);
+  T result{};
   if (doc.IsObject() || doc.IsArray()) {
     from_json(doc, result);
   }

--- a/olp-cpp-sdk-core/tests/olpclient/OlpClientTest.cpp
+++ b/olp-cpp-sdk-core/tests/olpclient/OlpClientTest.cpp
@@ -76,7 +76,7 @@ TEST_F(OlpClientTest, NumberOfAttempts) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   auto cancel_token = client_.CallApi(std::string(), "GET",
@@ -112,7 +112,7 @@ TEST_F(OlpClientTest, ZeroAttempts) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   auto cancel_token = client_.CallApi(std::string(), "GET",
@@ -145,7 +145,7 @@ TEST_F(OlpClientTest, DefaultRetryCondition) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   auto cancel_token = client_.CallApi(std::string(), "GET",
@@ -192,7 +192,7 @@ TEST_F(OlpClientTest, RetryCondition) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   auto cancel_token = client_.CallApi(std::string(), "GET",
@@ -229,7 +229,7 @@ TEST_F(OlpClientTest, RetryTimeLinear) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   auto cancel_token = client_.CallApi(std::string(), "GET",
@@ -275,7 +275,7 @@ TEST_F(OlpClientTest, RetryTimeExponential) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   auto cancel_token = client_.CallApi(std::string(), "GET",
@@ -321,7 +321,7 @@ TEST_F(OlpClientTest, SetInitialBackdownPeriod) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   auto cancel_token = client_.CallApi(std::string(), "GET",
@@ -361,7 +361,7 @@ TEST_F(OlpClientTest, Timeout) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   auto cancel_token = client_.CallApi(std::string(), "GET",
@@ -414,7 +414,7 @@ TEST_F(OlpClientTest, Proxy) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   client_.CallApi(std::string(), "GET",
@@ -469,7 +469,7 @@ TEST_F(OlpClientTest, EmptyProxy) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   client_.CallApi(std::string(), "GET",
@@ -502,7 +502,7 @@ TEST_F(OlpClientTest, HttpResponse) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   auto cancel_token = client_.CallApi(std::string(), "GET",
@@ -513,7 +513,7 @@ TEST_F(OlpClientTest, HttpResponse) {
 
   auto response = promise.get_future().get();
 
-  ASSERT_EQ("content", response.response);
+  ASSERT_EQ("content", response.response.str());
   ASSERT_EQ(200, response.status);
 }
 
@@ -538,7 +538,7 @@ TEST_F(OlpClientTest, Paths) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   client_.CallApi("/index", "GET", std::multimap<std::string, std::string>(),
@@ -571,7 +571,7 @@ TEST_F(OlpClientTest, MethodGET) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   client_.CallApi(std::string(), "GET",
@@ -603,7 +603,7 @@ TEST_F(OlpClientTest, MethodPOST) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   client_.CallApi(std::string(), "POST",
@@ -635,7 +635,7 @@ TEST_F(OlpClientTest, MethodPUT) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   client_.CallApi(std::string(), "PUT",
@@ -667,7 +667,7 @@ TEST_F(OlpClientTest, MethodDELETE) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   client_.CallApi(std::string(), "DELETE",
@@ -703,7 +703,7 @@ TEST_F(OlpClientTest, QueryParam) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   client_.CallApi("index", "GET", queryParams,
@@ -737,7 +737,7 @@ TEST_F(OlpClientTest, HeaderParams) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   client_.CallApi(std::string(), "GET",
@@ -778,7 +778,7 @@ TEST_F(OlpClientTest, DefaultHeaderParams) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   client_.CallApi(std::string(), "GET",
@@ -822,7 +822,7 @@ TEST_F(OlpClientTest, CombineHeaderParams) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   client_.CallApi(std::string(), "GET",
@@ -871,7 +871,7 @@ TEST_F(OlpClientTest, Content) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   client_.CallApi(std::string(), "GET",
@@ -922,11 +922,10 @@ TEST_F(OlpClientTest, CancelBeforeResponse) {
       .WillOnce(
           [=](olp::http::RequestId request_id) { was_cancelled->store(true); });
 
-  auto response_promise =
-      std::make_shared<std::promise<olp::client::HttpResponse>>();
+  std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
-      [response_promise](olp::client::HttpResponse http_response) {
-        response_promise->set_value(http_response);
+      [&promise](olp::client::HttpResponse http_response) {
+        promise.set_value(std::move(http_response));
       };
 
   auto cancel_token = client_.CallApi(std::string(), "GET",
@@ -939,7 +938,7 @@ TEST_F(OlpClientTest, CancelBeforeResponse) {
   wait_for_cancel->set_value(true);
   ASSERT_TRUE(was_cancelled->load());
   ASSERT_EQ(std::future_status::ready,
-            response_promise->get_future().wait_for(std::chrono::seconds(2)));
+            promise.get_future().wait_for(std::chrono::seconds(2)));
 }
 
 TEST_F(OlpClientTest, CancelAfterCompletion) {
@@ -967,7 +966,7 @@ TEST_F(OlpClientTest, CancelAfterCompletion) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   auto cancel_token = client_.CallApi(std::string(), "GET",
@@ -1010,11 +1009,10 @@ TEST_F(OlpClientTest, CancelDuplicate) {
       .WillOnce(
           [=](olp::http::RequestId request_id) { was_cancelled->store(true); });
 
-  auto response_promise =
-      std::make_shared<std::promise<olp::client::HttpResponse>>();
+  std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
-      [response_promise](olp::client::HttpResponse http_response) {
-        response_promise->set_value(http_response);
+      [&promise](olp::client::HttpResponse http_response) {
+        promise.set_value(std::move(http_response));
       };
 
   auto cancel_token = client_.CallApi(std::string(), "GET",
@@ -1031,7 +1029,7 @@ TEST_F(OlpClientTest, CancelDuplicate) {
 
   ASSERT_TRUE(was_cancelled->load());
   ASSERT_EQ(std::future_status::ready,
-            response_promise->get_future().wait_for(std::chrono::seconds(2)));
+            promise.get_future().wait_for(std::chrono::seconds(2)));
 }
 
 TEST_F(OlpClientTest, CancelRetry) {
@@ -1072,11 +1070,10 @@ TEST_F(OlpClientTest, CancelRetry) {
     cancelled->store(true);
   });
 
-  auto callback_promise =
-      std::make_shared<std::promise<olp::client::HttpResponse>>();
+  std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
-      [callback_promise](olp::client::HttpResponse http_response) {
-        callback_promise->set_value(http_response);
+      [&promise](olp::client::HttpResponse http_response) {
+        promise.set_value(std::move(http_response));
       };
 
   auto cancel_token = client_.CallApi(std::string(), std::string(),
@@ -1089,7 +1086,7 @@ TEST_F(OlpClientTest, CancelRetry) {
   cancel_token.cancel();
 
   EXPECT_EQ(std::future_status::ready,
-            callback_promise->get_future().wait_for(std::chrono::seconds(2)));
+            promise.get_future().wait_for(std::chrono::seconds(2)));
   ASSERT_LT(*number_of_tries, client_settings_.retry_settings.max_attempts);
 }
 
@@ -1115,7 +1112,7 @@ TEST_F(OlpClientTest, QueryMultiParams) {
   std::promise<olp::client::HttpResponse> promise;
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse http_response) {
-        promise.set_value(http_response);
+        promise.set_value(std::move(http_response));
       };
 
   std::multimap<std::string, std::string> queryParams = {
@@ -1175,7 +1172,7 @@ TEST_F(OlpClientTest, SlowDownError) {
   olp::client::NetworkAsyncCallback callback =
       [&promise](olp::client::HttpResponse response) {
         promise.set_value(
-            olp::client::ApiError(response.status, response.response));
+            olp::client::ApiError(response.status, response.response.str()));
       };
 
   auto cancel_token =

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/BlobApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/BlobApi.cpp
@@ -20,6 +20,8 @@
 #include "BlobApi.h"
 
 #include <map>
+#include <memory>
+#include <sstream>
 
 #include <olp/core/client/HttpResponse.h>
 #include <olp/core/client/OlpClient.h>
@@ -51,14 +53,15 @@ CancellationToken BlobApi::GetBlob(
 
   NetworkAsyncCallback callback =
       [dataResponseCallback](client::HttpResponse response) {
+        auto str_response = response.response.str();
         if (response.status != 200) {
-          dataResponseCallback(ApiError(response.status, response.response));
+          dataResponseCallback(ApiError(response.status, str_response));
         } else {
           dataResponseCallback(
               // TODO: response from HttpResponse should be already in
               // raw data format to avoid copy
-              std::make_shared<std::vector<unsigned char>>(
-                  response.response.begin(), response.response.end()));
+              std::make_shared<std::vector<unsigned char>>(str_response.begin(),
+                                                           str_response.end()));
         }
       };
 

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/ConfigApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/ConfigApi.cpp
@@ -19,6 +19,8 @@
 
 #include "ConfigApi.h"
 
+#include <sstream>
+
 #include <olp/core/client/HttpResponse.h>
 #include <olp/core/client/OlpClient.h>
 // clang-format off
@@ -50,7 +52,8 @@ CancellationToken ConfigApi::GetCatalog(
   NetworkAsyncCallback callback = [catalogCallback](
                                       client::HttpResponse response) {
     if (response.status != 200) {
-      catalogCallback(client::ApiError(response.status, response.response));
+      catalogCallback(
+          client::ApiError(response.status, response.response.str()));
     } else {
       catalogCallback(olp::parser::parse<model::Catalog>(response.response));
     }

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/MetadataApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/MetadataApi.cpp
@@ -72,15 +72,15 @@ CancellationToken MetadataApi::GetLayerVersions(
 
   std::string metadataUri = "/layerVersions";
 
-  NetworkAsyncCallback callback =
-      [layerVersionsCallback](client::HttpResponse response) {
-        if (response.status != 200) {
-          layerVersionsCallback(ApiError(response.status, response.response));
-        } else {
-          layerVersionsCallback(
-              olp::parser::parse<model::LayerVersions>(response.response));
-        }
-      };
+  NetworkAsyncCallback callback = [layerVersionsCallback](
+                                      client::HttpResponse response) {
+    if (response.status != 200) {
+      layerVersionsCallback(ApiError(response.status, response.response.str()));
+    } else {
+      layerVersionsCallback(
+          olp::parser::parse<model::LayerVersions>(response.response));
+    }
+  };
 
   return client.CallApi(metadataUri, "GET", queryParams, headerParams,
                         formParams, nullptr, "", callback);
@@ -114,15 +114,15 @@ CancellationToken MetadataApi::GetPartitions(
 
   std::string metadataUri = "/layers/" + layerId + "/partitions";
 
-  NetworkAsyncCallback callback =
-      [partitionsCallback](client::HttpResponse response) {
-        if (response.status != 200) {
-          partitionsCallback(ApiError(response.status, response.response));
-        } else {
-          partitionsCallback(
-              olp::parser::parse<model::Partitions>(response.response));
-        }
-      };
+  NetworkAsyncCallback callback = [partitionsCallback](
+                                      client::HttpResponse response) {
+    if (response.status != 200) {
+      partitionsCallback(ApiError(response.status, response.response.str()));
+    } else {
+      partitionsCallback(
+          olp::parser::parse<model::Partitions>(response.response));
+    }
+  };
 
   return client.CallApi(metadataUri, "GET", queryParams, headerParams,
                         formParams, nullptr, "", callback);
@@ -149,7 +149,8 @@ CancellationToken MetadataApi::GetLatestCatalogVersion(
   NetworkAsyncCallback callback =
       [catalogVersionCallback](client::HttpResponse response) {
         if (response.status != 200) {
-          catalogVersionCallback(ApiError(response.status, response.response));
+          catalogVersionCallback(
+              ApiError(response.status, response.response.str()));
         } else {
           catalogVersionCallback(
               olp::parser::parse<model::VersionResponse>(response.response));

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/PlatformApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/PlatformApi.cpp
@@ -19,6 +19,9 @@
 
 #include "PlatformApi.h"
 
+#include <memory>
+#include <sstream>
+
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/HttpResponse.h>
 #include <olp/core/client/OlpClient.h>
@@ -41,19 +44,19 @@ client::CancellationToken PlatformApi::GetApis(
 
   std::string platformUrl = "/platform/apis/" + service + "/" + serviceVersion;
 
-  client::NetworkAsyncCallback callback = [apisCallback](
-                                              client::HttpResponse response) {
-    if (response.status != 200) {
-      apisCallback(
-          ApisResponse(client::ApiError(response.status, response.response)));
-    } else {
-      // parse the services
-      // TODO catch any exception and return as Error
-      apisCallback(
-          ApisResponse(parser::parse<olp::dataservice::read::model::Apis>(
-              response.response)));
-    }
-  };
+  client::NetworkAsyncCallback callback =
+      [apisCallback](client::HttpResponse response) {
+        if (response.status != 200) {
+          apisCallback(ApisResponse(
+              client::ApiError(response.status, response.response.str())));
+        } else {
+          // parse the services
+          // TODO catch any exception and return as Error
+          apisCallback(
+              ApisResponse(parser::parse<olp::dataservice::read::model::Apis>(
+                  response.response)));
+        }
+      };
 
   return client->CallApi(platformUrl, "GET", queryParams, headerParams,
                          formParams, nullptr, "", callback);

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.cpp
@@ -23,10 +23,9 @@
 #include <map>
 #include <sstream>
 
-#include <olp/core/logging/Log.h>
-
 #include <olp/core/client/HttpResponse.h>
 #include <olp/core/client/OlpClient.h>
+#include <olp/core/logging/Log.h>
 // clang-format off
 #include "generated/parser/IndexParser.h"
 #include "generated/parser/PartitionsParser.h"
@@ -85,15 +84,16 @@ client::CancellationToken QueryApi::GetPartitionsbyId(
 
   std::string metadataUri = "/layers/" + layerId + "/partitions";
 
-  client::NetworkAsyncCallback callback = [partitionsCallback](
-                                              client::HttpResponse response) {
-    if (response.status != 200) {
-      partitionsCallback(client::ApiError(response.status, response.response));
-    } else {
-      partitionsCallback(
-          olp::parser::parse<model::Partitions>(response.response));
-    }
-  };
+  client::NetworkAsyncCallback callback =
+      [partitionsCallback](client::HttpResponse response) {
+        if (response.status != 200) {
+          partitionsCallback(
+              client::ApiError(response.status, response.response.str()));
+        } else {
+          partitionsCallback(
+              olp::parser::parse<model::Partitions>(response.response));
+        }
+      };
 
   return client.CallApi(metadataUri, "GET", queryParams, headerParams,
                         formParams, nullptr, "", callback);
@@ -123,16 +123,16 @@ client::CancellationToken QueryApi::QuadTreeIndex(
                             std::to_string(version) + "/quadkeys/" + quadKey +
                             "/depths/" + std::to_string(depth);
 
-  client::NetworkAsyncCallback callback =
-      [indexCallback](client::HttpResponse response) {
-        OLP_SDK_LOG_TRACE_F(LOGTAG, "QuadTreeIndex callback, status=%d",
-                            response.status);
-        if (response.status != 200) {
-          indexCallback(client::ApiError(response.status, response.response));
-        } else {
-          indexCallback(olp::parser::parse<model::Index>(response.response));
-        }
-      };
+  client::NetworkAsyncCallback callback = [indexCallback](
+                                              client::HttpResponse response) {
+    OLP_SDK_LOG_TRACE_F(LOGTAG, "QuadTreeIndex callback, status=%d",
+                        response.status);
+    if (response.status != 200) {
+      indexCallback(client::ApiError(response.status, response.response.str()));
+    } else {
+      indexCallback(olp::parser::parse<model::Index>(response.response));
+    }
+  };
 
   OLP_SDK_LOG_TRACE(LOGTAG, "QuadTreeIndex");
 

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/ResourcesApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/ResourcesApi.cpp
@@ -19,6 +19,9 @@
 
 #include "ResourcesApi.h"
 
+#include <memory>
+#include <sstream>
+
 #include <olp/core/client/HttpResponse.h>
 #include <olp/core/client/OlpClient.h>
 // clang-format off
@@ -43,19 +46,19 @@ client::CancellationToken ResourcesApi::GetApis(
   std::string resourceUrl =
       "/resources/" + hrn + "/apis/" + service + "/" + service_version;
 
-  client::NetworkAsyncCallback callback = [apisCallback](
-                                              client::HttpResponse response) {
-    if (response.status != 200) {
-      apisCallback(
-          ApisResponse(client::ApiError(response.status, response.response)));
-    } else {
-      // parse the services
-      // TODO catch any exception and return as Error
-      apisCallback(
-          ApisResponse(parser::parse<olp::dataservice::read::model::Apis>(
-              response.response)));
-    }
-  };
+  client::NetworkAsyncCallback callback =
+      [apisCallback](client::HttpResponse response) {
+        if (response.status != 200) {
+          apisCallback(ApisResponse(
+              client::ApiError(response.status, response.response.str())));
+        } else {
+          // parse the services
+          // TODO catch any exception and return as Error
+          apisCallback(
+              ApisResponse(parser::parse<olp::dataservice::read::model::Apis>(
+                  response.response)));
+        }
+      };
   return client->CallApi(resourceUrl, "GET", queryParams, headerParams,
                          formParams, nullptr, "", callback);
 }

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/VolatileBlobApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/VolatileBlobApi.cpp
@@ -20,6 +20,8 @@
 #include "VolatileBlobApi.h"
 
 #include <map>
+#include <memory>
+#include <sstream>
 
 #include <olp/core/client/HttpResponse.h>
 #include <olp/core/client/OlpClient.h>
@@ -47,14 +49,15 @@ CancellationToken VolatileBlobApi::GetVolatileBlob(
 
   NetworkAsyncCallback callback =
       [dataResponseCallback](client::HttpResponse response) {
+        auto str_response = response.response.str();
         if (response.status != 200) {
-          dataResponseCallback(ApiError(response.status, response.response));
+          dataResponseCallback(ApiError(response.status, str_response));
         } else {
           dataResponseCallback(
               // TODO: response from HttpResponse should be already in
               // raw data format to avoid copy
-              std::make_shared<std::vector<unsigned char>>(
-                  response.response.begin(), response.response.end()));
+              std::make_shared<std::vector<unsigned char>>(str_response.begin(),
+                                                           str_response.end()));
         }
       };
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.cpp
@@ -19,6 +19,9 @@
 
 #include "BlobApi.h"
 
+#include <memory>
+#include <sstream>
+
 #include <olp/core/client/HttpResponse.h>
 
 using namespace olp::client;
@@ -67,7 +70,7 @@ CancellationToken BlobApi::PutBlob(
       content_type, [callback](client::HttpResponse http_response) {
         if (http_response.status != 200 && http_response.status != 204) {
           callback(PutBlobResponse(
-              ApiError(http_response.status, http_response.response)));
+              ApiError(http_response.status, http_response.response.str())));
           return;
         }
 
@@ -99,7 +102,7 @@ CancellationToken BlobApi::deleteBlob(
       nullptr, "", [callback](client::HttpResponse http_response) {
         if (http_response.status != 200 && http_response.status != 202) {
           callback(PutBlobResponse(
-              ApiError(http_response.status, http_response.response)));
+              ApiError(http_response.status, http_response.response.str())));
           return;
         }
         callback(DeleteBlobRespone(ApiNoResult()));
@@ -132,7 +135,7 @@ CancellationToken BlobApi::checkBlobExists(
           return;
         } else {
           callback(CheckBlobRespone(
-              ApiError(http_response.status, http_response.response)));
+              ApiError(http_response.status, http_response.response.str())));
         }
       });
   return cancel_token;

--- a/olp-cpp-sdk-dataservice-write/src/generated/ConfigApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/ConfigApi.cpp
@@ -20,10 +20,11 @@
 #include "ConfigApi.h"
 
 #include <map>
+#include <memory>
+#include <sstream>
 
 #include <olp/core/client/HttpResponse.h>
 #include <olp/core/client/OlpClient.h>
-
 // clang-format off
 // Ordering Required - Parser template specializations before JsonParser.h
 #include "parser/CatalogParser.h"
@@ -67,7 +68,7 @@ CancellationToken ConfigApi::GetCatalog(
       [catalogCallback](client::HttpResponse response) {
         if (response.status != 200) {
           catalogCallback(CatalogResponse(
-              client::ApiError(response.status, response.response)));
+              client::ApiError(response.status, response.response.str())));
         } else {
           catalogCallback(CatalogResponse(
               olp::parser::parse<model::Catalog>(response.response)));

--- a/olp-cpp-sdk-dataservice-write/src/generated/IndexApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/IndexApi.cpp
@@ -18,7 +18,9 @@
  */
 
 #include "IndexApi.h"
-#include <iostream>
+
+#include <memory>
+#include <sstream>
 
 #include <olp/core/client/HttpResponse.h>
 // clang-format off
@@ -77,7 +79,7 @@ CancellationToken IndexApi::insertIndexes(
       data, "application/json", [callback](client::HttpResponse http_response) {
         if (http_response.status > 201) {
           callback(InsertIndexesResponse(
-              ApiError(http_response.status, http_response.response)));
+              ApiError(http_response.status, http_response.response.str())));
           return;
         }
 
@@ -123,7 +125,7 @@ CancellationToken IndexApi::performUpdate(
       "application/json", [callback](client::HttpResponse http_response) {
         if (http_response.status > 201) {
           callback(InsertIndexesResponse(
-              ApiError(http_response.status, http_response.response)));
+              ApiError(http_response.status, http_response.response.str())));
           return;
         }
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/IngestApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/IngestApi.cpp
@@ -20,13 +20,13 @@
 #include "IngestApi.h"
 
 #include <map>
+#include <memory>
+#include <sstream>
 
 #include <olp/core/client/HttpResponse.h>
 #include <olp/core/client/OlpClient.h>
-
 #include <olp/dataservice/write/generated/model/ResponseOk.h>
 #include <olp/dataservice/write/generated/model/ResponseOkSingle.h>
-
 // clang-format off
 // Ordering Required - Parser template specializations before JsonParser.h
 #include "parser/ResponseOkParser.h"
@@ -91,8 +91,8 @@ client::CancellationToken IngestApi::IngestData(
       ingest_uri, "POST", query_params, header_params, form_params, data,
       content_type, [callback](client::HttpResponse http_response) {
         if (http_response.status != 200) {
-          callback(IngestDataResponse{
-              client::ApiError(http_response.status, http_response.response)});
+          callback(IngestDataResponse{client::ApiError(
+              http_response.status, http_response.response.str())});
           return;
         }
 
@@ -149,12 +149,9 @@ client::CancellationToken IngestApi::IngestSDII(
       [callback](client::HttpResponse http_response) {
         if (http_response.status != 200) {
           callback(IngestSdiiResponse(
-              ApiError(http_response.status, http_response.response)));
+              ApiError(http_response.status, http_response.response.str())));
           return;
         }
-
-        auto response_ok = std::make_shared<model::ResponseOk>(
-            olp::parser::parse<model::ResponseOk>(http_response.response));
 
         callback(IngestSdiiResponse(
             olp::parser::parse<model::ResponseOk>(http_response.response)));

--- a/olp-cpp-sdk-dataservice-write/src/generated/MetadataApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/MetadataApi.cpp
@@ -72,15 +72,15 @@ CancellationToken MetadataApi::GetLayerVersions(
 
   std::string metadataUri = "/layerVersions";
 
-  NetworkAsyncCallback callback =
-      [layerVersionsCallback](client::HttpResponse response) {
-        if (response.status != 200) {
-          layerVersionsCallback(ApiError(response.status, response.response));
-        } else {
-          layerVersionsCallback(
-              olp::parser::parse<model::LayerVersions>(response.response));
-        }
-      };
+  NetworkAsyncCallback callback = [layerVersionsCallback](
+                                      client::HttpResponse response) {
+    if (response.status != 200) {
+      layerVersionsCallback(ApiError(response.status, response.response.str()));
+    } else {
+      layerVersionsCallback(
+          olp::parser::parse<model::LayerVersions>(response.response));
+    }
+  };
 
   return client.CallApi(metadataUri, "GET", queryParams, headerParams,
                         formParams, nullptr, "", callback);
@@ -114,15 +114,15 @@ CancellationToken MetadataApi::GetPartitions(
 
   std::string metadataUri = "/layers/" + layerId + "/partitions";
 
-  NetworkAsyncCallback callback =
-      [partitionsCallback](client::HttpResponse response) {
-        if (response.status != 200) {
-          partitionsCallback(ApiError(response.status, response.response));
-        } else {
-          partitionsCallback(
-              olp::parser::parse<model::Partitions>(response.response));
-        }
-      };
+  NetworkAsyncCallback callback = [partitionsCallback](
+                                      client::HttpResponse response) {
+    if (response.status != 200) {
+      partitionsCallback(ApiError(response.status, response.response.str()));
+    } else {
+      partitionsCallback(
+          olp::parser::parse<model::Partitions>(response.response));
+    }
+  };
 
   return client.CallApi(metadataUri, "GET", queryParams, headerParams,
                         formParams, nullptr, "", callback);
@@ -149,7 +149,8 @@ CancellationToken MetadataApi::GetLatestCatalogVersion(
   NetworkAsyncCallback callback =
       [catalogVersionCallback](client::HttpResponse response) {
         if (response.status != 200) {
-          catalogVersionCallback(ApiError(response.status, response.response));
+          catalogVersionCallback(
+              ApiError(response.status, response.response.str()));
         } else {
           catalogVersionCallback(
               olp::parser::parse<model::VersionResponse>(response.response));

--- a/olp-cpp-sdk-dataservice-write/src/generated/PlatformApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/PlatformApi.cpp
@@ -19,10 +19,12 @@
 
 #include "PlatformApi.h"
 
+#include <memory>
+#include <sstream>
+
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/HttpResponse.h>
 #include <olp/core/client/OlpClient.h>
-
 // clang-format off
 #include "generated/parser/ApiParser.h"
 #include <olp/core/generated/parser/JsonParser.h>
@@ -44,8 +46,8 @@ client::CancellationToken PlatformApi::GetApis(
   client::NetworkAsyncCallback callback = [apisCallback](
                                               client::HttpResponse response) {
     if (response.status != 200) {
-      apisCallback(
-          ApisResponse(client::ApiError(response.status, response.response)));
+      apisCallback(ApisResponse(
+          client::ApiError(response.status, response.response.str())));
     } else {
       // parse the services
       // TODO catch any exception and return as Error

--- a/olp-cpp-sdk-dataservice-write/src/generated/PublishApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/PublishApi.cpp
@@ -19,6 +19,9 @@
 
 #include "PublishApi.h"
 
+#include <memory>
+#include <sstream>
+
 #include <olp/core/client/HttpResponse.h>
 // clang-format off
 // Ordering Required - Parser template specializations before JsonParser.h
@@ -78,7 +81,7 @@ CancellationToken PublishApi::InitPublication(
       data, "application/json", [callback](client::HttpResponse http_response) {
         if (http_response.status != 200) {
           callback(InitPublicationResponse{
-              ApiError(http_response.status, http_response.response)});
+              ApiError(http_response.status, http_response.response.str())});
           return;
         }
 
@@ -132,7 +135,7 @@ CancellationToken PublishApi::UploadPartitions(
       data, "application/json", [callback](client::HttpResponse http_response) {
         if (http_response.status != 204) {
           callback(UploadPartitionsResponse{
-              ApiError(http_response.status, http_response.response)});
+              ApiError(http_response.status, http_response.response.str())});
           return;
         }
 
@@ -171,18 +174,18 @@ CancellationToken PublishApi::SubmitPublication(
 
   std::string submit_publication_uri = "/publications/" + publication_id;
 
-  auto cancel_token =
-      client.CallApi(submit_publication_uri, "PUT", query_params, header_params,
-                     form_params, nullptr, "application/json",
-                     [callback](client::HttpResponse http_response) {
-                       if (http_response.status != 204) {
-                         callback(SubmitPublicationResponse{ApiError(
-                             http_response.status, http_response.response)});
-                         return;
-                       }
+  auto cancel_token = client.CallApi(
+      submit_publication_uri, "PUT", query_params, header_params, form_params,
+      nullptr, "application/json",
+      [callback](client::HttpResponse http_response) {
+        if (http_response.status != 204) {
+          callback(SubmitPublicationResponse{
+              ApiError(http_response.status, http_response.response.str())});
+          return;
+        }
 
-                       callback(SubmitPublicationResponse(ApiNoResult()));
-                     });
+        callback(SubmitPublicationResponse(ApiNoResult()));
+      });
 
   return cancel_token;
 }
@@ -222,7 +225,7 @@ CancellationToken PublishApi::GetPublication(
       [callback](client::HttpResponse http_response) {
         if (http_response.status != 200) {
           callback(GetPublicationResponse{
-              ApiError(http_response.status, http_response.response)});
+              ApiError(http_response.status, http_response.response.str())});
           return;
         }
 
@@ -262,18 +265,18 @@ CancellationToken PublishApi::CancelPublication(
 
   std::string submit_publication_uri = "/publications/" + publication_id;
 
-  auto cancel_token =
-      client.CallApi(submit_publication_uri, "DELETE", query_params,
-                     header_params, form_params, nullptr, "application/json",
-                     [callback](client::HttpResponse http_response) {
-                       if (http_response.status != 204) {
-                         callback(SubmitPublicationResponse{ApiError(
-                             http_response.status, http_response.response)});
-                         return;
-                       }
+  auto cancel_token = client.CallApi(
+      submit_publication_uri, "DELETE", query_params, header_params,
+      form_params, nullptr, "application/json",
+      [callback](client::HttpResponse http_response) {
+        if (http_response.status != 204) {
+          callback(SubmitPublicationResponse{
+              ApiError(http_response.status, http_response.response.str())});
+          return;
+        }
 
-                       callback(SubmitPublicationResponse(ApiNoResult()));
-                     });
+        callback(SubmitPublicationResponse(ApiNoResult()));
+      });
 
   return cancel_token;
 }

--- a/olp-cpp-sdk-dataservice-write/src/generated/QueryApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/QueryApi.cpp
@@ -79,15 +79,15 @@ CancellationToken QueryApi::GetPartitionsById(
 
   std::string queryUri = "/layers/" + layerId + "/partitions";
 
-  NetworkAsyncCallback callback =
-      [partitionsCallback](client::HttpResponse response) {
-        if (response.status != 200) {
-          partitionsCallback(ApiError(response.status, response.response));
-        } else {
-          partitionsCallback(
-              olp::parser::parse<model::Partitions>(response.response));
-        }
-      };
+  NetworkAsyncCallback callback = [partitionsCallback](
+                                      client::HttpResponse response) {
+    if (response.status != 200) {
+      partitionsCallback(ApiError(response.status, response.response.str()));
+    } else {
+      partitionsCallback(
+          olp::parser::parse<model::Partitions>(response.response));
+    }
+  };
 
   return client.CallApi(queryUri, "GET", queryParams, headerParams, formParams,
                         nullptr, "", callback);

--- a/olp-cpp-sdk-dataservice-write/src/generated/ResourcesApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/ResourcesApi.cpp
@@ -19,6 +19,9 @@
 
 #include "ResourcesApi.h"
 
+#include <memory>
+#include <sstream>
+
 #include <olp/core/client/HttpResponse.h>
 #include <olp/core/client/OlpClient.h>
 // clang-format off
@@ -45,8 +48,8 @@ client::CancellationToken ResourcesApi::GetApis(
   client::NetworkAsyncCallback callback = [apisCallback](
                                               client::HttpResponse response) {
     if (response.status != 200) {
-      apisCallback(
-          ApisResponse(client::ApiError(response.status, response.response)));
+      apisCallback(ApisResponse(
+          client::ApiError(response.status, response.response.str())));
     } else {
       // parse the services
       // TODO catch any exception and return as Error

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationTestUtils.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationTestUtils.cpp
@@ -95,7 +95,7 @@ bool AuthenticationTestUtils::CreateFacebookTestUser(
                    user.token.status = network_response.GetStatus();
                    if (user.token.status == olp::http::HttpStatusCode::OK) {
                      auto document = std::make_shared<rapidjson::Document>();
-                     rapidjson::IStreamWrapper stream(*payload.get());
+                     rapidjson::IStreamWrapper stream(*payload);
                      document->ParseStream(stream);
                      const bool is_valid =
                          !document->HasParseError() &&
@@ -236,7 +236,7 @@ bool AuthenticationTestUtils::GetAccessTokenImpl(
                    token.status = network_response.GetStatus();
                    if (token.status == olp::http::HttpStatusCode::OK) {
                      auto document = std::make_shared<rapidjson::Document>();
-                     rapidjson::IStreamWrapper stream(*payload.get());
+                     rapidjson::IStreamWrapper stream(*payload);
                      document->ParseStream(stream);
                      bool is_valid = !document->HasParseError() &&
                                      document->HasMember(kAccessToken.c_str());

--- a/tests/functional/olp-cpp-sdk-core/OlpClientDefaultAsyncHttpTest.cpp
+++ b/tests/functional/olp-cpp-sdk-core/OlpClientDefaultAsyncHttpTest.cpp
@@ -42,7 +42,7 @@ TEST_F(OlpClientDefaultAsyncHttpTest, GetGoogleWebsite) {
 
   std::promise<olp::client::HttpResponse> p;
   olp::client::NetworkAsyncCallback callback =
-      [&p](olp::client::HttpResponse response) { p.set_value(response); };
+      [&p](olp::client::HttpResponse response) { p.set_value(std::move(response)); };
 
   auto cancel_token = client_.CallApi(std::string(), std::string(),
                                       std::multimap<std::string, std::string>(),
@@ -52,7 +52,7 @@ TEST_F(OlpClientDefaultAsyncHttpTest, GetGoogleWebsite) {
 
   auto response = p.get_future().get();
   ASSERT_EQ(200, response.status);
-  ASSERT_LT(0u, response.response.size());
+  ASSERT_LT(0u, response.response.str().size());
 }
 
 TEST_F(OlpClientDefaultAsyncHttpTest, GetNonExistentWebsite) {
@@ -60,7 +60,7 @@ TEST_F(OlpClientDefaultAsyncHttpTest, GetNonExistentWebsite) {
   client_.SetBaseUrl("https://example.test");
   std::promise<olp::client::HttpResponse> p;
   olp::client::NetworkAsyncCallback callback =
-      [&p](olp::client::HttpResponse response) { p.set_value(response); };
+      [&p](olp::client::HttpResponse response) { p.set_value(std::move(response)); };
 
   client_settings_.network_request_handler = olp::client::
       OlpClientSettingsFactory::CreateDefaultNetworkRequestHandler();


### PR DESCRIPTION
The class now hold the stream to response data rather a string.
JsonParser.h extended with stream variant of the parser.

Resolves: OLPEDGE-684

Signed-off-by: Sergii Vostrikov <ext-sergii.vostrikov@here.com>