### PR TITLE
CatalogClient now have GetLatestVersion methods

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogClient.h
@@ -95,6 +95,29 @@ class DATASERVICE_READ_API CatalogClient final {
    * available, or an error is encountered.
    * @return A token that can be used to cancel this request
    */
+  client::CancellationToken GetLatestVersion(CatalogVersionRequest request,
+                                             CatalogVersionCallback callback);
+
+  /**
+   * @brief fetches catalog version asynchronously.
+   * @param request contains the complete set of request parameters.
+   * @return CancellableFuture of type CatalogVersionResponse, which when
+   * complete will contain the catalog configuration or an error.
+   * Alternatively, the CancellableFuture can be used to cancel this request.
+   */
+  client::CancellableFuture<CatalogVersionResponse> GetLatestVersion(
+      CatalogVersionRequest request);
+
+  /**
+   * @brief fetches catalog version asynchronously.
+   * @param request contains the complete set of request parameters.
+   * @param callback will be invoked once the catalog version is
+   * available, or an error is encountered.
+   * @return A token that can be used to cancel this request
+   * @deprecated Will be removed in 1.1, please use \c GetLatestVersion instead.
+   */
+  OLP_SDK_DEPRECATED(
+      "Will be removed in 1.1, please use GetLatestVersion() instead")
   client::CancellationToken GetCatalogMetadataVersion(
       const CatalogVersionRequest& request,
       const CatalogVersionCallback& callback);
@@ -105,7 +128,10 @@ class DATASERVICE_READ_API CatalogClient final {
    * @return CancellableFuture of type CatalogVersionResponse, which when
    * complete will contain the catalog configuration or an error.
    * Alternatively, the CancellableFuture can be used to cancel this request.
+   * @deprecated Will be removed in 1.1, please use \c GetLatestVersion instead.
    */
+  OLP_SDK_DEPRECATED(
+      "Will be removed in 1.1, please use GetLatestVersion() instead")
   client::CancellableFuture<CatalogVersionResponse> GetCatalogMetadataVersion(
       const CatalogVersionRequest& request);
 

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClient.cpp
@@ -57,15 +57,25 @@ client::CancellableFuture<CatalogResponse> CatalogClient::GetCatalog(
   return impl_->GetCatalog(request);
 }
 
+client::CancellationToken CatalogClient::GetLatestVersion(
+    CatalogVersionRequest request, CatalogVersionCallback callback) {
+  return impl_->GetLatestVersion(std::move(request), std::move(callback));
+}
+
+client::CancellableFuture<CatalogVersionResponse>
+CatalogClient::GetLatestVersion(CatalogVersionRequest request) {
+  return impl_->GetLatestVersion(std::move(request));
+}
+
 client::CancellationToken CatalogClient::GetCatalogMetadataVersion(
     const CatalogVersionRequest& request,
     const CatalogVersionCallback& callback) {
-  return impl_->GetCatalogMetadataVersion(request, callback);
+  return impl_->GetLatestVersion(request, callback);
 }
 
 client::CancellableFuture<CatalogVersionResponse>
 CatalogClient::GetCatalogMetadataVersion(const CatalogVersionRequest& request) {
-  return impl_->GetCatalogMetadataVersion(request);
+  return impl_->GetLatestVersion(request);
 }
 
 client::CancellationToken CatalogClient::GetPartitions(

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.h
@@ -61,12 +61,11 @@ class CatalogClientImpl final {
   client::CancellableFuture<CatalogResponse> GetCatalog(
       const CatalogRequest& request);
 
-  client::CancellationToken GetCatalogMetadataVersion(
-      const CatalogVersionRequest& request,
-      const CatalogVersionCallback& callback);
+  client::CancellationToken GetLatestVersion(CatalogVersionRequest request,
+                                             CatalogVersionCallback callback);
 
-  client::CancellableFuture<CatalogVersionResponse> GetCatalogMetadataVersion(
-      const CatalogVersionRequest& request);
+  client::CancellableFuture<CatalogVersionResponse> GetLatestVersion(
+      CatalogVersionRequest request);
 
   client::CancellationToken GetPartitions(
       const PartitionsRequest& request,

--- a/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientCacheTest.cpp
@@ -98,7 +98,7 @@ TEST_P(CatalogClientCacheTest, GetApi) {
 
   auto request = CatalogVersionRequest().WithStartVersion(-1);
 
-  auto future = catalog_client->GetCatalogMetadataVersion(request);
+  auto future = catalog_client->GetLatestVersion(request);
   auto catalog_version_response = future.GetFuture().get();
 
   ASSERT_TRUE(catalog_version_response.IsSuccessful())

--- a/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
@@ -1296,7 +1296,7 @@ TEST_P(CatalogClientTest, GetCatalogVersion) {
 
   auto request = CatalogVersionRequest().WithStartVersion(-1);
 
-  auto future = catalog_client->GetCatalogMetadataVersion(request);
+  auto future = catalog_client->GetLatestVersion(request);
   auto catalog_version_response = future.GetFuture().get();
 
   ASSERT_TRUE(catalog_version_response.IsSuccessful())
@@ -1439,7 +1439,7 @@ TEST_P(CatalogClientTest, GetCatalogVersionCancel) {
         promise.set_value(response);
       };
   olp::client::CancellationToken cancel_token =
-      catalog_client->GetCatalogMetadataVersion(request, callback);
+      catalog_client->GetLatestVersion(request, callback);
 
   wait_for_cancel->get_future().get();
   cancel_token.cancel();
@@ -1908,8 +1908,7 @@ TEST_P(CatalogClientTest, DISABLED_CancelPendingRequestsCatalog) {
 
   waits.push_back(wait_for_cancel2);
   pauses.push_back(pause_for_cancel2);
-  auto version_future =
-      catalog_client->GetCatalogMetadataVersion(version_request);
+  auto version_future = catalog_client->GetLatestVersion(version_request);
 
   for (auto wait : waits) {
     wait->get_future().get();


### PR DESCRIPTION
The new methods replace older GetCatalogMetadataVersion ones.

Resolves: OLPEDGE-1000

Signed-off-by: Sergii Vostrikov <ext-sergii.vostrikov@here.com>