### PR TITLE
Disabled the performance tests for iOS and Android

### DIFF
--- a/tests/performance/CMakeLists.txt
+++ b/tests/performance/CMakeLists.txt
@@ -17,6 +17,11 @@
 
 cmake_minimum_required(VERSION 3.5)
 
+if (ANDROID OR IOS)
+    message(STATUS "Currently the performance test runner for mobile platforms is not supported")
+    return()
+endif()
+
 set(OLP_SDK_PERFORMANCE_TESTS_SOURCES
     ./CatalogClientTest.cpp
 )


### PR DESCRIPTION
Disabled the performance tests for mobile platforms. This will fix the CMake setup errors while configuring iOS build.

Relates to: OLPEDGE-788

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>