### PR TITLE
Fixed generating of Android test runner

### DIFF
--- a/cmake/android/tester/CMakeLists.txt.in
+++ b/cmake/android/tester/CMakeLists.txt.in
@@ -27,8 +27,6 @@ set(SETUP_TARGET ${BUILD_TARGET}-setup)
 
 set(TESTER_LIB ${PROJECT_NAME}-lib)
 
-get_property(CUSTOM_PARAMS_DIR TARGET custom-params PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
-
 # duplicated in gen_android_test.cmake
 string(REGEX REPLACE "[\.-]" "" PACKAGE_NAME @SERVICE_TEST_LIB_NAME@)
 
@@ -47,8 +45,6 @@ add_library(${TESTER_LIB} SHARED ${APP_SRC} ${APP_INC})
 
 target_include_directories(${TESTER_LIB}
     PRIVATE ${@SERVICE_TARGET_NAME@_INCLUDE_DIRS}
-    PRIVATE GTest
-    PRIVATE ${CUSTOM_PARAMS_DIR}
 )
 
 set (UNWIND "")
@@ -64,7 +60,7 @@ target_link_libraries(${TESTER_LIB}
     olp-cpp-sdk-core
     ${SVC_LIB}
     ${SVC_TEST_LIB}
-    custom-params
+    gtest
     "-Wl,--no-whole-archive"
 )
 

--- a/olp-cpp-sdk-authentication/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-authentication/tests/CMakeLists.txt
@@ -22,18 +22,20 @@ set(OLP_AUTHENTICATION_TEST_SOURCES
 )
 
 if (ANDROID OR IOS)
-    add_library(olp-cpp-sdk-authentication-tests-lib
+    set(OLP_SDK_AUTHENTICATION_TESTS_LIB olp-cpp-sdk-authentication-tests-lib)
+
+    add_library(${OLP_SDK_AUTHENTICATION_TESTS_LIB}
         ${OLP_AUTHENTICATION_TEST_SOURCES}
     )
 
-    target_link_libraries(olp-cpp-sdk-authentication-tests-lib
+    target_link_libraries(${OLP_SDK_AUTHENTICATION_TESTS_LIB}
     PRIVATE
         gtest
         olp-cpp-sdk-authentication
     )
 
     # For internal testing
-    target_include_directories(olp-cpp-sdk-authentication-tests-lib
+    target_include_directories(${OLP_SDK_AUTHENTICATION_TESTS_LIB}
     PRIVATE
         ${${PROJECT_NAME}_SOURCE_DIR}/src
     )
@@ -41,14 +43,14 @@ if (ANDROID OR IOS)
     if (ANDROID)
         include(${CMAKE_SOURCE_DIR}/cmake/android/gen_android_test.cmake)
         gen_android_test_runner(olp-cpp-sdk-authentication-tests
-            olp-cpp-sdk-authentication-tests-lib)
+            ${OLP_SDK_AUTHENTICATION_TESTS_LIB})
         add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/android
             ${CMAKE_CURRENT_BINARY_DIR}/android)
 
     else()
         include(${CMAKE_SOURCE_DIR}/cmake/ios/gen_ios_test.cmake)
         gen_ios_test_runner(olp-cpp-sdk-authentication-tests
-            olp-cpp-sdk-authentication-tests-lib)
+            ${OLP_SDK_AUTHENTICATION_TESTS_LIB})
         add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/ios
             ${CMAKE_CURRENT_BINARY_DIR}/ios)
 

--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -44,8 +44,10 @@ set(OLP_CPP_SDK_CORE_TESTS_SOURCES
 )
 
 if (ANDROID OR IOS)
-    add_library(olp-cpp-sdk-core-tests-lib ${OLP_CPP_SDK_CORE_TESTS_SOURCES})
-    target_link_libraries(olp-cpp-sdk-core-tests-lib
+    set(OLP_SDK_CORE_TESTS_LIB olp-cpp-sdk-core-tests-lib)
+
+    add_library(${OLP_SDK_CORE_TESTS_LIB} ${OLP_CPP_SDK_CORE_TESTS_SOURCES})
+    target_link_libraries(${OLP_SDK_CORE_TESTS_LIB}
         PRIVATE
             custom-params
             gmock
@@ -55,20 +57,20 @@ if (ANDROID OR IOS)
 
     # Some tests include private headers of core. This should be fixed in tests,
     # only then here.
-    target_include_directories(olp-cpp-sdk-core-tests-lib
+    target_include_directories(${OLP_SDK_CORE_TESTS_LIB}
         PRIVATE
             ../src/cache
     )
     if (ANDROID)
         include(${CMAKE_SOURCE_DIR}/cmake/android/gen_android_test.cmake)
         gen_android_test_runner(olp-cpp-sdk-core-tests
-            olp-cpp-sdk-core-tests-lib)
+            ${OLP_SDK_CORE_TESTS_LIB})
         add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/android
             ${CMAKE_CURRENT_BINARY_DIR}/android)
 
     else()
         include(${CMAKE_SOURCE_DIR}/cmake/ios/gen_ios_test.cmake)
-        gen_ios_test_runner(olp-cpp-sdk-core-tests olp-cpp-sdk-core-tests-lib)
+        gen_ios_test_runner(olp-cpp-sdk-core-tests ${OLP_SDK_CORE_TESTS_LIB})
         add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/ios
             ${CMAKE_CURRENT_BINARY_DIR}/ios)
 

--- a/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
@@ -35,11 +35,13 @@ set(OLP_SDK_DATASERVICE_READ_TEST_SOURCES
 )
 
 if (ANDROID OR IOS)
-    add_library(olp-cpp-sdk-dataservice-read-tests-lib
+    set(OLP_SDK_DATASERVICE_READ_TESTS_LIB olp-cpp-sdk-dataservice-read-tests-lib)
+
+    add_library(${OLP_SDK_DATASERVICE_READ_TESTS_LIB}
         ${OLP_SDK_DATASERVICE_READ_TEST_SOURCES}
     )
 
-    target_link_libraries(olp-cpp-sdk-dataservice-read-tests-lib
+    target_link_libraries(${OLP_SDK_DATASERVICE_READ_TESTS_LIB}
     PRIVATE
         gmock
         gtest
@@ -49,7 +51,7 @@ if (ANDROID OR IOS)
     )
 
     # For internal testing
-    target_include_directories(olp-cpp-sdk-dataservice-read-tests-lib
+    target_include_directories(${OLP_SDK_DATASERVICE_READ_TESTS_LIB}
     PRIVATE
         ${${PROJECT_NAME}_SOURCE_DIR}/src
     )
@@ -57,14 +59,14 @@ if (ANDROID OR IOS)
     if (ANDROID)
         include(${CMAKE_SOURCE_DIR}/cmake/android/gen_android_test.cmake)
         gen_android_test_runner(olp-cpp-sdk-dataservice-read-tests
-            olp-cpp-sdk-dataservice-read-tests-lib)
+            ${OLP_SDK_DATASERVICE_READ_TESTS_LIB})
         add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/android
             ${CMAKE_CURRENT_BINARY_DIR}/android)
 
     else()
         include(${CMAKE_SOURCE_DIR}/cmake/ios/gen_ios_test.cmake)
         gen_ios_test_runner(olp-cpp-sdk-dataservice-read-tests
-            olp-cpp-sdk-dataservice-read-tests-lib)
+            ${OLP_SDK_DATASERVICE_READ_TESTS_LIB})
         add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/ios
             ${CMAKE_CURRENT_BINARY_DIR}/ios)
 

--- a/olp-cpp-sdk-dataservice-write/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-write/tests/CMakeLists.txt
@@ -31,11 +31,13 @@ set(OLP_SDK_DATASERVICE_WRITE_TEST_SOURCES
 find_package(OpenSSL)
 
 if (ANDROID OR IOS)
-    add_library(olp-cpp-sdk-dataservice-write-tests-lib
+    set(OLP_SDK_DASERVICE_WRITE_TESTS_LIB olp-cpp-sdk-dataservice-write-tests-lib)
+
+    add_library(${OLP_SDK_DASERVICE_WRITE_TESTS_LIB}
         ${OLP_SDK_DATASERVICE_WRITE_TEST_SOURCES}
     )
 
-    target_link_libraries(olp-cpp-sdk-dataservice-write-tests-lib
+    target_link_libraries(${OLP_SDK_DASERVICE_WRITE_TESTS_LIB}
     PRIVATE
         custom-params
         gmock
@@ -46,24 +48,24 @@ if (ANDROID OR IOS)
     )
 
     # For internal testing
-    target_include_directories(olp-cpp-sdk-dataservice-write-tests-lib
+    target_include_directories(${OLP_SDK_DASERVICE_WRITE_TESTS_LIB}
     PRIVATE
         ${${PROJECT_NAME}_SOURCE_DIR}/src
     )
 
     # For checksum testing
     if(OPENSSL_FOUND)
-        target_include_directories(olp-cpp-sdk-dataservice-write-tests-lib
+        target_include_directories(${OLP_SDK_DASERVICE_WRITE_TESTS_LIB}
         PRIVATE
             ${OPENSSL_INCLUDE_DIR}
         )
 
-        target_link_libraries(olp-cpp-sdk-dataservice-write-tests-lib
+        target_link_libraries(${OLP_SDK_DASERVICE_WRITE_TESTS_LIB}
         PRIVATE
             ${OPENSSL_CRYPTO_LIBRARY}
         )
 
-        target_compile_definitions(olp-cpp-sdk-dataservice-write-tests-lib
+        target_compile_definitions(${OLP_SDK_DASERVICE_WRITE_TESTS_LIB}
         PRIVATE
             DATASERVICE_WRITE_HAS_OPENSSL
         )
@@ -72,14 +74,14 @@ if (ANDROID OR IOS)
     if (ANDROID)
         include(${CMAKE_SOURCE_DIR}/cmake/android/gen_android_test.cmake)
         gen_android_test_runner(olp-cpp-sdk-dataservice-write-tests
-            olp-cpp-sdk-dataservice-write-tests-lib)
+            ${OLP_SDK_DASERVICE_WRITE_TESTS_LIB})
         add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/android
             ${CMAKE_CURRENT_BINARY_DIR}/android)
 
     else()
         include(${CMAKE_SOURCE_DIR}/cmake/ios/gen_ios_test.cmake)
         gen_ios_test_runner(olp-cpp-sdk-dataservice-write-tests
-            olp-cpp-sdk-dataservice-write-tests-lib)
+            ${OLP_SDK_DASERVICE_WRITE_TESTS_LIB})
         add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/ios
             ${CMAKE_CURRENT_BINARY_DIR}/ios)
 

--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -47,15 +47,17 @@ set(OLP_SDK_FUNCTIONAL_TESTS_HEADERS
 )
 
 if (ANDROID OR IOS)
-    add_library(olp-cpp-sdk-functional-tests-lib
+    set(OLP_SDK_FUNCTIONAL_TESTS_LIB olp-cpp-sdk-functional-tests-lib)
+
+    add_library(${OLP_SDK_FUNCTIONAL_TESTS_LIB}
         ${OLP_SDK_FUNCTIONAL_TESTS_SOURCES}
         ${OLP_SDK_FUNCTIONAL_TESTS_HEADERS})
-    target_include_directories(olp-cpp-sdk-functional-lib
+    target_include_directories(${OLP_SDK_FUNCTIONAL_TESTS_LIB}
         PRIVATE
             ${PROJECT_SOURCE_DIR}/olp-cpp-sdk-dataservice-read/src
             utils
     )
-    target_link_libraries(olp-cpp-sdk-functional-tests-lib
+    target_link_libraries(${OLP_SDK_FUNCTIONAL_TESTS_LIB}
         PRIVATE
             custom-params
             gtest
@@ -68,13 +70,13 @@ if (ANDROID OR IOS)
     if (ANDROID)
         include(${CMAKE_SOURCE_DIR}/cmake/android/gen_android_test.cmake)
         gen_android_test_runner(olp-cpp-sdk-functional-tests
-            olp-cpp-sdk-functional-tests-lib)
+            ${OLP_SDK_FUNCTIONAL_TESTS_LIB})
         add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/android
             ${CMAKE_CURRENT_BINARY_DIR}/android)
 
     else()
         include(${CMAKE_SOURCE_DIR}/cmake/ios/gen_ios_test.cmake)
-        gen_ios_test_runner(olp-cpp-sdk-functional-tests olp-cpp-sdk-functional-tests-lib)
+        gen_ios_test_runner(olp-cpp-sdk-functional-tests ${OLP_SDK_FUNCTIONAL_TESTS_LIB})
         add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/ios
             ${CMAKE_CURRENT_BINARY_DIR}/ios)
 

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -34,10 +34,12 @@ set(OLP_SDK_INTEGRATIONAL_TESTS_SOURCES
 )
 
 if (ANDROID OR IOS)
-    add_library(olp-cpp-sdk-integration-tests-lib ${OLP_SDK_INTEGRATIONAL_TESTS_SOURCES})
-    target_link_libraries(olp-cpp-sdk-integration-tests-lib
+    set(OLP_SDK_INTEGRATION_TESTS_LIB olp-cpp-sdk-integration-tests-lib)
+
+    add_library(${OLP_SDK_INTEGRATION_TESTS_LIB} ${OLP_SDK_INTEGRATIONAL_TESTS_SOURCES})
+    target_link_libraries(${OLP_SDK_INTEGRATION_TESTS_LIB}
         PRIVATE
-            gtest
+            gmock
             olp-cpp-sdk-tests-common
             olp-cpp-sdk-core
             olp-cpp-sdk-authentication
@@ -48,13 +50,13 @@ if (ANDROID OR IOS)
     if (ANDROID)
         include(${CMAKE_SOURCE_DIR}/cmake/android/gen_android_test.cmake)
         gen_android_test_runner(olp-cpp-sdk-integration-tests
-            olp-cpp-sdk-integration-tests-lib)
+            ${OLP_SDK_INTEGRATION_TESTS_LIB})
         add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/android
             ${CMAKE_CURRENT_BINARY_DIR}/android)
 
     else()
         include(${CMAKE_SOURCE_DIR}/cmake/ios/gen_ios_test.cmake)
-        gen_ios_test_runner(olp-cpp-sdk-integration-tests olp-cpp-sdk-integration-tests-lib)
+        gen_ios_test_runner(olp-cpp-sdk-integration-tests ${OLP_SDK_INTEGRATION_TESTS_LIB})
         add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/ios
             ${CMAKE_CURRENT_BINARY_DIR}/ios)
 


### PR DESCRIPTION
Fixed broken Android test runner because of invalid dependency on custom-params and incorrect setup of test library for Android test runner.

Relates to: OLPEDGE-788

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>