### PR TITLE
Fix data race in sync GetData methods

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -121,7 +121,7 @@ VersionedLayerClientImpl::GetPartitions(PartitionsRequest partitions_request) {
 
 client::CancellationToken VersionedLayerClientImpl::GetData(
     DataRequest request, DataResponseCallback callback) {
-  auto add_task = [&](DataRequest& request, DataResponseCallback callback) {
+  auto add_task = [&](DataRequest request, DataResponseCallback callback) {
     auto catalog = catalog_;
     auto layer_id = layer_id_;
     auto settings = *settings_;
@@ -156,7 +156,7 @@ client::CancellationToken VersionedLayerClientImpl::GetData(
       online_token.cancel();
     });
   } else {
-    return add_task(request, std::move(callback));
+    return add_task(std::move(request), std::move(callback));
   }
 }
 

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -112,7 +112,7 @@ VolatileLayerClientImpl::GetPartitions(PartitionsRequest request) {
 
 client::CancellationToken VolatileLayerClientImpl::GetData(
     DataRequest request, DataResponseCallback callback) {
-  auto add_task = [&](DataRequest& request, DataResponseCallback callback) {
+  auto add_task = [&](DataRequest request, DataResponseCallback callback) {
     auto catalog = catalog_;
     auto layer_id = layer_id_;
     auto settings = *settings_;
@@ -147,7 +147,7 @@ client::CancellationToken VolatileLayerClientImpl::GetData(
       online_token.cancel();
     });
   } else {
-    return add_task(request, std::move(callback));
+    return add_task(std::move(request), std::move(callback));
   }
 }
 


### PR DESCRIPTION
Capture copies of request, not references, which are modified on the
fly.

Relates-To: OLPEDGE-1002