### PR TITLE
Utilization of sync GetLatestVersion

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.h
@@ -62,9 +62,8 @@ class CatalogRepository final {
       const read::CatalogVersionCallback& callback);
 
   static MetadataApi::CatalogVersionResponse GetLatestVersion(
-      const client::HRN& catalog,
-      client::CancellationContext cancellation_context,
-      const DataRequest& data_request, client::OlpClientSettings settings);
+      client::HRN catalog, client::CancellationContext cancellation_context,
+      CatalogVersionRequest request, client::OlpClientSettings settings);
 
  private:
   client::HRN hrn_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
@@ -31,6 +31,7 @@
 #include "PartitionsRepository.h"
 #include "generated/api/VolatileBlobApi.h"
 #include "olp/dataservice/read/CatalogRequest.h"
+#include "olp/dataservice/read/CatalogVersionRequest.h"
 #include "olp/dataservice/read/DataRequest.h"
 #include "olp/dataservice/read/PartitionsRequest.h"
 
@@ -337,9 +338,12 @@ DataResponse DataRepository::GetVersionedData(
   if (!request.GetDataHandle()) {
     if (!request.GetVersion()) {
       // get latest version of the layer if it wasn't set by the user
+      CatalogVersionRequest version_request;
+      version_request.WithFetchOption(request.GetFetchOption())
+          .WithBillingTag(request.GetBillingTag());
       auto latest_version_response =
-          repository::CatalogRepository::GetLatestVersion(catalog, context,
-                                                          request, settings);
+          repository::CatalogRepository::GetLatestVersion(
+              catalog, context, std::move(version_request), settings);
       if (!latest_version_response.IsSuccessful()) {
         return latest_version_response.GetError();
       }

--- a/olp-cpp-sdk-dataservice-read/tests/CatalogRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/CatalogRepositoryTest.cpp
@@ -26,6 +26,8 @@
 #include <olp/core/client/OlpClientFactory.h>
 #include "ApiClientLookup.h"
 #include "olp/dataservice/read/CatalogRequest.h"
+#include "olp/dataservice/read/CatalogVersionRequest.h"
+#include "olp/dataservice/read/DataRequest.h"
 
 #define OLP_SDK_URL_LOOKUP_METADATA \
   R"(https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data::olp-here-test:hereos-internal-test-v2/apis/metadata/v1)"
@@ -56,7 +58,8 @@ using namespace olp::dataservice::read;
 using namespace ::testing;
 using namespace olp::tests::common;
 
-const std::string kCatalog = "hrn:here:data::olp-here-test:hereos-internal-test-v2";
+const std::string kCatalog =
+    "hrn:here:data::olp-here-test:hereos-internal-test-v2";
 const std::string kLatestVersionCacheKey = kCatalog + "::latestVersion";
 const std::string kCatalogCacheKey = kCatalog + "::catalog";
 const std::string kMetadataServiceName = "metadata";
@@ -97,7 +100,7 @@ class CatalogRepositoryTest : public ::testing::Test {
 TEST_F(CatalogRepositoryTest, GetLatestVersionCacheOnlyFound) {
   olp::client::CancellationContext context;
 
-  auto request = DataRequest();
+  auto request = CatalogVersionRequest();
 
   request.WithFetchOption(CacheOnly);
 
@@ -118,7 +121,7 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionCacheOnlyFound) {
 TEST_F(CatalogRepositoryTest, GetLatestVersionCacheOnlyNotFound) {
   olp::client::CancellationContext context;
 
-  auto request = olp::dataservice::read::DataRequest();
+  auto request = CatalogVersionRequest();
 
   request.WithFetchOption(CacheOnly);
 
@@ -143,7 +146,7 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionCacheOnlyNotFound) {
 TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyNotFound) {
   olp::client::CancellationContext context;
 
-  auto request = olp::dataservice::read::DataRequest();
+  auto request = CatalogVersionRequest();
 
   request.WithFetchOption(OnlineOnly);
 
@@ -170,7 +173,7 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyNotFound) {
 TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyFoundAndCacheWritten) {
   olp::client::CancellationContext context;
 
-  auto request = olp::dataservice::read::DataRequest();
+  auto request = CatalogVersionRequest();
 
   request.WithFetchOption(OnlineOnly);
 
@@ -208,7 +211,7 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyFoundAndCacheWritten) {
 TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyUserCancelled1) {
   olp::client::CancellationContext context;
 
-  auto request = olp::dataservice::read::DataRequest();
+  auto request = CatalogVersionRequest();
 
   std::promise<bool> cancelled;
 
@@ -249,7 +252,7 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyUserCancelled1) {
 TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyUserCancelled2) {
   olp::client::CancellationContext context;
 
-  auto request = olp::dataservice::read::DataRequest();
+  auto request = CatalogVersionRequest();
 
   ON_CALL(*network_,
           Send(IsGetRequest(OLP_SDK_URL_LOOKUP_METADATA), _, _, _, _))
@@ -282,7 +285,7 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionCancelledBeforeExecution) {
   settings_.retry_settings.timeout = 0;
   olp::client::CancellationContext context;
 
-  auto request = olp::dataservice::read::DataRequest();
+  auto request = CatalogVersionRequest();
 
   ON_CALL(*network_, Send(_, _, _, _, _))
       .WillByDefault([&](olp::http::NetworkRequest, olp::http::Network::Payload,
@@ -307,7 +310,7 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionCancelledBeforeExecution) {
 TEST_F(CatalogRepositoryTest, GetLatestVersionTimeouted) {
   olp::client::CancellationContext context;
 
-  auto request = olp::dataservice::read::DataRequest();
+  auto request = CatalogVersionRequest();
 
   ON_CALL(*network_,
           Send(IsGetRequest(OLP_SDK_URL_LOOKUP_METADATA), _, _, _, _))
@@ -392,7 +395,7 @@ TEST_F(CatalogRepositoryTest, GetCatalogCacheOnlyFound) {
 TEST_F(CatalogRepositoryTest, GetCatalogCacheOnlyNotFound) {
   olp::client::CancellationContext context;
 
-  auto request = olp::dataservice::read::DataRequest();
+  auto request = CatalogVersionRequest();
 
   request.WithFetchOption(CacheOnly);
 


### PR DESCRIPTION
CatalogClientImpl now uses general TaskContext approach for querying
GetLatestVersion()

Relates-to: OLPEDGE-1001

Signed-off-by: Sergii Vostrikov <ext-sergii.vostrikov@here.com>