### PR TITLE
Add cmake target URL & HASH hook

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -35,6 +35,21 @@ if(NOT N EQUAL 0)
     endif()
 endif()
 
+# Setup versions for external project 
+set(OLP_SDK_CPP_GOOGLETEST_URL "https://github.com/google/googletest.git")
+set(OLP_SDK_CPP_GOOGLETEST_TAG "release-1.10.0")
+
+set(OLP_SDK_CPP_SNAPPY_URL "https://github.com/google/snappy.git")
+set(OLP_SDK_CPP_SNAPPY_TAG "1.1.7")
+
+set(OLP_SDK_CPP_LEVELDB_URL "https://github.com/google/leveldb.git")
+set(OLP_SDK_CPP_LEVELDB_TAG "1.21")
+
+set(OLP_SDK_CPP_RAPIDJSON_URL "https://github.com/Tencent/rapidjson.git")
+set(OLP_SDK_CPP_RAPIDJSON_TAG "master")
+
+set(OLP_SDK_CPP_BOOST_URL "https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz")
+
 # Add external projects
 add_subdirectory(googletest)
 

--- a/external/boost/CMakeLists.txt.boost.in
+++ b/external/boost/CMakeLists.txt.boost.in
@@ -21,7 +21,7 @@ project(boost-download NONE)
 
 include(ExternalProject)
 ExternalProject_Add(Boost
-  URL               https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz
+  URL               @OLP_SDK_CPP_BOOST_URL@
   DOWNLOAD_DIR      "${CMAKE_CURRENT_BINARY_DIR}/download"
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/external_boost"
   CONFIGURE_COMMAND ""

--- a/external/googletest/CMakeLists.txt.googletest.in
+++ b/external/googletest/CMakeLists.txt.googletest.in
@@ -21,8 +21,8 @@ project(googletest-download NONE)
 
 include(ExternalProject)
 ExternalProject_Add(googletest
-  GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           6d668180665e313bbda19f8187abf6140e80a7d7
+  GIT_REPOSITORY    @OLP_SDK_CPP_GOOGLETEST_URL@
+  GIT_TAG           @OLP_SDK_CPP_GOOGLETEST_TAG@
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""

--- a/external/leveldb/CMakeLists.txt.leveldb.in
+++ b/external/leveldb/CMakeLists.txt.leveldb.in
@@ -22,16 +22,16 @@ project(leveldb-download NONE)
 include(ExternalProject)
 
 ExternalProject_Add(snappy
-  GIT_REPOSITORY    https://github.com/google/snappy.git
-  GIT_TAG           1.1.7
+  GIT_REPOSITORY    @OLP_SDK_CPP_SNAPPY_URL@
+  GIT_TAG           @OLP_SDK_CPP_SNAPPY_TAG@
   CMAKE_ARGS        ${CMAKE_ARGS} ${SNAPPY_CMAKE_ARGS}
   BUILD_COMMAND     "${CMAKE_COMMAND}" --build . --config ${CMAKE_BUILD_TYPE} ${EXTERNAL_BUILD_FLAGS}
   TEST_COMMAND      ""
 )
 
 ExternalProject_Add(leveldb
-  GIT_REPOSITORY    https://github.com/google/leveldb.git
-  GIT_TAG           1.21
+  GIT_REPOSITORY    @OLP_SDK_CPP_LEVELDB_URL@
+  GIT_TAG           @OLP_SDK_CPP_LEVELDB_TAG@
   PATCH_COMMAND     "${CMAKE_COMMAND}" -E copy_directory "${CMAKE_CURRENT_BINARY_DIR}/config/leveldb" "${CMAKE_CURRENT_BINARY_DIR}/download/leveldb-prefix/src/leveldb/."
   CMAKE_ARGS        ${CMAKE_ARGS} ${LEVELDB_CMAKE_ARGS}
   BUILD_COMMAND     "${CMAKE_COMMAND}" --build . --config ${CMAKE_BUILD_TYPE} ${EXTERNAL_BUILD_FLAGS}

--- a/external/rapidjson/CMakeLists.txt.rapidjson.in
+++ b/external/rapidjson/CMakeLists.txt.rapidjson.in
@@ -21,10 +21,8 @@ project(rapidjson-download NONE)
 
 include(ExternalProject)
 ExternalProject_Add(rapidjson
-  GIT_REPOSITORY    https://github.com/Tencent/rapidjson.git
-  GIT_TAG           master
-  GIT_SHALLOW       TRUE
-  GIT_PROGRESS      TRUE
+  GIT_REPOSITORY    @OLP_SDK_CPP_RAPIDJSON_URL@
+  GIT_TAG           @OLP_SDK_CPP_RAPIDJSON_TAG@
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
Build of external dependencies is decoupled from main build script, so
that is not possible to share variables, other that separate
configuration stage. Substitution variables are used as means to pass
correct version.

Relates-To: OLPEDGE-221