### PR TITLE
Implemented custom requests limit for NetworkAndroid

### DIFF
--- a/olp-cpp-sdk-core/src/http/Network.cpp
+++ b/olp-cpp-sdk-core/src/http/Network.cpp
@@ -40,7 +40,7 @@ CORE_API std::shared_ptr<Network> CreateDefaultNetwork(
 #ifdef NETWORK_HAS_CURL
   return std::make_shared<NetworkCurl>(max_requests_count);
 #elif NETWORK_HAS_ANDROID
-  return std::make_shared<NetworkAndroid>();
+  return std::make_shared<NetworkAndroid>(max_requests_count);
 #elif NETWORK_HAS_IOS
   return std::make_shared<OLPNetworkIOS>(max_requests_count);
 #elif NETWORK_HAS_WINHTTP

--- a/olp-cpp-sdk-core/src/http/android/NetworkAndroid.h
+++ b/olp-cpp-sdk-core/src/http/android/NetworkAndroid.h
@@ -42,8 +42,9 @@ class NetworkAndroid : public Network {
  public:
   /**
    * @brief NetworkAndroid constructor
+   * @param max_requests_count Maximum requests the NetworkAndroid can process.
    */
-  NetworkAndroid();
+  explicit NetworkAndroid(size_t max_requests_count);
 
   /**
    * @brief NetworkAndroid destructor
@@ -196,6 +197,8 @@ class NetworkAndroid : public Network {
   bool started_;
   bool initialized_;
   std::condition_variable run_thread_ready_cv_;
+
+  const size_t max_requests_count_;
 
   RequestId request_id_counter_{
       static_cast<RequestId>(RequestIdConstants::RequestIdMin)};


### PR DESCRIPTION
Implemented maximum requests count limit for Android implementation of Network (NetworkAndroid).
Also fixed crash when NetworkAndroid was cancelling requests without callbacks on NetworkAndroid destruction.

Resolved: OLPEDGE-777

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>