### PR TITLE
Configurable max requests count for WinHttp

### DIFF
--- a/olp-cpp-sdk-core/src/http/Network.cpp
+++ b/olp-cpp-sdk-core/src/http/Network.cpp
@@ -44,7 +44,7 @@ CORE_API std::shared_ptr<Network> CreateDefaultNetwork(
 #elif NETWORK_HAS_IOS
   return std::make_shared<OLPNetworkIOS>(max_requests_count);
 #elif NETWORK_HAS_WINHTTP
-  return std::make_shared<NetworkWinHttp>();
+  return std::make_shared<NetworkWinHttp>(max_requests_count);
 #else
   static_assert(false, "No default network implementation provided");
 #endif


### PR DESCRIPTION
NetworkWinHttp now has a configurable parameter in constructor for maximum
allowed requests. Any additional queued request produces
NETWORK_OVERLOAD_ERROR

Resolves: OLPEDGE-779

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>