### PR TITLE
Convert NETWORK_OVERLOAD_ERROR to SlowDown error

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/http/HttpStatusCode.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/HttpStatusCode.h
@@ -158,6 +158,8 @@ class HttpStatusCode {
           return olp::client::ErrorCode::AccessDenied;
         case olp::http::ErrorCode::INVALID_URL_ERROR:
           return olp::client::ErrorCode::ServiceUnavailable;
+        case olp::http::ErrorCode::NETWORK_OVERLOAD_ERROR:
+          return olp::client::ErrorCode::SlowDown;
         case olp::http::ErrorCode::UNKNOWN_ERROR:
         default:
           return olp::client::ErrorCode::Unknown;


### PR DESCRIPTION
Error code from network code was lost in translation and if there's no
free handles client receives UnknownError. Now this error is propagated
to client as SlowDown error.

Relates-To: OLPEDGE-831
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>