### PR TITLE
Clean up CatalogClient

### DIFF
--- a/examples/dataservice-read/example.cpp
+++ b/examples/dataservice-read/example.cpp
@@ -30,9 +30,6 @@
 #include <olp/core/porting/make_unique.h>
 
 #include <olp/dataservice/read/CatalogClient.h>
-#include <olp/dataservice/read/CatalogRequest.h>
-#include <olp/dataservice/read/DataRequest.h>
-#include <olp/dataservice/read/PartitionsRequest.h>
 #include <olp/dataservice/read/VersionedLayerClient.h>
 
 namespace {

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogClient.h
@@ -22,13 +22,15 @@
 #include <functional>
 #include <memory>
 
-#include <olp/core/cache/CacheSettings.h>
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/core/geo/tiling/TileKey.h>
 #include <olp/core/porting/deprecated.h>
-#include "DataServiceReadApi.h"
-#include "olp/dataservice/read/PrefetchTileResult.h"
-#include "olp/dataservice/read/Types.h"
+#include <olp/dataservice/read/CatalogRequest.h>
+#include <olp/dataservice/read/CatalogVersionRequest.h>
+#include <olp/dataservice/read/DataRequest.h>
+#include <olp/dataservice/read/DataServiceReadApi.h>
+#include <olp/dataservice/read/PartitionsRequest.h>
+#include <olp/dataservice/read/Types.h>
 
 namespace olp {
 
@@ -40,12 +42,6 @@ namespace dataservice {
 namespace read {
 
 class CatalogClientImpl;
-
-class CatalogRequest;
-class CatalogVersionRequest;
-class DataRequest;
-class PartitionsRequest;
-class PrefetchTilesRequest;
 
 /**
  * @brief The CatalogClient class. Marshals Requests and their Results.

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClient.cpp
@@ -20,8 +20,8 @@
 #include "olp/dataservice/read/CatalogClient.h"
 
 #include "CatalogClientImpl.h"
-#include "olp/core/cache/DefaultCache.h"
-#include "olp/core/client/OlpClientSettingsFactory.h"
+#include <olp/core/cache/DefaultCache.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
 
 namespace olp {
 namespace dataservice {
@@ -29,7 +29,7 @@ namespace read {
 
 CatalogClient::CatalogClient(client::HRN catalog,
                              client::OlpClientSettings settings) {
-  // If the user did not specify cache, we creade a default one (memory only)
+  // If the user did not specify cache, we create a default one (memory only)
   if (!settings.cache) {
     settings.cache = client::OlpClientSettingsFactory::CreateDefaultCache({});
   }

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.h
@@ -29,6 +29,7 @@
 #include <olp/dataservice/read/CatalogVersionRequest.h>
 #include <olp/dataservice/read/DataRequest.h>
 #include <olp/dataservice/read/PartitionsRequest.h>
+#include <olp/dataservice/read/PrefetchTilesRequest.h>
 
 namespace olp {
 namespace client {

--- a/olp-cpp-sdk-dataservice-read/src/PrefetchTilesProvider.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/PrefetchTilesProvider.cpp
@@ -26,6 +26,7 @@
 #include "olp/dataservice/read/CatalogVersionRequest.h"
 #include "olp/dataservice/read/DataRequest.h"
 #include "olp/dataservice/read/PrefetchTilesRequest.h"
+#include "olp/dataservice/read/PrefetchTileResult.h"
 
 #include "repositories/ApiRepository.h"
 #include "repositories/CatalogRepository.h"

--- a/tests/functional/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
@@ -46,11 +46,6 @@
 #include <olp/core/porting/make_unique.h>
 #include <olp/core/utils/Dir.h>
 #include <olp/dataservice/read/CatalogClient.h>
-#include <olp/dataservice/read/CatalogRequest.h>
-#include <olp/dataservice/read/CatalogVersionRequest.h>
-#include <olp/dataservice/read/DataRequest.h>
-#include <olp/dataservice/read/PartitionsRequest.h>
-#include <olp/dataservice/read/PrefetchTilesRequest.h>
 #include <olp/dataservice/read/model/Catalog.h>
 #include "Utils.h"
 

--- a/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientCacheTest.cpp
@@ -10,10 +10,6 @@
 #include <olp/core/porting/make_unique.h>
 #include <olp/core/utils/Dir.h>
 #include <olp/dataservice/read/CatalogClient.h>
-#include <olp/dataservice/read/CatalogRequest.h>
-#include <olp/dataservice/read/CatalogVersionRequest.h>
-#include <olp/dataservice/read/DataRequest.h>
-#include <olp/dataservice/read/PartitionsRequest.h>
 #include "HttpResponses.h"
 
 namespace {

--- a/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
@@ -20,6 +20,7 @@
 #include <gmock/gmock.h>
 #include <matchers/NetworkUrlMatchers.h>
 #include <mocks/NetworkMock.h>
+#include <olp/core/cache/CacheSettings.h>
 #include <olp/core/cache/KeyValueCache.h>
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
@@ -27,11 +28,6 @@
 #include <olp/core/logging/Log.h>
 #include <olp/core/porting/make_unique.h>
 #include <olp/dataservice/read/CatalogClient.h>
-#include <olp/dataservice/read/CatalogRequest.h>
-#include <olp/dataservice/read/CatalogVersionRequest.h>
-#include <olp/dataservice/read/DataRequest.h>
-#include <olp/dataservice/read/PartitionsRequest.h>
-#include <olp/dataservice/read/PrefetchTilesRequest.h>
 #include <olp/dataservice/read/model/Catalog.h>
 #include "CatalogClientTestBase.h"
 #include "HttpResponses.h"

--- a/tests/performance/CatalogClientTest.cpp
+++ b/tests/performance/CatalogClientTest.cpp
@@ -22,13 +22,13 @@
 
 #include <gtest/gtest.h>
 
+#include "olp/core/cache/CacheSettings.h"
 #include "olp/core/cache/KeyValueCache.h"
 #include "olp/core/client/HRN.h"
 #include "olp/core/client/OlpClientSettings.h"
 #include "olp/core/client/OlpClientSettingsFactory.h"
 #include "olp/core/logging/Log.h"
 #include "olp/dataservice/read/CatalogClient.h"
-#include "olp/dataservice/read/DataRequest.h"
 
 namespace {
 struct CatalogClientTestConfiguration {
@@ -208,4 +208,4 @@ TEST_P(CatalogClientTest, ReadNPartitionsFromVersionedLayer) {
 INSTANTIATE_TEST_SUITE_P(MemoryUsage, CatalogClientTest,
                          ::testing::Values(CatalogClientTestConfiguration{
                              3, 5, 5, std::chrono::hours(10)}));
-}  // namespace
+} // namespace


### PR DESCRIPTION
Add includes, that are mandatory for non-trivial class usage. Remove
redundant includes from examples and tests. Remove redundant forward
declarations.

Relates-To: OLPEDGE-798
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>