### PR TITLE
Add sync GetPartitions in VolatileLayerClient

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -68,10 +68,10 @@ class PartitionsRepository final {
       client::CancellationContext cancellation_context,
       read::PartitionsRequest data_request, client::OlpClientSettings settings);
 
-  static PartitionsResponse GetPartitions(
+  static PartitionsResponse GetVolatilePartitions(
       client::HRN catalog, std::string layer,
       client::CancellationContext cancellation_context,
-      read::PartitionsRequest request, client::OlpClientSettings settings);
+      read::PartitionsRequest data_request, client::OlpClientSettings settings);
 
   static QueryApi::PartitionsResponse GetPartitionById(
       const client::HRN& catalog, const std::string& layer,
@@ -79,6 +79,12 @@ class PartitionsRepository final {
       const DataRequest& data_request, client::OlpClientSettings settings);
 
  private:
+  static PartitionsResponse GetPartitions(
+      client::HRN catalog, std::string layer,
+      client::CancellationContext cancellation_context,
+      read::PartitionsRequest request, client::OlpClientSettings settings,
+      boost::optional<time_t> expiry = boost::none);
+
   client::HRN hrn_;
   std::shared_ptr<ApiRepository> apiRepo_;
   std::shared_ptr<CatalogRepository> catalogRepo_;

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -17,14 +17,18 @@
  * License-Filename: LICENSE
  */
 
+#include "repositories/PartitionsRepository.h"
+
 #include <gmock/gmock.h>
 #include <matchers/NetworkUrlMatchers.h>
 #include <mocks/CacheMock.h>
 #include <mocks/NetworkMock.h>
+#include <olp/core/cache/CacheSettings.h>
 #include <olp/core/client/OlpClientSettings.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
 #include <olp/dataservice/read/DataRequest.h>
+#include <olp/dataservice/read/PartitionsRequest.h>
 #include <olp/dataservice/read/model/Partitions.h>
-#include "../src/repositories/PartitionsRepository.h"
 
 // clang-format off
 #include "generated/parser/PartitionsParser.h"
@@ -59,6 +63,30 @@ const std::string kOlpSdkHttpResponsePartitionById =
     R"jsonString({ "partitions": [{"version":42,"partition":")jsonString" +
     kPartitionId +
     R"jsonString(","layer":"olp-cpp-sdk-ingestion-test-volatile-layer","dataHandle":"PartitionsRepositoryTest-partitionId"}]})jsonString";
+
+const std::string kOlpSdkUrlLookupConfig =
+    R"(https://api-lookup.data.api.platform.here.com/lookup/v1/platform/apis/config/v1)";
+
+const std::string kOlpSdkHttpResponseLookupConfig =
+    R"jsonString([{"api":"config","version":"v1","baseURL":"https://config.data.api.platform.in.here.com/config/v1","parameters":{}},{"api":"pipelines","version":"v1","baseURL":"https://pipelines.api.platform.in.here.com/pipeline-service","parameters":{}},{"api":"pipelines","version":"v2","baseURL":"https://pipelines.api.platform.in.here.com/pipeline-service","parameters":{}}])jsonString";
+
+const std::string kOlpSdkUrlConfig =
+    R"(https://config.data.api.platform.in.here.com/config/v1/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2)";
+
+const std::string
+    kOlpSdkHttpResponseConfig =
+        R"jsonString({"id":"hereos-internal-test","hrn":"hrn:here-dev:data:::hereos-internal-test","name":"hereos-internal-test","summary":"Internal test for hereos","description":"Used for internal testing on the staging olp.","contacts":{},"owner":{"creator":{"id":"HERE-88c95a7e-4123-4dcd-ae0e-4682aa5c3db4"},"organisation":{"id":"olp-here"}},"tags":[],"billingTags":[],"created":"2018-07-13T20:50:08.425Z","layers":[{"id":"hype-test-prefetch","hrn":"hrn:here-dev:data:::hereos-internal-test:hype-test-prefetch","name":"Hype Test Prefetch","summary":"hype prefetch testing","description":"Layer for hype prefetch testing","coverage":{"adminAreas":[]},"owner":{"creator":{"id":"HERE-88c95a7e-4123-4dcd-ae0e-4682aa5c3db4"},"organisation":{"id":"olp-here"}},"partitioningScheme":"heretile","partitioning":{"tileLevels":[],"scheme":"heretile"},"contentType":"application/x-protobuf","volume":{"volumeType":"durable"},"tags":[],"billingTags":[],"created":"2018-07-13T20:56:19.181Z","layerType":"versioned"},{"id":"testlayer_res","hrn":"hrn:here-dev:data:::hereos-internal-test:testlayer_res","name":"Resource Test Layer","summary":"testlayer_res","description":"testlayer_res","coverage":{"adminAreas":[]},"owner":{"creator":{"id":"HERE-88c95a7e-4123-4dcd-ae0e-4682aa5c3db4"},"organisation":{"id":"olp-here"}},"partitioningScheme":"generic","partitioning":{"scheme":"generic"},"contentType":"application/x-protobuf","volume":{"volumeType":"durable"},"tags":["TEST"],"billingTags":[],"created":"2018-07-13T20:56:19.181Z","layerType":"versioned"},{"id":"testlayer","hrn":"hrn:here-dev:data:::hereos-internal-test:testlayer","name":"Test Layer","summary":"A test layer","description":"A simple test layer","coverage":{"adminAreas":[]},"owner":{"creator":{"id":"HERE-88c95a7e-4123-4dcd-ae0e-4682aa5c3db4"},"organisation":{"id":"olp-here"}},"partitioningScheme":"generic","partitioning":{"scheme":"generic"},"contentType":"application/x-protobuf","volume":{"volumeType":"durable"},"tags":["TEST"],"billingTags":[],"created":"2018-07-13T20:56:19.181Z","layerType":"versioned"},{"id":"testlayer_volatile","ttl":1000,"hrn":"hrn:here-dev:data:::hereos-internal-test:testlayer","name":"Test Layer","summary":"A test layer","description":"A simple test layer","coverage":{"adminAreas":[]},"owner":{"creator":{"id":"HERE-88c95a7e-4123-4dcd-ae0e-4682aa5c3db4"},"organisation":{"id":"olp-here"}},"partitioningScheme":"generic","partitioning":{"scheme":"generic"},"contentType":"application/x-protobuf","volume":{"volumeType":"durable"},"tags":["TEST"],"billingTags":[],"created":"2018-07-13T20:56:19.181Z","layerType":"volatile"},{"id":"testlayer_stream","hrn":"hrn:here-dev:data:::hereos-internal-test:testlayer","name":"Test Layer","summary":"A test layer","description":"A simple test layer","coverage":{"adminAreas":[]},"owner":{"creator":{"id":"HERE-88c95a7e-4123-4dcd-ae0e-4682aa5c3db4"},"organisation":{"id":"olp-here"}},"partitioningScheme":"generic","partitioning":{"scheme":"generic"},"contentType":"application/x-protobuf","volume":{"volumeType":"durable"},"tags":["TEST"],"billingTags":[],"created":"2018-07-13T20:56:19.181Z","layerType":"stream"},{"id":"multilevel_testlayer","hrn":"hrn:here-dev:data:::hereos-internal-test:multilevel_testlayer","name":"Multi Level Test Layer","summary":"Multi Level Test Layer","description":"A multi level test layer just for testing","coverage":{"adminAreas":[]},"owner":{"creator":{"id":"HERE-88c95a7e-4123-4dcd-ae0e-4682aa5c3db4"},"organisation":{"id":"olp-here"}},"partitioningScheme":"generic","partitioning":{"scheme":"generic"},"contentType":"application/x-protobuf","volume":{"volumeType":"durable"},"tags":["TEST"],"billingTags":[],"created":"2018-07-13T20:56:19.181Z","layerType":"versioned"},{"id":"hype-test-prefetch-2","hrn":"hrn:here-dev:data:::hereos-internal-test:hype-test-prefetch-2","name":"Hype Test Prefetch2","summary":"Layer for testing hype2 prefetching","description":"Layer for testing hype2 prefetching","coverage":{"adminAreas":[]},"owner":{"creator":{"id":"HERE-88c95a7e-4123-4dcd-ae0e-4682aa5c3db4"},"organisation":{"id":"olp-here"}},"partitioningScheme":"heretile","partitioning":{"tileLevels":[],"scheme":"heretile"},"contentType":"application/x-protobuf","volume":{"volumeType":"durable"},"tags":["TEST"],"billingTags":[],"created":"2018-07-24T17:52:23.818Z","layerType":"versioned"}],"version":3})jsonString";
+
+const std::string kOlpSdkUrlLookupMetadata2 =
+    R"(https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data::olp-here-test:hereos-internal-test-v2/apis/metadata/v1)";
+const std::string kOlpSdkHttpResponseLookupMetadata2 =
+    R"jsonString([{"api":"metadata","version":"v1","baseURL":"https://metadata.data.api.platform.here.com/metadata/v1/catalogs/hereos-internal-test-v2","parameters":{}}])jsonString";
+
+const std::string kOlpSdkUrlPartitions =
+    R"(https://metadata.data.api.platform.here.com/metadata/v1/catalogs/hereos-internal-test-v2/layers/testlayer_volatile/partitions)";
+
+const std::string kOlpSdkHttpResponsePartitions =
+    R"jsonString({ "partitions": [{"version":4,"partition":"269","layer":"testlayer","dataHandle":"4eed6ed1-0d32-43b9-ae79-043cb4256432"},{"version":4,"partition":"270","layer":"testlayer","dataHandle":"30640762-b429-47b9-9ed6-7a4af6086e8e"},{"version":4,"partition":"3","layer":"testlayer","dataHandle":"data:SomethingBaH!"},{"version":4,"partition":"here_van_wc2018_pool","layer":"testlayer","dataHandle":"bcde4cc0-2678-40e9-b791-c630faee14c3"}]})jsonString";
 
 TEST(PartitionsRepositoryTest, GetPartitionById) {
   using namespace testing;
@@ -490,6 +518,80 @@ TEST(PartitionsRepositoryTest, GetPartitionById) {
     EXPECT_EQ(response.GetError().GetErrorCode(),
               olp::client::ErrorCode::Cancelled);
     Mock::VerifyAndClearExpectations(network.get());
+  }
+}
+
+TEST(PartitionsRepositoryTest, GetVolatilePartitions) {
+  using namespace testing;
+  using testing::Return;
+
+  std::shared_ptr<cache::KeyValueCache> default_cache =
+      olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
+
+  auto mock_network = std::make_shared<NetworkMock>();
+  const auto catalog = HRN::FromString(kCatalog);
+
+  EXPECT_CALL(*mock_network,
+              Send(IsGetRequest(kOlpSdkUrlLookupConfig), _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kOlpSdkHttpResponseLookupConfig));
+
+  EXPECT_CALL(*mock_network, Send(IsGetRequest(kOlpSdkUrlConfig), _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kOlpSdkHttpResponseConfig));
+
+  EXPECT_CALL(*mock_network,
+              Send(IsGetRequest(kOlpSdkUrlLookupMetadata2), _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kOlpSdkHttpResponseLookupMetadata2));
+
+  EXPECT_CALL(*mock_network,
+              Send(IsGetRequest(kOlpSdkUrlPartitions), _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kOlpSdkHttpResponsePartitions));
+
+  const auto layer = "testlayer_volatile";
+
+  {
+    SCOPED_TRACE("Successfull fetch from network");
+
+    OlpClientSettings settings;
+    settings.cache = default_cache;
+    settings.network_request_handler = mock_network;
+    settings.retry_settings.timeout = 1;
+
+    CancellationContext context;
+    PartitionsRequest request;
+    auto response = repository::PartitionsRepository::GetVolatilePartitions(
+        catalog, layer, context, request, settings);
+
+    ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
+    EXPECT_EQ(response.GetResult().GetPartitions().size(), 4);
+  }
+
+  {
+    SCOPED_TRACE("Successfull fetch from only cache");
+
+    OlpClientSettings settings;
+    settings.cache = default_cache;
+    settings.retry_settings.timeout = 0;
+
+    CancellationContext context;
+    PartitionsRequest request;
+    // Volatile layer must survive attempt to fetch versioned data
+    request.WithFetchOption(FetchOptions::CacheOnly).WithVersion(10);
+
+    auto cache_only_response =
+        repository::PartitionsRepository::GetVolatilePartitions(
+            catalog, layer, context, request, settings);
+
+    ASSERT_TRUE(cache_only_response.IsSuccessful())
+        << cache_only_response.GetError().GetMessage();
+    EXPECT_EQ(cache_only_response.GetResult().GetPartitions().size(), 4);
   }
 }
 }  // namespace

--- a/scripts/linux/fv/olp-cpp-sdk-functional-test.variables
+++ b/scripts/linux/fv/olp-cpp-sdk-functional-test.variables
@@ -18,4 +18,7 @@ export dataservice_read_test_versioned_prefetch_tile="5904591"
 export dataservice_read_test_versioned_prefetch_subpartition1="23618365"
 export dataservice_read_test_versioned_prefetch_subpartition2="1476147"
 
-export dataservice_read_volatile_layer="testlayer"
+export dataservice_read_volatile_test_appid="${dataservice_read_volatile_test_appid}"
+export dataservice_read_volatile_test_secret="${dataservice_read_volatile_test_secret}"
+export dataservice_read_volatile_layer="test-volatile-layer"
+export dataservice_read_volatile_test_catalog="hrn:here:data::olp-here-test:here-olp-sdk-cpp"

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVolatileLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVolatileLayerClientTest.cpp
@@ -41,10 +41,11 @@ using namespace testing;
 
 namespace {
 
-const auto kAppIdEnvName = "dataservice_read_test_appid";
-const auto kAppSecretEnvName = "dataservice_read_test_secret";
-const auto kCatalogEnvName = "dataservice_read_test_catalog";
+const auto kAppIdEnvName = "dataservice_read_volatile_test_appid";
+const auto kAppSecretEnvName = "dataservice_read_volatile_test_secret";
+const auto kCatalogEnvName = "dataservice_read_volatile_test_catalog";
 const auto kLayerEnvName = "dataservice_read_volatile_layer";
+
 const auto kTimeout = std::chrono::seconds(5);
 
 class VolatileLayerClientTest : public ::testing::Test {

--- a/tests/integration/olp-cpp-sdk-dataservice-read/HttpResponses.h
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/HttpResponses.h
@@ -57,6 +57,12 @@
 #define URL_PARTITIONS_VN1 \
   R"(https://metadata.data.api.platform.here.com/metadata/v1/catalogs/hereos-internal-test-v2/layers/testlayer/partitions?version=-1)"
 
+#define URL_PARTITIONS_VOLATILE \
+  R"(https://metadata.data.api.platform.here.com/metadata/v1/catalogs/hereos-internal-test-v2/layers/testlayer/partitions)"
+
+#define URL_PARTITIONS_VOLATILE_INVALID_LAYER \
+  R"(https://metadata.data.api.platform.here.com/metadata/v1/catalogs/hereos-internal-test-v2/layers/somewhat_not_okay/partitions)"
+
 #define URL_LOOKUP_QUERY \
   R"(https://api-lookup.data.api.platform.here.com/lookup/v1/resources/)"+GetTestCatalog()+R"(/apis/query/v1)"
 

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientTest.cpp
@@ -84,6 +84,8 @@ void DataserviceReadVolatileLayerClientTest::SetUp() {
   olp::cache::CacheSettings cache_settings;
   settings_.cache =
       olp::client::OlpClientSettingsFactory::CreateDefaultCache(cache_settings);
+  settings_.task_scheduler =
+      olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler(1u);
 
   SetUpCommonNetworkMockCalls();
 }
@@ -109,164 +111,17 @@ void DataserviceReadVolatileLayerClientTest::SetUpCommonNetworkMockCalls() {
                              HTTP_RESPONSE_LOOKUP_METADATA));
 
   ON_CALL(*network_mock_,
-          Send(IsGetRequest(URL_LATEST_CATALOG_VERSION), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_LATEST_CATALOG_VERSION));
-
-  ON_CALL(*network_mock_, Send(IsGetRequest(URL_LAYER_VERSIONS), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_LAYER_VERSIONS));
-
-  ON_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
+          Send(IsGetRequest(URL_PARTITIONS_VOLATILE), _, _, _, _))
       .WillByDefault(
           ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
                              HTTP_RESPONSE_PARTITIONS));
 
-  ON_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_QUERY), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_LOOKUP_QUERY));
-
   ON_CALL(*network_mock_,
-          Send(IsGetRequest(URL_QUERY_PARTITION_269), _, _, _, _))
+          Send(IsGetRequest(URL_PARTITIONS_VOLATILE_INVALID_LAYER), _, _, _, _))
       .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_PARTITION_269));
-
-  ON_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_LOOKUP_BLOB));
-
-  ON_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_BLOB_DATA_269));
-
-  ON_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITION_3), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_PARTITION_3));
-
-  ON_CALL(*network_mock_,
-          Send(IsGetRequest(URL_LOOKUP_VOLATILE_BLOB), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_LOOKUP_VOLATILE_BLOB));
-
-  ON_CALL(*network_mock_, Send(IsGetRequest(URL_LAYER_VERSIONS_V2), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_LAYER_VERSIONS_V2));
-
-  ON_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS_V2), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_PARTITIONS_V2));
-
-  ON_CALL(*network_mock_,
-          Send(IsGetRequest(URL_QUERY_PARTITION_269_V2), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_PARTITION_269_V2));
-
-  ON_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269_V2), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_BLOB_DATA_269_V2));
-
-  ON_CALL(*network_mock_,
-          Send(IsGetRequest(URL_QUERY_PARTITION_269_V10), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(400),
-                             HTTP_RESPONSE_INVALID_VERSION_V10));
-
-  ON_CALL(*network_mock_,
-          Send(IsGetRequest(URL_QUERY_PARTITION_269_VN1), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(400),
+          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                 olp::http::HttpStatusCode::NOT_FOUND),
                              HTTP_RESPONSE_INVALID_VERSION_VN1));
-
-  ON_CALL(*network_mock_,
-          Send(IsGetRequest(URL_LAYER_VERSIONS_V10), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(400),
-                             HTTP_RESPONSE_INVALID_VERSION_V10));
-
-  ON_CALL(*network_mock_,
-          Send(IsGetRequest(URL_LAYER_VERSIONS_VN1), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(400),
-                             HTTP_RESPONSE_INVALID_VERSION_VN1));
-
-  ON_CALL(*network_mock_, Send(IsGetRequest(URL_CONFIG_V2), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_CONFIG_V2));
-
-  ON_CALL(*network_mock_, Send(IsGetRequest(URL_QUADKEYS_23618364), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_QUADKEYS_23618364));
-
-  ON_CALL(*network_mock_, Send(IsGetRequest(URL_QUADKEYS_1476147), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_QUADKEYS_1476147));
-
-  ON_CALL(*network_mock_, Send(IsGetRequest(URL_QUADKEYS_5904591), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_QUADKEYS_5904591));
-
-  ON_CALL(*network_mock_, Send(IsGetRequest(URL_QUADKEYS_369036), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_QUADKEYS_369036));
-
-  ON_CALL(*network_mock_,
-          Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_1), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_BLOB_DATA_PREFETCH_1));
-
-  ON_CALL(*network_mock_,
-          Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_2), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_BLOB_DATA_PREFETCH_2));
-
-  ON_CALL(*network_mock_,
-          Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_3), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_BLOB_DATA_PREFETCH_3));
-
-  ON_CALL(*network_mock_,
-          Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_4), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_BLOB_DATA_PREFETCH_4));
-
-  ON_CALL(*network_mock_,
-          Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_5), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_BLOB_DATA_PREFETCH_5));
-
-  ON_CALL(*network_mock_,
-          Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_6), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_BLOB_DATA_PREFETCH_6));
-
-  ON_CALL(*network_mock_,
-          Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_7), _, _, _, _))
-      .WillByDefault(
-          ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
-                             HTTP_RESPONSE_BLOB_DATA_PREFETCH_7));
 
   // Catch any non-interesting network calls that don't need to be verified
   EXPECT_CALL(*network_mock_, Send(_, _, _, _, _)).Times(testing::AtLeast(0));
@@ -294,6 +149,56 @@ TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitions) {
   ASSERT_TRUE(partitions_response.IsSuccessful())
       << ApiErrorToString(partitions_response.GetError());
   ASSERT_EQ(4u, partitions_response.GetResult().GetPartitions().size());
+}
+
+TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitionsVersionIsIgnored) {
+  olp::client::HRN hrn(GetTestCatalog());
+
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_CONFIG), _, _, _, _))
+      .Times(1);
+
+  olp::dataservice::read::VolatileLayerClient client(hrn, "testlayer",
+                                                     settings_);
+
+  {
+    SCOPED_TRACE(
+        "Online request with version in request. Version should be ignored.");
+    auto request = olp::dataservice::read::PartitionsRequest();
+    request.WithVersion(4);
+    request.WithFetchOption(FetchOptions::OnlineOnly);
+
+    PartitionsResponse partitions_response;
+    olp::client::Condition condition;
+    client.GetPartitions(request, [&](PartitionsResponse response) {
+      partitions_response = std::move(response);
+      condition.Notify();
+    });
+
+    ASSERT_TRUE(condition.Wait(kTimeout));
+
+    ASSERT_TRUE(partitions_response.IsSuccessful())
+        << ApiErrorToString(partitions_response.GetError());
+    ASSERT_EQ(4u, partitions_response.GetResult().GetPartitions().size());
+  }
+
+  {
+    SCOPED_TRACE("Cache have data without version");
+    auto request = olp::dataservice::read::PartitionsRequest();
+    request.WithFetchOption(FetchOptions::CacheOnly);
+
+    PartitionsResponse partitions_response;
+    olp::client::Condition condition;
+    client.GetPartitions(request, [&](PartitionsResponse response) {
+      partitions_response = std::move(response);
+      condition.Notify();
+    });
+
+    ASSERT_TRUE(condition.Wait(kTimeout));
+
+    ASSERT_TRUE(partitions_response.IsSuccessful())
+        << ApiErrorToString(partitions_response.GetError());
+    ASSERT_EQ(4u, partitions_response.GetResult().GetPartitions().size());
+  }
 }
 
 TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitionsCancellableFuture) {
@@ -345,7 +250,8 @@ TEST_F(DataserviceReadVolatileLayerClientTest,
 TEST_F(DataserviceReadVolatileLayerClientTest, GetEmptyPartitions) {
   olp::client::HRN hrn(GetTestCatalog());
 
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(URL_PARTITIONS_VOLATILE), _, _, _, _))
       .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(200),
                                    HTTP_RESPONSE_EMPTY_PARTITIONS));
 
@@ -406,13 +312,15 @@ TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitions429Error) {
   {
     testing::InSequence s;
 
-    EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
+    EXPECT_CALL(*network_mock_,
+                Send(IsGetRequest(URL_PARTITIONS_VOLATILE), _, _, _, _))
         .Times(2)
         .WillRepeatedly(
             ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(429),
                                "Server busy at the moment."));
 
-    EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
+    EXPECT_CALL(*network_mock_,
+                Send(IsGetRequest(URL_PARTITIONS_VOLATILE), _, _, _, _))
         .Times(1);
   }
 
@@ -485,7 +393,7 @@ TEST_F(DataserviceReadVolatileLayerClientTest, ApiLookup429) {
 TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitionsForInvalidLayer) {
   olp::client::HRN hrn(GetTestCatalog());
 
-  olp::dataservice::read::VolatileLayerClient client(hrn, "InvalidLayer",
+  olp::dataservice::read::VolatileLayerClient client(hrn, "somewhat_not_okay",
                                                      settings_);
 
   auto request = olp::dataservice::read::PartitionsRequest();
@@ -500,7 +408,7 @@ TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitionsForInvalidLayer) {
 
   ASSERT_FALSE(partitions_response.IsSuccessful())
       << ApiErrorToString(partitions_response.GetError());
-  ASSERT_EQ(olp::client::ErrorCode::InvalidArgument,
+  ASSERT_EQ(olp::client::ErrorCode::NotFound,
             partitions_response.GetError().GetErrorCode());
 }
 
@@ -580,110 +488,6 @@ TEST_F(DataserviceReadVolatileLayerClientTest,
             partitions_response.GetError().GetErrorCode());
 }
 
-TEST_F(DataserviceReadVolatileLayerClientTest,
-       GetPartitionsCancelLatestCatalogVersion) {
-  olp::client::HRN hrn(GetTestCatalog());
-
-  // Setup the expected calls :
-  auto wait_for_cancel = std::make_shared<std::promise<void>>();
-  auto pause_for_cancel = std::make_shared<std::promise<void>>();
-
-  olp::http::RequestId request_id;
-  NetworkCallback send_mock;
-  CancelCallback cancel_mock;
-
-  std::tie(request_id, send_mock, cancel_mock) =
-      GenerateNetworkMockActions(wait_for_cancel, pause_for_cancel,
-                                 {200, HTTP_RESPONSE_LATEST_CATALOG_VERSION});
-
-  EXPECT_CALL(*network_mock_,
-              Send(IsGetRequest(URL_LATEST_CATALOG_VERSION), _, _, _, _))
-      .Times(1)
-      .WillOnce(testing::Invoke(std::move(send_mock)));
-
-  EXPECT_CALL(*network_mock_, Cancel(request_id))
-      .WillOnce(testing::Invoke(std::move(cancel_mock)));
-
-  EXPECT_CALL(*network_mock_,
-              Send(IsGetRequest(URL_LAYER_VERSIONS), _, _, _, _))
-      .Times(0);
-
-  std::promise<PartitionsResponse> promise;
-  auto callback = [&promise](PartitionsResponse response) {
-    promise.set_value(response);
-  };
-
-  VolatileLayerClient client(hrn, "testlayer", settings_);
-
-  auto request = olp::dataservice::read::PartitionsRequest();
-  auto cancel_token = client.GetPartitions(request, callback);
-
-  wait_for_cancel->get_future().get();  // wait for handler to get the request
-  cancel_token.cancel();
-  pause_for_cancel->set_value();  // unblock the handler
-  PartitionsResponse partitions_response = promise.get_future().get();
-
-  ASSERT_FALSE(partitions_response.IsSuccessful())
-      << ApiErrorToString(partitions_response.GetError());
-  ASSERT_EQ(static_cast<int>(olp::http::ErrorCode::CANCELLED_ERROR),
-            partitions_response.GetError().GetHttpStatusCode())
-      << ApiErrorToString(partitions_response.GetError());
-  ASSERT_EQ(olp::client::ErrorCode::Cancelled,
-            partitions_response.GetError().GetErrorCode())
-      << ApiErrorToString(partitions_response.GetError());
-}
-
-TEST_F(DataserviceReadVolatileLayerClientTest,
-       DISABLED_GetPartitionsCancelLayerVersions) {
-  olp::client::HRN hrn(GetTestCatalog());
-
-  // Setup the expected calls :
-  auto wait_for_cancel = std::make_shared<std::promise<void>>();
-  auto pause_for_cancel = std::make_shared<std::promise<void>>();
-
-  olp::http::RequestId request_id;
-  NetworkCallback send_mock;
-  CancelCallback cancel_mock;
-
-  std::tie(request_id, send_mock, cancel_mock) = GenerateNetworkMockActions(
-      wait_for_cancel, pause_for_cancel, {200, HTTP_RESPONSE_LAYER_VERSIONS});
-
-  EXPECT_CALL(*network_mock_,
-              Send(IsGetRequest(URL_LAYER_VERSIONS), _, _, _, _))
-      .Times(1)
-      .WillOnce(testing::Invoke(std::move(send_mock)));
-
-  EXPECT_CALL(*network_mock_, Cancel(request_id))
-      .WillOnce(testing::Invoke(std::move(cancel_mock)));
-
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
-      .Times(0);
-
-  std::promise<PartitionsResponse> promise;
-  auto callback = [&promise](PartitionsResponse response) {
-    promise.set_value(response);
-  };
-
-  VolatileLayerClient client(hrn, "testlayer", settings_);
-
-  auto request = olp::dataservice::read::PartitionsRequest();
-  auto cancel_token = client.GetPartitions(request, callback);
-
-  wait_for_cancel->get_future().get();  // wait for handler to get the request
-  cancel_token.cancel();
-  pause_for_cancel->set_value();  // unblock the handler
-  PartitionsResponse partitions_response = promise.get_future().get();
-
-  ASSERT_FALSE(partitions_response.IsSuccessful())
-      << ApiErrorToString(partitions_response.GetError());
-  ASSERT_EQ(static_cast<int>(olp::http::ErrorCode::CANCELLED_ERROR),
-            partitions_response.GetError().GetHttpStatusCode())
-      << ApiErrorToString(partitions_response.GetError());
-  ASSERT_EQ(olp::client::ErrorCode::Cancelled,
-            partitions_response.GetError().GetErrorCode())
-      << ApiErrorToString(partitions_response.GetError());
-}
-
 TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitionsCacheOnly) {
   olp::client::HRN hrn(GetTestCatalog());
 
@@ -758,8 +562,7 @@ TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitionsOnlineOnly) {
   }
 }
 
-TEST_F(DataserviceReadVolatileLayerClientTest,
-       DISABLED_GetPartitionsCacheWithUpdate) {
+TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitionsCacheWithUpdate) {
   olp::logging::Log::setLevel(olp::logging::Level::Trace);
 
   olp::client::HRN hrn(GetTestCatalog());
@@ -777,12 +580,10 @@ TEST_F(DataserviceReadVolatileLayerClientTest,
       wait_to_start_signal, pre_callback_wait, {200, HTTP_RESPONSE_PARTITIONS},
       wait_for_end_signal);
 
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(URL_PARTITIONS_VOLATILE), _, _, _, _))
       .Times(1)
       .WillOnce(testing::Invoke(std::move(send_mock)));
-
-  EXPECT_CALL(*network_mock_, Cancel(request_id))
-      .WillOnce(testing::Invoke(std::move(cancel_mock)));
 
   olp::dataservice::read::VolatileLayerClient client(hrn, "testlayer",
                                                      settings_);
@@ -827,9 +628,11 @@ TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitions403CacheClear) {
                                                      settings_);
   {
     testing::InSequence s;
-    EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
+    EXPECT_CALL(*network_mock_,
+                Send(IsGetRequest(URL_PARTITIONS_VOLATILE), _, _, _, _))
         .Times(1);
-    EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
+    EXPECT_CALL(*network_mock_,
+                Send(IsGetRequest(URL_PARTITIONS_VOLATILE), _, _, _, _))
         .WillOnce(ReturnHttpResponse(
             olp::http::NetworkResponse().WithStatus(403), HTTP_RESPONSE_403));
   }


### PR DESCRIPTION
Implement sync GetVolatilePartitions on top of GetPartitions::PartitionRepository.
Fix functional test to use volatile layer. Fix disabled integration test.

Resolves: OLPEDGE-1004
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>