### PR TITLE
Pass arguments to CatalogClient by value

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogClient.h
@@ -75,8 +75,8 @@ class DATASERVICE_READ_API CatalogClient final {
    * available, or an error is encountered.
    * @return A token that can be used to cancel this request
    */
-  client::CancellationToken GetCatalog(const CatalogRequest& request,
-                                       const CatalogResponseCallback& callback);
+  client::CancellationToken GetCatalog(CatalogRequest request,
+                                       CatalogResponseCallback callback);
 
   /**
    * @brief fetches catalog configuration asynchronously.
@@ -85,8 +85,7 @@ class DATASERVICE_READ_API CatalogClient final {
    * contain the catalog configuration or an error. Alternatively, the
    * CancellableFuture can be used to cancel this request.
    */
-  client::CancellableFuture<CatalogResponse> GetCatalog(
-      const CatalogRequest& request);
+  client::CancellableFuture<CatalogResponse> GetCatalog(CatalogRequest request);
 
   /**
    * @brief fetches catalog version asynchronously.
@@ -119,8 +118,7 @@ class DATASERVICE_READ_API CatalogClient final {
   OLP_SDK_DEPRECATED(
       "Will be removed in 1.1, please use GetLatestVersion() instead")
   client::CancellationToken GetCatalogMetadataVersion(
-      const CatalogVersionRequest& request,
-      const CatalogVersionCallback& callback);
+      CatalogVersionRequest request, CatalogVersionCallback callback);
 
   /**
    * @brief fetches catalog version asynchronously.
@@ -133,7 +131,7 @@ class DATASERVICE_READ_API CatalogClient final {
   OLP_SDK_DEPRECATED(
       "Will be removed in 1.1, please use GetLatestVersion() instead")
   client::CancellableFuture<CatalogVersionResponse> GetCatalogMetadataVersion(
-      const CatalogVersionRequest& request);
+      CatalogVersionRequest request);
 
   /**
    * @brief fetches a list partitions for given generic layer asynchronously.

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClient.cpp
@@ -48,13 +48,13 @@ bool CatalogClient::CancelPendingRequests() {
 }
 
 client::CancellationToken CatalogClient::GetCatalog(
-    const CatalogRequest& request, const CatalogResponseCallback& callback) {
-  return impl_->GetCatalog(request, callback);
+    CatalogRequest request, CatalogResponseCallback callback) {
+  return impl_->GetCatalog(std::move(request), std::move(callback));
 }
 
 client::CancellableFuture<CatalogResponse> CatalogClient::GetCatalog(
-    const CatalogRequest& request) {
-  return impl_->GetCatalog(request);
+    CatalogRequest request) {
+  return impl_->GetCatalog(std::move(request));
 }
 
 client::CancellationToken CatalogClient::GetLatestVersion(
@@ -68,14 +68,13 @@ CatalogClient::GetLatestVersion(CatalogVersionRequest request) {
 }
 
 client::CancellationToken CatalogClient::GetCatalogMetadataVersion(
-    const CatalogVersionRequest& request,
-    const CatalogVersionCallback& callback) {
-  return impl_->GetLatestVersion(request, callback);
+    CatalogVersionRequest request, CatalogVersionCallback callback) {
+  return impl_->GetLatestVersion(std::move(request), std::move(callback));
 }
 
 client::CancellableFuture<CatalogVersionResponse>
-CatalogClient::GetCatalogMetadataVersion(const CatalogVersionRequest& request) {
-  return impl_->GetLatestVersion(request);
+CatalogClient::GetCatalogMetadataVersion(CatalogVersionRequest request) {
+  return impl_->GetLatestVersion(std::move(request));
 }
 
 client::CancellationToken CatalogClient::GetPartitions(


### PR DESCRIPTION
Pass arguments to methods of CatalogClient by value and move them inside.

Relates-to: OLPEDGE-798
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>