### PR TITLE
Removed client_id from NetworkAndroid and HttpClient

### DIFF
--- a/olp-cpp-sdk-core/src/http/android/NetworkAndroid.h
+++ b/olp-cpp-sdk-core/src/http/android/NetworkAndroid.h
@@ -38,8 +38,7 @@ namespace http {
  * @brief Implementation of Network interface for Android based on the
  * java.net.HttpURLConnection
  */
-class NetworkAndroid : public Network,
-                       public std::enable_shared_from_this<NetworkAndroid> {
+class NetworkAndroid : public Network {
  public:
   /**
    * @brief NetworkAndroid constructor
@@ -193,7 +192,6 @@ class NetworkAndroid : public Network,
   jmethodID jni_send_method_;
   jmethodID java_shutdown_method_;
   jobject obj_;
-  jint unique_id_;
 
   bool started_;
   bool initialized_;


### PR DESCRIPTION
Removed the `client_id` usage from `NetworkAndroid.cpp` and `HttpClient.java` files.
Also, removed `std::enable_shared_from_this` from `NetworkAndroid` inteface.

Relates to: OLPEDGE-735

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>