### PR TITLE
Make CatalogClient and LayerClients movable non-copyable

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogClient.h
@@ -54,6 +54,12 @@ class DATASERVICE_READ_API CatalogClient final {
  public:
   CatalogClient(client::HRN catalog, client::OlpClientSettings settings);
 
+  // Movable, non-copyable
+  CatalogClient(const CatalogClient& other) = delete;
+  CatalogClient(CatalogClient&& other) noexcept;
+  CatalogClient& operator=(const CatalogClient& other) = delete;
+  CatalogClient& operator=(CatalogClient&& other) noexcept;
+
   ~CatalogClient() = default;
 
   /**

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -98,6 +98,12 @@ class DATASERVICE_READ_API VersionedLayerClient final {
   VersionedLayerClient(client::HRN catalog, std::string layer_id,
                        client::OlpClientSettings settings);
 
+  // Movable, non-copyable
+  VersionedLayerClient(const VersionedLayerClient& other) = delete; 
+  VersionedLayerClient(VersionedLayerClient&& other) noexcept; 
+  VersionedLayerClient& operator=(const VersionedLayerClient& other) = delete; 
+  VersionedLayerClient& operator=(VersionedLayerClient&& other) noexcept;
+
   ~VersionedLayerClient();
 
   /**

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
@@ -82,6 +82,12 @@ class DATASERVICE_READ_API VolatileLayerClient final {
   VolatileLayerClient(client::HRN catalog, std::string layer_id,
                       client::OlpClientSettings settings);
 
+  // Movable, non-copyable
+  VolatileLayerClient(const VolatileLayerClient& other) = delete; 
+  VolatileLayerClient(VolatileLayerClient&& other) noexcept; 
+  VolatileLayerClient& operator=(const VolatileLayerClient& other) = delete; 
+  VolatileLayerClient& operator=(VolatileLayerClient&& other) noexcept;
+
   ~VolatileLayerClient();
 
   /**

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClient.cpp
@@ -19,9 +19,9 @@
 
 #include "olp/dataservice/read/CatalogClient.h"
 
+#include "CatalogClientImpl.h"
 #include "olp/core/cache/DefaultCache.h"
 #include "olp/core/client/OlpClientSettingsFactory.h"
-#include "CatalogClientImpl.h"
 
 namespace olp {
 namespace dataservice {
@@ -37,6 +37,11 @@ CatalogClient::CatalogClient(client::HRN catalog,
   impl_ = std::make_shared<CatalogClientImpl>(std::move(catalog),
                                               std::move(settings));
 }
+
+CatalogClient::CatalogClient(CatalogClient&& other) noexcept = default;
+
+CatalogClient& CatalogClient::operator=(CatalogClient&& other) noexcept =
+    default;
 
 bool CatalogClient::CancelPendingRequests() {
   return impl_->CancelPendingRequests();

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
@@ -32,6 +32,12 @@ VersionedLayerClient::VersionedLayerClient(client::HRN catalog,
     : impl_(std::make_unique<VersionedLayerClientImpl>(
           std::move(catalog), std::move(layer_id), std::move(settings))) {}
 
+VersionedLayerClient::VersionedLayerClient(
+    VersionedLayerClient&& other) noexcept = default;
+
+VersionedLayerClient& VersionedLayerClient::operator=(
+    VersionedLayerClient&& other) noexcept = default;
+
 VersionedLayerClient::~VersionedLayerClient() = default;
 
 client::CancellationToken VersionedLayerClient::GetData(

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClient.cpp
@@ -32,6 +32,12 @@ VolatileLayerClient::VolatileLayerClient(client::HRN catalog,
     : impl_(std::make_unique<VolatileLayerClientImpl>(
           std::move(catalog), std::move(layer_id), std::move(settings))) {}
 
+VolatileLayerClient::VolatileLayerClient(VolatileLayerClient&& other) noexcept =
+    default;
+
+VolatileLayerClient& VolatileLayerClient::operator=(
+    VolatileLayerClient&& other) noexcept = default;
+
 VolatileLayerClient::~VolatileLayerClient() = default;
 
 client::CancellationToken VolatileLayerClient::GetPartitions(

--- a/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ cmake_minimum_required(VERSION 3.5)
 
 set(OLP_SDK_DATASERVICE_READ_TEST_SOURCES
     ApiClientLookupTest.cpp
+    CatalogClientTest.cpp
     CatalogRepositoryTest.cpp
     DataRepositoryTest.cpp
     MultiRequestContextTest.cpp
@@ -28,6 +29,7 @@ set(OLP_SDK_DATASERVICE_READ_TEST_SOURCES
     PendingRequestsTest.cpp
     SerializerTest.cpp
     TaskContextTest.cpp
+    VersionedLayerClientTest.cpp
     VolatileLayerClientImplTest.cpp
     VolatileLayerClientTest.cpp
 )

--- a/olp-cpp-sdk-dataservice-read/tests/CatalogClientTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/CatalogClientTest.cpp
@@ -18,16 +18,17 @@
  */
 
 #include <gtest/gtest.h>
-#include <olp/dataservice/read/VolatileLayerClient.h>
+#include <olp/core/client/HRN.h>
+#include <olp/dataservice/read/CatalogClient.h>
 
 namespace {
 using namespace olp::dataservice::read;
 using namespace ::testing;
 
-TEST(VolatileLayerClientTest, CanBeMoved) {
-  VolatileLayerClient client_a(olp::client::HRN(), "", {});
-  VolatileLayerClient client_b(std::move(client_a));
-  VolatileLayerClient client_c(olp::client::HRN(), "", {});
+TEST(CatalogClientTest, CanBeMoved) {
+  CatalogClient client_a(olp::client::HRN(), {});
+  CatalogClient client_b(std::move(client_a));
+  CatalogClient client_c(olp::client::HRN(), {});
   client_c = std::move(client_b);
 }
 

--- a/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientTest.cpp
@@ -18,16 +18,16 @@
  */
 
 #include <gtest/gtest.h>
-#include <olp/dataservice/read/VolatileLayerClient.h>
+#include <olp/dataservice/read/VersionedLayerClient.h>
 
 namespace {
 using namespace olp::dataservice::read;
 using namespace ::testing;
 
-TEST(VolatileLayerClientTest, CanBeMoved) {
-  VolatileLayerClient client_a(olp::client::HRN(), "", {});
-  VolatileLayerClient client_b(std::move(client_a));
-  VolatileLayerClient client_c(olp::client::HRN(), "", {});
+TEST(VersionedLayerClientTest, CanBeMoved) {
+  VersionedLayerClient client_a(olp::client::HRN(), "", {});
+  VersionedLayerClient client_b(std::move(client_a));
+  VersionedLayerClient client_c(olp::client::HRN(), "", {});
   client_c = std::move(client_b);
 }
 


### PR DESCRIPTION
Added unit tests to test that clients are movable at compile-time.

Relates-To: OLPEDGE-1014

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>