### PR TITLE
Fixed crash in CatalogClientTest.GetPartitionsWithInvalidHrn

### DIFF
--- a/tests/functional/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
@@ -109,9 +109,10 @@ class CatalogClientTest : public ::testing::TestWithParam<CacheType> {
   void TearDown() override {
     client_.reset();
     auto network = std::move(settings_.network_request_handler);
+    settings_ = olp::client::OlpClientSettings();
     // when test ends we must be sure that network pointer is not captured
     // anywhere
-    assert(network.use_count() == 1);
+    EXPECT_EQ(network.use_count(), 1);
   }
 
  protected:


### PR DESCRIPTION
Resolves: OLPEDGE-1031

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>