### PR TITLE
Add sync GetCatalog in CatalogRepository

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.h
@@ -55,11 +55,10 @@ class CatalogClientImpl final {
 
   bool CancelPendingRequests();
 
-  client::CancellationToken GetCatalog(const CatalogRequest& request,
-                                       const CatalogResponseCallback& callback);
+  client::CancellationToken GetCatalog(CatalogRequest request,
+                                       CatalogResponseCallback callback);
 
-  client::CancellableFuture<CatalogResponse> GetCatalog(
-      const CatalogRequest& request);
+  client::CancellableFuture<CatalogResponse> GetCatalog(CatalogRequest request);
 
   client::CancellationToken GetCatalogMetadataVersion(
       const CatalogVersionRequest& request,
@@ -90,6 +89,7 @@ class CatalogClientImpl final {
  private:
   client::HRN catalog_;
   std::shared_ptr<client::OlpClientSettings> settings_;
+  std::shared_ptr<thread::TaskScheduler> task_scheduler_;
   std::shared_ptr<repository::CatalogRepository> catalog_repo_;
   std::shared_ptr<repository::PartitionsRepository> partition_repo_;
   std::shared_ptr<repository::DataRepository> data_repo_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.h
@@ -52,6 +52,11 @@ class CatalogRepository final {
       const read::CatalogRequest& request,
       const read::CatalogResponseCallback& callback);
 
+  static read::CatalogResponse GetCatalog(client::HRN catalog,
+                                          client::CancellationContext context,
+                                          read::CatalogRequest request,
+                                          client::OlpClientSettings settings);
+
   client::CancellationToken getLatestCatalogVersion(
       const read::CatalogVersionRequest& request,
       const read::CatalogVersionCallback& callback);

--- a/olp-cpp-sdk-dataservice-read/tests/CatalogRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/CatalogRepositoryTest.cpp
@@ -25,6 +25,7 @@
 #include <mocks/NetworkMock.h>
 #include <olp/core/client/OlpClientFactory.h>
 #include "ApiClientLookup.h"
+#include "olp/dataservice/read/CatalogRequest.h"
 
 #define OLP_SDK_URL_LOOKUP_METADATA \
   R"(https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data:::hereos-internal-test-v2/apis/metadata/v1)"
@@ -37,6 +38,18 @@
 #define OLP_SDK_HTTP_RESPONSE_LATEST_CATALOG_VERSION \
   R"jsonString({"version":4})jsonString"
 
+#define OLP_SDK_URL_CONFIG \
+  R"(https://config.data.api.platform.in.here.com/config/v1/catalogs/hrn:here:data:::hereos-internal-test-v2)"
+
+#define OLP_SDK_HTTP_RESPONSE_CONFIG \
+  R"jsonString({"id":"hereos-internal-test","hrn":"hrn:here-dev:data:::hereos-internal-test","name":"hereos-internal-test","summary":"Internal test for hereos","description":"Used for internal testing on the staging olp.","contacts":{},"owner":{"creator":{"id":"HERE-88c95a7e-4123-4dcd-ae0e-4682aa5c3db4"},"organisation":{"id":"olp-here"}},"tags":[],"billingTags":[],"created":"2018-07-13T20:50:08.425Z","layers":[{"id":"hype-test-prefetch","hrn":"hrn:here-dev:data:::hereos-internal-test:hype-test-prefetch","name":"Hype Test Prefetch","summary":"hype prefetch testing","description":"Layer for hype prefetch testing","coverage":{"adminAreas":[]},"owner":{"creator":{"id":"HERE-88c95a7e-4123-4dcd-ae0e-4682aa5c3db4"},"organisation":{"id":"olp-here"}},"partitioningScheme":"heretile","partitioning":{"tileLevels":[],"scheme":"heretile"},"contentType":"application/x-protobuf","volume":{"volumeType":"durable"},"tags":[],"billingTags":[],"created":"2018-07-13T20:56:19.181Z","layerType":"versioned"},{"id":"testlayer_res","hrn":"hrn:here-dev:data:::hereos-internal-test:testlayer_res","name":"Resource Test Layer","summary":"testlayer_res","description":"testlayer_res","coverage":{"adminAreas":[]},"owner":{"creator":{"id":"HERE-88c95a7e-4123-4dcd-ae0e-4682aa5c3db4"},"organisation":{"id":"olp-here"}},"partitioningScheme":"generic","partitioning":{"scheme":"generic"},"contentType":"application/x-protobuf","volume":{"volumeType":"durable"},"tags":["TEST"],"billingTags":[],"created":"2018-07-13T20:56:19.181Z","layerType":"versioned"},{"id":"testlayer","hrn":"hrn:here-dev:data:::hereos-internal-test:testlayer","name":"Test Layer","summary":"A test layer","description":"A simple test layer","coverage":{"adminAreas":[]},"owner":{"creator":{"id":"HERE-88c95a7e-4123-4dcd-ae0e-4682aa5c3db4"},"organisation":{"id":"olp-here"}},"partitioningScheme":"generic","partitioning":{"scheme":"generic"},"contentType":"application/x-protobuf","volume":{"volumeType":"durable"},"tags":["TEST"],"billingTags":[],"created":"2018-07-13T20:56:19.181Z","layerType":"versioned"},{"id":"testlayer_volatile","ttl":1000,"hrn":"hrn:here-dev:data:::hereos-internal-test:testlayer","name":"Test Layer","summary":"A test layer","description":"A simple test layer","coverage":{"adminAreas":[]},"owner":{"creator":{"id":"HERE-88c95a7e-4123-4dcd-ae0e-4682aa5c3db4"},"organisation":{"id":"olp-here"}},"partitioningScheme":"generic","partitioning":{"scheme":"generic"},"contentType":"application/x-protobuf","volume":{"volumeType":"durable"},"tags":["TEST"],"billingTags":[],"created":"2018-07-13T20:56:19.181Z","layerType":"volatile"},{"id":"testlayer_stream","hrn":"hrn:here-dev:data:::hereos-internal-test:testlayer","name":"Test Layer","summary":"A test layer","description":"A simple test layer","coverage":{"adminAreas":[]},"owner":{"creator":{"id":"HERE-88c95a7e-4123-4dcd-ae0e-4682aa5c3db4"},"organisation":{"id":"olp-here"}},"partitioningScheme":"generic","partitioning":{"scheme":"generic"},"contentType":"application/x-protobuf","volume":{"volumeType":"durable"},"tags":["TEST"],"billingTags":[],"created":"2018-07-13T20:56:19.181Z","layerType":"stream"},{"id":"multilevel_testlayer","hrn":"hrn:here-dev:data:::hereos-internal-test:multilevel_testlayer","name":"Multi Level Test Layer","summary":"Multi Level Test Layer","description":"A multi level test layer just for testing","coverage":{"adminAreas":[]},"owner":{"creator":{"id":"HERE-88c95a7e-4123-4dcd-ae0e-4682aa5c3db4"},"organisation":{"id":"olp-here"}},"partitioningScheme":"generic","partitioning":{"scheme":"generic"},"contentType":"application/x-protobuf","volume":{"volumeType":"durable"},"tags":["TEST"],"billingTags":[],"created":"2018-07-13T20:56:19.181Z","layerType":"versioned"},{"id":"hype-test-prefetch-2","hrn":"hrn:here-dev:data:::hereos-internal-test:hype-test-prefetch-2","name":"Hype Test Prefetch2","summary":"Layer for testing hype2 prefetching","description":"Layer for testing hype2 prefetching","coverage":{"adminAreas":[]},"owner":{"creator":{"id":"HERE-88c95a7e-4123-4dcd-ae0e-4682aa5c3db4"},"organisation":{"id":"olp-here"}},"partitioningScheme":"heretile","partitioning":{"tileLevels":[],"scheme":"heretile"},"contentType":"application/x-protobuf","volume":{"volumeType":"durable"},"tags":["TEST"],"billingTags":[],"created":"2018-07-24T17:52:23.818Z","layerType":"versioned"}],"version":3})jsonString"
+
+#define OLP_SDK_URL_LOOKUP_CONFIG \
+  R"(https://api-lookup.data.api.platform.here.com/lookup/v1/platform/apis/config/v1)"
+
+#define OLP_SDK_HTTP_RESPONSE_LOOKUP_CONFIG \
+  R"jsonString([{"api":"config","version":"v1","baseURL":"https://config.data.api.platform.in.here.com/config/v1","parameters":{}},{"api":"pipelines","version":"v1","baseURL":"https://pipelines.api.platform.in.here.com/pipeline-service","parameters":{}},{"api":"pipelines","version":"v2","baseURL":"https://pipelines.api.platform.in.here.com/pipeline-service","parameters":{}}])jsonString"
+
 namespace {
 
 using namespace olp::dataservice::read;
@@ -44,14 +57,18 @@ using namespace ::testing;
 using namespace olp::tests::common;
 
 const std::string kCatalog = "hrn:here:data:::hereos-internal-test-v2";
-const std::string kCacheKey = kCatalog + "::latestVersion";
-const std::string kServiceName = "metadata";
+const std::string kLatestVersionCacheKey = kCatalog + "::latestVersion";
+const std::string kCatalogCacheKey = kCatalog + "::catalog";
+const std::string kMetadataServiceName = "metadata";
+const std::string kConfigServiceName = "config";
 const std::string kServiceVersion = "v1";
-const std::string kCacheKeyMetadata =
-    kCatalog + "::" + kServiceName + "::" + kServiceVersion + "::api";
+const std::string kMetadataCacheKey =
+    kCatalog + "::" + kMetadataServiceName + "::" + kServiceVersion + "::api";
+const std::string kConfigCacheKey =
+    kCatalog + "::" + kConfigServiceName + "::" + kServiceVersion + "::api";
 const std::string kLookupUrl =
     "https://api-lookup.data.api.platform.here.com/lookup/v1/resources/" +
-    kCatalog + "/apis/" + kServiceName + "/" + kServiceVersion;
+    kCatalog + "/apis/" + kMetadataServiceName + "/" + kServiceVersion;
 const auto kHRN = olp::client::HRN::FromString(kCatalog);
 
 class CatalogRepositoryTest : public ::testing::Test {
@@ -84,12 +101,12 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionCacheOnlyFound) {
 
   request.WithFetchOption(CacheOnly);
 
-  model::VersionResponse cached_vesrion;
-  cached_vesrion.SetVersion(10);
+  model::VersionResponse cached_version;
+  cached_version.SetVersion(10);
 
-  EXPECT_CALL(*cache_, Get(kCacheKey, _))
+  EXPECT_CALL(*cache_, Get(kLatestVersionCacheKey, _))
       .Times(1)
-      .WillOnce(Return(cached_vesrion));
+      .WillOnce(Return(cached_version));
 
   auto response = repository::CatalogRepository::GetLatestVersion(
       kHRN, context, request, settings_);
@@ -163,9 +180,9 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyFoundAndCacheWritten) {
         return boost::any{};
       });
 
-  EXPECT_CALL(*cache_, Put(Eq(kCacheKey), _, _, _)).Times(1);
+  EXPECT_CALL(*cache_, Put(Eq(kLatestVersionCacheKey), _, _, _)).Times(1);
 
-  EXPECT_CALL(*cache_, Put(Eq(kCacheKeyMetadata), _, _, _)).Times(1);
+  EXPECT_CALL(*cache_, Put(Eq(kMetadataCacheKey), _, _, _)).Times(1);
 
   EXPECT_CALL(*network_,
               Send(IsGetRequest(OLP_SDK_URL_LOOKUP_METADATA), _, _, _, _))
@@ -319,4 +336,227 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionTimeouted) {
             response.GetError().GetErrorCode());
 }
 
+TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyFoundAndCacheWritten) {
+  olp::client::CancellationContext context;
+
+  auto request = CatalogRequest();
+  request.WithFetchOption(OnlineOnly);
+
+  ON_CALL(*cache_, Get(_, _))
+      .WillByDefault([](const std::string&, const olp::cache::Decoder&) {
+        ADD_FAILURE() << "Cache should not be used in OnlineOnly request";
+        return boost::any{};
+      });
+
+  EXPECT_CALL(*cache_, Put(Eq(kCatalogCacheKey), _, _, _)).Times(1);
+
+  EXPECT_CALL(*cache_, Put(Eq(kConfigCacheKey), _, _, _)).Times(1);
+
+  ON_CALL(*network_, Send(IsGetRequest(OLP_SDK_URL_LOOKUP_CONFIG), _, _, _, _))
+      .WillByDefault(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                            olp::http::HttpStatusCode::OK),
+                                        OLP_SDK_HTTP_RESPONSE_LOOKUP_CONFIG));
+
+  ON_CALL(*network_, Send(IsGetRequest(OLP_SDK_URL_CONFIG), _, _, _, _))
+      .WillByDefault(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                            olp::http::HttpStatusCode::OK),
+                                        OLP_SDK_HTTP_RESPONSE_CONFIG));
+
+  auto response = repository::CatalogRepository::GetCatalog(kHRN, context,
+                                                            request, settings_);
+
+  ASSERT_TRUE(response.IsSuccessful());
+}
+
+TEST_F(CatalogRepositoryTest, GetCatalogCacheOnlyFound) {
+  olp::client::CancellationContext context;
+
+  auto request = CatalogRequest();
+
+  request.WithFetchOption(CacheOnly);
+
+  CatalogResult cached_version;
+  cached_version.SetHrn(kCatalog);
+
+  EXPECT_CALL(*cache_, Get(kCatalogCacheKey, _))
+      .Times(1)
+      .WillOnce(Return(cached_version));
+
+  auto response = repository::CatalogRepository::GetCatalog(kHRN, context,
+                                                            request, settings_);
+
+  ASSERT_TRUE(response.IsSuccessful());
+  EXPECT_EQ(kCatalog, response.GetResult().GetHrn());
+}
+
+TEST_F(CatalogRepositoryTest, GetCatalogCacheOnlyNotFound) {
+  olp::client::CancellationContext context;
+
+  auto request = olp::dataservice::read::DataRequest();
+
+  request.WithFetchOption(CacheOnly);
+
+  EXPECT_CALL(*cache_, Get(_, _)).Times(1).WillOnce(Return(boost::any{}));
+
+  ON_CALL(*network_, Send(_, _, _, _, _))
+      .WillByDefault([](olp::http::NetworkRequest, olp::http::Network::Payload,
+                        olp::http::Network::Callback,
+                        olp::http::Network::HeaderCallback,
+                        olp::http::Network::DataCallback) {
+        ADD_FAILURE() << "Should not be called with CacheOnly";
+        return olp::http::SendOutcome(olp::http::ErrorCode::UNKNOWN_ERROR);
+      });
+
+  auto response =
+      olp::dataservice::read::repository::CatalogRepository::GetLatestVersion(
+          kHRN, context, request, settings_);
+
+  EXPECT_FALSE(response.IsSuccessful());
+}
+
+TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyNotFound) {
+  olp::client::CancellationContext context;
+
+  auto request = CatalogRequest();
+
+  request.WithFetchOption(OnlineOnly);
+
+  ON_CALL(*cache_, Get(_, _))
+      .WillByDefault([](const std::string&, const olp::cache::Decoder&) {
+        ADD_FAILURE() << "Cache should not be used in OnlineOnly request";
+        return boost::any{};
+      });
+
+  EXPECT_CALL(*network_,
+              Send(IsGetRequest(OLP_SDK_URL_LOOKUP_CONFIG), _, _, _, _))
+      .Times(1)
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::NOT_FOUND),
+                                   ""));
+
+  auto response = repository::CatalogRepository::GetCatalog(kHRN, context,
+                                                            request, settings_);
+
+  EXPECT_FALSE(response.IsSuccessful());
+}
+
+TEST_F(CatalogRepositoryTest, GetCatalogCancelledBeforeExecution) {
+  settings_.retry_settings.timeout = 0;
+  olp::client::CancellationContext context;
+
+  auto request = CatalogRequest();
+
+  ON_CALL(*network_, Send(_, _, _, _, _))
+      .WillByDefault([&](olp::http::NetworkRequest, olp::http::Network::Payload,
+                         olp::http::Network::Callback,
+                         olp::http::Network::HeaderCallback,
+                         olp::http::Network::DataCallback) {
+        ADD_FAILURE() << "Should not be called on cancelled operation";
+        constexpr auto unused_request_id = 10;
+        return olp::http::SendOutcome(unused_request_id);
+      });
+
+  context.CancelOperation();
+  auto response = repository::CatalogRepository::GetCatalog(kHRN, context,
+                                                            request, settings_);
+
+  ASSERT_FALSE(response.IsSuccessful());
+  EXPECT_EQ(olp::client::ErrorCode::Cancelled,
+            response.GetError().GetErrorCode());
+}
+
+TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyUserCancelled1) {
+  olp::client::CancellationContext context;
+
+  auto request = CatalogRequest();
+
+  std::promise<bool> cancelled;
+
+  ON_CALL(*network_, Send(IsGetRequest(OLP_SDK_URL_LOOKUP_CONFIG), _, _, _, _))
+      .WillByDefault([&context](olp::http::NetworkRequest,
+                                olp::http::Network::Payload,
+                                olp::http::Network::Callback,
+                                olp::http::Network::HeaderCallback,
+                                olp::http::Network::DataCallback) {
+        std::thread([&context]() { context.CancelOperation(); }).detach();
+
+        constexpr auto unused_request_id = 5;
+        return olp::http::SendOutcome(unused_request_id);
+      });
+
+  ON_CALL(*network_, Send(IsGetRequest(OLP_SDK_URL_CONFIG), _, _, _, _))
+      .WillByDefault([](olp::http::NetworkRequest, olp::http::Network::Payload,
+                        olp::http::Network::Callback,
+                        olp::http::Network::HeaderCallback,
+                        olp::http::Network::DataCallback) {
+        ADD_FAILURE()
+            << "Should not be called. Previous request was cancelled.";
+        constexpr auto unused_request_id = 5;
+        return olp::http::SendOutcome(unused_request_id);
+      });
+
+  auto response = repository::CatalogRepository::GetCatalog(kHRN, context,
+                                                            request, settings_);
+
+  ASSERT_FALSE(response.IsSuccessful());
+  EXPECT_EQ(olp::client::ErrorCode::Cancelled,
+            response.GetError().GetErrorCode());
+}
+
+TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyUserCancelled2) {
+  olp::client::CancellationContext context;
+
+  auto request = CatalogRequest();
+
+  ON_CALL(*network_, Send(IsGetRequest(OLP_SDK_URL_LOOKUP_CONFIG), _, _, _, _))
+      .WillByDefault(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                            olp::http::HttpStatusCode::OK),
+                                        OLP_SDK_HTTP_RESPONSE_LOOKUP_CONFIG));
+
+  ON_CALL(*network_, Send(IsGetRequest(OLP_SDK_URL_CONFIG), _, _, _, _))
+      .WillByDefault([&](olp::http::NetworkRequest, olp::http::Network::Payload,
+                         olp::http::Network::Callback,
+                         olp::http::Network::HeaderCallback,
+                         olp::http::Network::DataCallback) {
+        std::thread([&]() { context.CancelOperation(); }).detach();
+
+        constexpr auto unused_request_id = 10;
+        return olp::http::SendOutcome(unused_request_id);
+      });
+
+  auto response = repository::CatalogRepository::GetCatalog(kHRN, context,
+                                                            request, settings_);
+
+  ASSERT_FALSE(response.IsSuccessful());
+  EXPECT_EQ(olp::client::ErrorCode::Cancelled,
+            response.GetError().GetErrorCode());
+}
+
+TEST_F(CatalogRepositoryTest, GetCatalogTimeout) {
+  olp::client::CancellationContext context;
+
+  auto request = CatalogRequest();
+
+  ON_CALL(*network_, Send(IsGetRequest(OLP_SDK_URL_LOOKUP_CONFIG), _, _, _, _))
+      .WillByDefault(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                            olp::http::HttpStatusCode::OK),
+                                        OLP_SDK_HTTP_RESPONSE_LOOKUP_CONFIG));
+
+  ON_CALL(*network_, Send(IsGetRequest(OLP_SDK_URL_CONFIG), _, _, _, _))
+      .WillByDefault([&](olp::http::NetworkRequest, olp::http::Network::Payload,
+                         olp::http::Network::Callback,
+                         olp::http::Network::HeaderCallback,
+                         olp::http::Network::DataCallback) {
+        constexpr auto unused_request_id = 10;
+        return olp::http::SendOutcome(unused_request_id);
+      });
+  settings_.retry_settings.timeout = 0;
+
+  auto response = repository::CatalogRepository::GetCatalog(kHRN, context,
+                                                            request, settings_);
+
+  ASSERT_FALSE(response.IsSuccessful());
+  EXPECT_EQ(olp::client::ErrorCode::RequestTimeout,
+            response.GetError().GetErrorCode());
+}
 }  // namespace

--- a/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTestBase.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTestBase.cpp
@@ -71,6 +71,8 @@ void CatalogClientTestBase::SetUp() {
   settings_.cache =
       olp::client::OlpClientSettingsFactory::CreateDefaultCache(cache_settings);
   client_ = olp::client::OlpClientFactory::Create(settings_);
+  settings_.task_scheduler =
+      olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler(1u);
 
   SetUpCommonNetworkMockCalls();
 }


### PR DESCRIPTION
Add sync version of GetCatalog in CatalogRepository and port GetCatalog
from CatalogClient to use that version. Add default task scheduler for
tests.

Resolves: OLPEDGE-1002