### PR TITLE
Default network scheduler settings for tests

### DIFF
--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationProductionTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationProductionTest.cpp
@@ -37,7 +37,7 @@ class AuthenticationProductionTest : public ::testing::Test {
  protected:
   static void SetUpTestSuite() {
     s_network_ = olp::client::OlpClientSettingsFactory::
-        CreateDefaultNetworkRequestHandler(1);
+        CreateDefaultNetworkRequestHandler();
   }
 
   static void TearDownTestSuite() { s_network_.reset(); }

--- a/tests/functional/olp-cpp-sdk-authentication/HereAccountOauth2ProductionTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/HereAccountOauth2ProductionTest.cpp
@@ -237,7 +237,7 @@ class HereAccountOuauth2ProductionTest : public ::testing::Test {
  protected:
   static void SetUpTestSuite() {
     s_network_ = olp::client::OlpClientSettingsFactory::
-        CreateDefaultNetworkRequestHandler(1);
+        CreateDefaultNetworkRequestHandler();
   }
 
   static void TearDownTestSuite() { s_network_.reset(); }


### PR DESCRIPTION
AuthenticationProductionTest and HereAccountOauth2ProductionTest are now
use default settings for creating network handler. This allows the
library to avoid problems with multiple http requests at the same time
being discarded due to requests limit.

Relates-to: OLPEDGE-778

Signed-off-by: Sergii Vostrikov <ext-sergii.vostrikov@here.com>