### PR TITLE
Align cmake_minimum_version to 3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.9)
 
 # Build the sdk targets
 project(olp-cpp-sdk VERSION 0.8.0)

--- a/examples/dataservice-read/CMakeLists.txt
+++ b/examples/dataservice-read/CMakeLists.txt
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
-cmake_minimum_required(VERSION 3.5)
 
 set(OLP_SDK_DATASERVICE_READ_EXAMPLE_TARGET dataservice-read-example)
 

--- a/examples/dataservice-write/CMakeLists.txt
+++ b/examples/dataservice-write/CMakeLists.txt
@@ -15,8 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-cmake_minimum_required(VERSION 3.5)
-
 set(OLP_SDK_DATASERVICE_WRITE_EXAMPLE_TARGET dataservice-write-example)
 set(OLP_SDK_EXAMPLE_SUCCESS_STRING "Publish Successfull")
 set(OLP_SDK_EXAMPLE_FAILURE_STRING "Publish Failed!")

--- a/examples/helpers/ios/CMakeLists.txt.in
+++ b/examples/helpers/ios/CMakeLists.txt.in
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.9)
 
 if (NOT IOS)
     message(FATAL_ERROR "Unsupported platform!")

--- a/external/boost/CMakeLists.txt.boost.in
+++ b/external/boost/CMakeLists.txt.boost.in
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.9)
 
 project(boost-download NONE)
 

--- a/external/googletest/CMakeLists.txt.googletest.in
+++ b/external/googletest/CMakeLists.txt.googletest.in
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.9)
 
 project(googletest-download NONE)
 

--- a/external/rapidjson/CMakeLists.txt.rapidjson.in
+++ b/external/rapidjson/CMakeLists.txt.rapidjson.in
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.9)
 
 project(rapidjson-download NONE)
 

--- a/olp-cpp-sdk-authentication/CMakeLists.txt
+++ b/olp-cpp-sdk-authentication/CMakeLists.txt
@@ -15,7 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-cmake_minimum_required(VERSION 3.5)
 project(olp-cpp-sdk-authentication VERSION 0.8.0)
 set(DESCRIPTION "C++ API library for accesing HERE Account authentication service")
 

--- a/olp-cpp-sdk-authentication/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-authentication/tests/CMakeLists.txt
@@ -15,8 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-cmake_minimum_required(VERSION 3.5)
-
 set(OLP_AUTHENTICATION_TEST_SOURCES
     placeholder.cpp
 )

--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -15,7 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-cmake_minimum_required(VERSION 3.5)
 
 project(olp-cpp-sdk-core VERSION 0.8.0)
 set(DESCRIPTION "Core network and utility library for the HERE OLP SDK C++")

--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -15,8 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-cmake_minimum_required(VERSION 3.5)
-
 set(OLP_CPP_SDK_CORE_TESTS_SOURCES
     ./cache/DefaultCacheTest.cpp
     ./cache/InMemoryCacheTest.cpp

--- a/olp-cpp-sdk-dataservice-read/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/CMakeLists.txt
@@ -15,8 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-cmake_minimum_required(VERSION 3.5)
-
 project(olp-cpp-sdk-dataservice-read VERSION 0.8.0)
 set(DESCRIPTION "C++ API library for reading OLP data")
 

--- a/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
@@ -15,9 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-
-cmake_minimum_required(VERSION 3.5)
-
 set(OLP_SDK_DATASERVICE_READ_TEST_SOURCES
     ApiClientLookupTest.cpp
     CatalogClientTest.cpp

--- a/olp-cpp-sdk-dataservice-write/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-write/CMakeLists.txt
@@ -15,7 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-cmake_minimum_required(VERSION 3.5)
 project(olp-cpp-sdk-dataservice-write VERSION 0.8.0)
 set(DESCRIPTION "C++ API library for writing data to OLP")
 

--- a/olp-cpp-sdk-dataservice-write/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-write/tests/CMakeLists.txt
@@ -15,9 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-
-cmake_minimum_required(VERSION 3.5)
-
 set(OLP_SDK_DATASERVICE_WRITE_TEST_SOURCES
     CancellationTokenListTest.cpp
     ParserTest.cpp

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -15,8 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-cmake_minimum_required(VERSION 3.5)
-
 set(OLP_SDK_TESTS_COMMON_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/matchers/NetworkUrlMatchers.h
     ${CMAKE_CURRENT_SOURCE_DIR}/mocks/NetworkMock.h

--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -15,7 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-cmake_minimum_required(VERSION 3.5)
 
 set(OLP_SDK_FUNCTIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-core/NetworkTest.cpp

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -15,8 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-cmake_minimum_required(VERSION 3.5)
-
 set(OLP_SDK_INTEGRATIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
     ./olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp

--- a/tests/performance/CMakeLists.txt
+++ b/tests/performance/CMakeLists.txt
@@ -15,8 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-cmake_minimum_required(VERSION 3.5)
-
 if (ANDROID OR IOS)
     message(STATUS "Currently the performance test runner for mobile platforms is not supported")
     return()


### PR DESCRIPTION
Update cmake_minimum_version to 3.9 in root CMakeLists. Remove version
check in non-root CMakeLists.

Resolves: OLPEDGE-361
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>