### PR TITLE
Move TaskContext to public API

### DIFF
--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(OLP_CPP_SDK_CORE_TESTS_SOURCES
 
     ./client/CancellationContextTest.cpp
     ./client/ConditionTest.cpp
+    ./client/TaskContextTest.cpp
 
     ./geo/coordinates/GeoCoordinates3dTest.cpp
     ./geo/coordinates/GeoCoordinatesTest.cpp

--- a/olp-cpp-sdk-core/tests/client/TaskContextTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/TaskContextTest.cpp
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-#include "TaskContext.h"
+#include <olp/core/client/TaskContext.h>
 
 #include <gtest/gtest.h>
 #include <olp/core/client/Condition.h>
@@ -25,7 +25,6 @@
 namespace {
 
 using namespace olp::client;
-using namespace olp::dataservice::read;
 
 using ResponseType = std::string;
 using Response = ApiResponse<ResponseType, ApiError>;

--- a/olp-cpp-sdk-dataservice-read/src/PendingRequests.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/PendingRequests.cpp
@@ -19,8 +19,8 @@
 
 #include "PendingRequests.h"
 
+#include <olp/core/client/TaskContext.h>
 #include <olp/core/logging/Log.h>
-#include "TaskContext.h"
 
 namespace olp {
 namespace dataservice {
@@ -71,7 +71,7 @@ bool PendingRequests::Insert(const client::CancellationToken& request,
   return true;
 }
 
-void PendingRequests::Insert(TaskContext task_context) {
+void PendingRequests::Insert(client::TaskContext task_context) {
   std::lock_guard<std::mutex> lk(requests_lock_);
   task_contexts_.insert(task_context);
 }
@@ -86,7 +86,7 @@ bool PendingRequests::Remove(int64_t key) {
   return false;
 }
 
-void PendingRequests::Remove(TaskContext task_context) {
+void PendingRequests::Remove(client::TaskContext task_context) {
   std::lock_guard<std::mutex> lk(requests_lock_);
   task_contexts_.erase(task_context);
 }

--- a/olp-cpp-sdk-dataservice-read/src/PendingRequests.h
+++ b/olp-cpp-sdk-dataservice-read/src/PendingRequests.h
@@ -26,7 +26,7 @@
 #include <vector>
 
 #include <olp/core/client/CancellationToken.h>
-#include "TaskContext.h"
+#include <olp/core/client/TaskContext.h>
 
 namespace olp {
 namespace dataservice {
@@ -63,7 +63,7 @@ class PendingRequests final {
    * @brief Inserts task context into the requests container.
    * @param task_context Task context.
    */
-  void Insert(TaskContext task_context);
+  void Insert(client::TaskContext task_context);
 
   /**
    * @brief Removes a pending request and placholder.
@@ -76,12 +76,13 @@ class PendingRequests final {
    * @brief Removes a task context.
    * @param task_context Task context.
    */
-  void Remove(TaskContext task_context);
+  void Remove(client::TaskContext task_context);
 
  private:
   int64_t key_ = 0;
   std::unordered_map<int64_t, client::CancellationToken> requests_map_;
-  std::unordered_set<TaskContext, TaskContextHash> task_contexts_;
+  std::unordered_set<client::TaskContext, client::TaskContextHash>
+      task_contexts_;
   std::mutex requests_lock_;
 };
 

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -21,10 +21,10 @@
 
 #include <olp/core/cache/DefaultCache.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/client/TaskContext.h>
 #include <olp/core/context/Context.h>
 #include <olp/core/thread/TaskScheduler.h>
 #include "PrefetchTilesProvider.h"
-#include "TaskContext.h"
 #include "repositories/ApiRepository.h"
 #include "repositories/CatalogRepository.h"
 #include "repositories/DataRepository.h"
@@ -131,7 +131,7 @@ client::CancellationToken VersionedLayerClientImpl::GetData(
     };
 
     auto context =
-        TaskContext::Create(std::move(data_task), std::move(callback));
+        client::TaskContext::Create(std::move(data_task), std::move(callback));
 
     pending_requests->Insert(context);
 

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -22,8 +22,8 @@
 #include <olp/core/cache/DefaultCache.h>
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/client/TaskContext.h>
 
-#include "TaskContext.h"
 #include "repositories/ApiRepository.h"
 #include "repositories/CatalogRepository.h"
 #include "repositories/DataRepository.h"
@@ -123,7 +123,7 @@ client::CancellationToken VolatileLayerClientImpl::GetData(
     };
 
     auto context =
-        TaskContext::Create(std::move(data_task), std::move(callback));
+        client::TaskContext::Create(std::move(data_task), std::move(callback));
 
     pending_requests->Insert(context);
 

--- a/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
@@ -28,7 +28,6 @@ set(OLP_SDK_DATASERVICE_READ_TEST_SOURCES
     PartitionsRepositoryTest.cpp
     PendingRequestsTest.cpp
     SerializerTest.cpp
-    TaskContextTest.cpp
     VersionedLayerClientTest.cpp
     VolatileLayerClientImplTest.cpp
     VolatileLayerClientTest.cpp


### PR DESCRIPTION
Move TaskContext to core component and document public API. Will be used
by sync versions of Dataservice-write.

Relates-To: OLPEDGE-1006
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>