### PR TITLE
Move PendingRequests to public API

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/PendingRequests.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/PendingRequests.h
@@ -29,9 +29,11 @@
 #include <olp/core/client/TaskContext.h>
 
 namespace olp {
-namespace dataservice {
-namespace read {
+namespace client {
 
+/**
+ * @brief Container for not yet finished requests.
+ */
 class PendingRequests final {
  public:
   PendingRequests();
@@ -86,6 +88,5 @@ class PendingRequests final {
   std::mutex requests_lock_;
 };
 
-}  // namespace read
-}  // namespace dataservice
+}  // namespace client
 }  // namespace olp

--- a/olp-cpp-sdk-core/src/client/PendingRequests.cpp
+++ b/olp-cpp-sdk-core/src/client/PendingRequests.cpp
@@ -17,14 +17,13 @@
  * License-Filename: LICENSE
  */
 
-#include "PendingRequests.h"
+#include <olp/core/client/PendingRequests.h>
 
 #include <olp/core/client/TaskContext.h>
 #include <olp/core/logging/Log.h>
 
 namespace olp {
-namespace dataservice {
-namespace read {
+namespace client {
 
 namespace {
 constexpr auto kLogTag = "PendingRequests";
@@ -91,6 +90,5 @@ void PendingRequests::Remove(client::TaskContext task_context) {
   task_contexts_.erase(task_context);
 }
 
-}  // namespace read
-}  // namespace dataservice
+}  // namespace client
 }  // namespace olp

--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(OLP_CPP_SDK_CORE_TESTS_SOURCES
     ./client/CancellationContextTest.cpp
     ./client/ConditionTest.cpp
     ./client/TaskContextTest.cpp
+    ./client/PendingRequestsTest.cpp
 
     ./geo/coordinates/GeoCoordinates3dTest.cpp
     ./geo/coordinates/GeoCoordinatesTest.cpp

--- a/olp-cpp-sdk-core/tests/client/PendingRequestsTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/PendingRequestsTest.cpp
@@ -1,40 +1,43 @@
-#include "PendingRequests.h"
+#include <olp/core/client/PendingRequests.h>
 
 #include <gtest/gtest.h>
+
 namespace {
 
+using olp::client::PendingRequests;
+
 TEST(PendingRequestsTest, InsertNeedsGeneratedPlaceholderInAdvancePositive) {
-  olp::dataservice::read::PendingRequests pending_request;
+  PendingRequests pending_request;
   auto key = pending_request.GenerateRequestPlaceholder();
   EXPECT_TRUE(pending_request.Insert(olp::client::CancellationToken(), key));
 }
 
 TEST(PendingRequestsTest, InsertNeedsGeneratedPlaceholderInAdvanceNegative) {
-  olp::dataservice::read::PendingRequests pending_request;
+  PendingRequests pending_request;
   EXPECT_FALSE(pending_request.Insert(olp::client::CancellationToken(), 0));
 }
 
 TEST(PendingRequestsTest, InsertFailsAftherThePlaceholderIsRemoved) {
-  olp::dataservice::read::PendingRequests pending_request;
+  PendingRequests pending_request;
   auto key = pending_request.GenerateRequestPlaceholder();
   EXPECT_TRUE(pending_request.Remove(key));
   EXPECT_FALSE(pending_request.Insert(olp::client::CancellationToken(), key));
 }
 
 TEST(PendingRequestsTest, PlaceholderCanBeRemovedAfterInsert) {
-  olp::dataservice::read::PendingRequests pending_request;
+  PendingRequests pending_request;
   auto key = pending_request.GenerateRequestPlaceholder();
   EXPECT_TRUE(pending_request.Insert(olp::client::CancellationToken(), key));
   EXPECT_TRUE(pending_request.Remove(key));
 }
 
 TEST(PendingRequestsTest, RemoveMissingKeyWillFail) {
-  olp::dataservice::read::PendingRequests pending_request;
+  PendingRequests pending_request;
   EXPECT_FALSE(pending_request.Remove(0));
 }
 
 TEST(PendingRequestsTest, CancelAllPendingRequest) {
-  olp::dataservice::read::PendingRequests pending_request;
+  PendingRequests pending_request;
   auto key = pending_request.GenerateRequestPlaceholder();
   bool cancelled = false;
   auto token = olp::client::CancellationToken([&]() { cancelled = true; });

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
@@ -19,8 +19,8 @@
 
 #include "CatalogClientImpl.h"
 
+#include <olp/core/client/PendingRequests.h>
 #include <olp/core/logging/Log.h>
-#include "PendingRequests.h"
 #include "PrefetchTilesProvider.h"
 #include "repositories/ApiRepository.h"
 #include "repositories/CatalogRepository.h"
@@ -63,7 +63,7 @@ CatalogClientImpl::CatalogClientImpl(HRN catalog, OlpClientSettings settings)
       catalog_, api_repo, catalog_repo_, data_repo_, std::move(prefetch_repo),
       settings_);
 
-  pending_requests_ = std::make_shared<PendingRequests>();
+  pending_requests_ = std::make_shared<client::PendingRequests>();
 }
 
 CatalogClientImpl::~CatalogClientImpl() { CancelPendingRequests(); }

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.h
@@ -34,6 +34,7 @@ namespace olp {
 namespace client {
 class OlpClient;
 struct OlpClientSettings;
+class PendingRequests;
 }  // namespace client
 
 namespace dataservice {
@@ -45,8 +46,6 @@ class CatalogRepository;
 class PartitionsRepository;
 class DataRepository;
 }  // namespace repository
-
-class PendingRequests;
 
 class CatalogClientImpl final {
  public:
@@ -95,7 +94,7 @@ class CatalogClientImpl final {
   std::shared_ptr<repository::PartitionsRepository> partition_repo_;
   std::shared_ptr<repository::DataRepository> data_repo_;
   std::shared_ptr<PrefetchTilesProvider> prefetch_provider_;
-  std::shared_ptr<PendingRequests> pending_requests_;
+  std::shared_ptr<client::PendingRequests> pending_requests_;
 
   template <typename Request, typename Response>
   client::CancellableFuture<Response> AsFuture(

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -21,6 +21,7 @@
 
 #include <olp/core/cache/DefaultCache.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/client/PendingRequests.h>
 #include <olp/core/client/TaskContext.h>
 #include <olp/core/context/Context.h>
 #include <olp/core/thread/TaskScheduler.h>
@@ -43,7 +44,7 @@ VersionedLayerClientImpl::VersionedLayerClientImpl(
       layer_id_(std::move(layer_id)),
       settings_(
           std::make_shared<client::OlpClientSettings>(std::move(settings))),
-      pending_requests_(std::make_shared<PendingRequests>()) {
+      pending_requests_(std::make_shared<client::PendingRequests>()) {
   if (!settings_->cache) {
     settings_->cache = client::OlpClientSettingsFactory::CreateDefaultCache({});
   }

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -25,13 +25,12 @@
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClientSettings.h>
+#include <olp/core/client/PendingRequests.h>
 #include <olp/dataservice/read/DataRequest.h>
 #include <olp/dataservice/read/PartitionsRequest.h>
 #include <olp/dataservice/read/PrefetchTileResult.h>
 #include <olp/dataservice/read/PrefetchTilesRequest.h>
 #include <olp/dataservice/read/Types.h>
-
-#include "PendingRequests.h"
 
 namespace olp {
 namespace thread {
@@ -76,7 +75,7 @@ class VersionedLayerClientImpl {
   std::string layer_id_;
   std::shared_ptr<client::OlpClientSettings> settings_;
   std::shared_ptr<thread::TaskScheduler> task_scheduler_;
-  std::shared_ptr<PendingRequests> pending_requests_;
+  std::shared_ptr<client::PendingRequests> pending_requests_;
   std::shared_ptr<repository::PartitionsRepository> partition_repo_;
   std::shared_ptr<PrefetchTilesProvider> prefetch_provider_;
 };

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -22,6 +22,7 @@
 #include <olp/core/cache/DefaultCache.h>
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/client/PendingRequests.h>
 #include <olp/core/client/TaskContext.h>
 
 #include "repositories/ApiRepository.h"
@@ -45,7 +46,7 @@ VolatileLayerClientImpl::VolatileLayerClientImpl(
       layer_id_(std::move(layer_id)),
       settings_(
           std::make_shared<client::OlpClientSettings>(std::move(settings))),
-      pending_requests_(std::make_shared<PendingRequests>()) {
+      pending_requests_(std::make_shared<client::PendingRequests>()) {
   if (!settings_->cache) {
     settings_->cache = client::OlpClientSettingsFactory::CreateDefaultCache({});
   }

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
@@ -26,9 +26,11 @@
 #include <olp/dataservice/read/PartitionsRequest.h>
 #include <olp/dataservice/read/Types.h>
 
-#include "PendingRequests.h"
-
 namespace olp {
+
+namespace client {
+class PendingRequests;
+}
 namespace dataservice {
 namespace read {
 
@@ -60,7 +62,7 @@ class VolatileLayerClientImpl {
   std::string layer_id_;
   std::shared_ptr<client::OlpClientSettings> settings_;
   std::shared_ptr<thread::TaskScheduler> task_scheduler_;
-  std::shared_ptr<PendingRequests> pending_requests_;
+  std::shared_ptr<client::PendingRequests> pending_requests_;
   std::shared_ptr<repository::PartitionsRepository> partition_repo_;
 };
 

--- a/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
@@ -26,7 +26,6 @@ set(OLP_SDK_DATASERVICE_READ_TEST_SOURCES
     MultiRequestContextTest.cpp
     ParserTest.cpp
     PartitionsRepositoryTest.cpp
-    PendingRequestsTest.cpp
     SerializerTest.cpp
     VersionedLayerClientTest.cpp
     VolatileLayerClientImplTest.cpp


### PR DESCRIPTION
Move PendingRequests to core component and fix document public API. Will
be used by sync versions of Dataservice-write.

Relates-To: OLPEDGE-1006
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>