### PR TITLE
Adapts InMemoryCache class to coding style.

### DIFF
--- a/olp-cpp-sdk-core/src/cache/InMemoryCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/InMemoryCache.cpp
@@ -17,104 +17,88 @@
  * License-Filename: LICENSE
  */
 
-#include <ctime>
-
 #include "InMemoryCache.h"
 
 namespace olp {
 namespace cache {
-InMemoryCache::TimeProvider& InMemoryCache::DefaultTimeProvider() {
-  static InMemoryCache::TimeProvider defaultTimeProvider = []() {
-    return std::time(nullptr);
-  };
-  return defaultTimeProvider;
+namespace {
+inline bool HasExpiry(time_t expiry_seconds) {
+  return (expiry_seconds != InMemoryCache::kExpiryMax);
 }
+}  // namespace
 
-InMemoryCache::ModelCacheCostFunc& InMemoryCache::EqualityCacheCost() {
-  static InMemoryCache::ModelCacheCostFunc equalityCacheCost =
-      [](const ItemTuple& tuple) { return 1; };
-  return equalityCacheCost;
-}
-
-InMemoryCache::ModelCacheCostFunc& InMemoryCache::PresetModelSizeCacheCost() {
-  static InMemoryCache::ModelCacheCostFunc presetModelSizeCacheCost =
-      [](const InMemoryCache::ItemTuple& tuple) {
-        auto result = std::get<3>(tuple);
-        if (result == 0) result = 1;
-        return result;
-      };
-  return presetModelSizeCacheCost;
-}
-
-InMemoryCache::InMemoryCache(size_t maxSize, ModelCacheCostFunc cacheCost,
-                             TimeProvider timeProvider)
-    : m_itemTuples(maxSize, std::move(cacheCost)),
-      m_timeProvider(std::move(timeProvider)) {
-  m_itemTuples.SetEvictionCallback(
+InMemoryCache::InMemoryCache(size_t max_size, ModelCacheCostFunc cache_cost,
+                             TimeProvider time_provider)
+    : item_tuples_(max_size, std::move(cache_cost)),
+      time_provider_(std::move(time_provider)) {
+  item_tuples_.SetEvictionCallback(
       [this](const std::string& key, ItemTuple&& value) {
         OnEviction(key, std::move(value));
       });
 }
 
-bool HasExpiry(time_t expirySeconds) {
-  return (expirySeconds != std::numeric_limits<time_t>::max());
-}
-
 bool InMemoryCache::Put(const std::string& key, const boost::any& item,
-                        time_t expireSeconds, size_t size) {
-  std::lock_guard<std::mutex> lock{m_mutex};
+                        time_t expire_seconds, size_t size) {
+  std::lock_guard<std::mutex> lock{mutex_};
 
   PurgeExpired();
 
-  bool expires = HasExpiry(expireSeconds);
+  bool expires = HasExpiry(expire_seconds);
   if (expires) {
     // can't expire in the past.
-    if (expireSeconds <= 0) return false;
-
-    expireSeconds += m_timeProvider();
+    if (expire_seconds <= 0) {
+      return false;
+    }
+    expire_seconds += time_provider_();
   }
-  auto itemTuple = std::make_tuple(key, expireSeconds, item, size);
-  auto ret = m_itemTuples.InsertOrAssign(key, itemTuple);
-  if (ret.second && expires) m_itemExpiries[expireSeconds].push_back(itemTuple);
+
+  auto item_tuple = std::make_tuple(key, expire_seconds, item, size);
+  auto ret = item_tuples_.InsertOrAssign(key, item_tuple);
+  if (ret.second && expires) {
+    item_expiries_[expire_seconds].push_back(item_tuple);
+  }
 
   return ret.second;
 }
 
 boost::any InMemoryCache::Get(const std::string& key) {
-  std::lock_guard<std::mutex> lock{m_mutex};
-  auto it = m_itemTuples.Find(key);
-  if (it != m_itemTuples.end()) {
-    auto expiryTime = std::get<1>(it.value());
-    if (expiryTime < m_timeProvider()) {
-      PurgeExpired(expiryTime);
-      return boost::any();
+  std::lock_guard<std::mutex> lock{mutex_};
+  auto it = item_tuples_.Find(key);
+  if (it != item_tuples_.end()) {
+    auto expiry_time = std::get<1>(it.value());
+    if (expiry_time < time_provider_()) {
+      PurgeExpired(expiry_time);
+      return {};
     }
 
     return std::get<2>(it.value());
   }
 
-  return boost::any();
+  return {};
 }
 
-size_t InMemoryCache::Size() const { return m_itemTuples.Size(); }
+size_t InMemoryCache::Size() const {
+  std::lock_guard<std::mutex> lock{mutex_};
+  return item_tuples_.Size();
+}
 
 void InMemoryCache::Clear() {
-  std::lock_guard<std::mutex> lock{m_mutex};
-  m_itemExpiries.clear();
-  m_itemTuples.Clear();
+  std::lock_guard<std::mutex> lock{mutex_};
+  item_expiries_.clear();
+  item_tuples_.Clear();
 }
 
-void InMemoryCache::Remove(const std::string& key) {
-  std::lock_guard<std::mutex> lock{m_mutex};
-  m_itemTuples.Erase(key);
+bool InMemoryCache::Remove(const std::string& key) {
+  std::lock_guard<std::mutex> lock{mutex_};
+  return item_tuples_.Erase(key);
 }
 
-void InMemoryCache::RemoveKeysWithPrefix(const std::string& keyPrefix) {
-  std::lock_guard<std::mutex> lock{m_mutex};
-  for (auto it = m_itemTuples.begin(); it != m_itemTuples.end();) {
-    if (it->key().substr(0, keyPrefix.length()) == keyPrefix) {
+void InMemoryCache::RemoveKeysWithPrefix(const std::string& key_prefix) {
+  std::lock_guard<std::mutex> lock{mutex_};
+  for (auto it = item_tuples_.begin(); it != item_tuples_.end();) {
+    if (it->key().substr(0, key_prefix.length()) == key_prefix) {
       // we allow concurrent modifications.
-      it = m_itemTuples.Erase(it);
+      it = item_tuples_.Erase(it);
     } else {
       ++it;
     }
@@ -123,42 +107,49 @@ void InMemoryCache::RemoveKeysWithPrefix(const std::string& keyPrefix) {
 
 bool InMemoryCache::PurgeExpired() {
   bool ret = true;
-  std::vector<time_t> expiredKeys;
-  for (auto item : m_itemExpiries) {
-    if (item.first < m_timeProvider())
-      expiredKeys.push_back(item.first);
-    else
-      break;  // std::map is sorted, so any further expiry times will be larger.
+  std::vector<time_t> expired_keys;
+  const auto time_now = time_provider_();
+
+  for (const auto& item : item_expiries_) {
+    if (item.first < time_now) {
+      expired_keys.push_back(item.first);
+    } else {
+      // std::map is sorted, so any further expiry times will be larger.
+      break;
+    }
   }
 
-  for (auto key : expiredKeys) ret &= PurgeExpired(key);
+  for (auto& key : expired_keys) {
+    ret &= PurgeExpired(key);
+  }
 
   return ret;
 }
 
-bool InMemoryCache::PurgeExpired(time_t expireTime) {
-  // TODO schedule a task and do this async?
-  for (auto itExp : m_itemExpiries[expireTime]) {
-    m_itemTuples.Erase(std::get<0>(itExp));
+bool InMemoryCache::PurgeExpired(time_t expire_time) {
+  bool ret = true;
+  for (auto& item : item_expiries_[expire_time]) {
+    ret &= item_tuples_.Erase(std::get<0>(item));
   }
-  m_itemExpiries.erase(expireTime);
 
-  return true;
+  item_expiries_.erase(expire_time);
+  return ret;
 }
 
 void InMemoryCache::OnEviction(const std::string& key, ItemTuple&& value) {
   time_t expiry = std::get<1>(value);
-  bool expires = HasExpiry(expiry);
-  if (expires) {
-    auto expVec = m_itemExpiries[expiry];
-    for (auto itTup = expVec.begin(); itTup != expVec.end(); itTup++) {
-      if (std::get<0>(*itTup) == key) {
-        expVec.erase(itTup);
+  if (HasExpiry(expiry)) {
+    auto item = item_expiries_[expiry];
+    for (auto it = item.begin(); it != item.end(); it++) {
+      if (std::get<0>(*it) == key) {
+        item.erase(it);
         break;
       }
     }
 
-    if (m_itemExpiries[expiry].size() == 0) m_itemExpiries.erase(expiry);
+    if (item_expiries_[expiry].size() == 0) {
+      item_expiries_.erase(expiry);
+    }
   }
 }
 


### PR DESCRIPTION
Adapts most of the internals of the InMemoryCache to the coding style.
Also removes static methods from InMemoryCache and replaces them with
nested structures to be used by the LRUCache and time provider default
parameter values. Add mutex lock for Size() method.
Promote private members to protected to be able to test via testable.
Adapts unit tests to coding style.

Relates-to: OLPEDGE-566

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>