### PR TITLE
Remove deprecated CatalogClient::GetData

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogClient.h
@@ -129,37 +129,6 @@ class DATASERVICE_READ_API CatalogClient final {
   client::CancellableFuture<CatalogVersionResponse> GetCatalogMetadataVersion(
       CatalogVersionRequest request);
 
-  /**
-   * @brief fetches data for a partition or data handle asynchronously. If the
-   * specified partition or data handle cannot be found in the layer, the
-   * callback will be invoked with an empty DataResponse (nullptr for result and
-   * error). If neither Partition Id or Data Handle were set in the request, the
-   * callback will be invoked with an error with ErrorCode::InvalidRequest.
-   * @param request contains the complete set of request parameters.
-   * @param callback will be invoked once the DataResult is available, or an
-   * error is encountered.
-   * @return A token that can be used to cancel this request
-   * @deprecated Will be removed in 1.0
-   */
-  OLP_SDK_DEPRECATED("Will be removed in 1.0")
-  client::CancellationToken GetData(const DataRequest& request,
-                                    const DataResponseCallback& callback);
-
-  /**
-   * @brief fetches data for a partition or data handle asynchronously. If the
-   * specified partition or data handle cannot be found in the layer, an empty
-   * DataResponse (nullptr for result and error) will be returned. If neither
-   * Partition Id or Data Handle were set in the request, an error with code
-   * ErrorCode::InvalidRequest will be returned.
-   * @param request contains the complete set of request parameters.
-   * @return CancellableFuture of type DataResponse, which when complete will
-   * contain the data or an error. Alternatively, the CancellableFuture can be
-   * used to cancel this request.
-   * @deprecated Will be removed in 1.0
-   */
-  OLP_SDK_DEPRECATED("Will be removed in 1.0")
-  client::CancellableFuture<DataResponse> GetData(const DataRequest& request);
-
  private:
   std::shared_ptr<CatalogClientImpl> impl_;
 };

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClient.cpp
@@ -76,16 +76,6 @@ client::CancellableFuture<CatalogVersionResponse>
 CatalogClient::GetCatalogMetadataVersion(CatalogVersionRequest request) {
   return impl_->GetLatestVersion(std::move(request));
 }
-
-client::CancellationToken CatalogClient::GetData(
-    const DataRequest& request, const DataResponseCallback& callback) {
-  return impl_->GetData(request, callback);
-}
-
-client::CancellableFuture<DataResponse> CatalogClient::GetData(
-    const DataRequest& request) {
-  return impl_->GetData(request);
-}
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
@@ -48,18 +48,6 @@ CatalogClientImpl::CatalogClientImpl(HRN catalog, OlpClientSettings settings)
   // without the scheduler
   task_scheduler_ = std::move(settings_->task_scheduler);
 
-  // create repositories, satisfying dependencies.
-  auto api_repo = std::make_shared<ApiRepository>(catalog_, settings_, cache);
-
-  catalog_repo_ =
-      std::make_shared<CatalogRepository>(catalog_, api_repo, cache);
-
-  partition_repo_ = std::make_shared<PartitionsRepository>(
-      catalog_, api_repo, catalog_repo_, cache);
-
-  data_repo_ = std::make_shared<DataRepository>(
-      catalog_, api_repo, catalog_repo_, partition_repo_, cache);
-
   pending_requests_ = std::make_shared<client::PendingRequests>();
 }
 
@@ -149,43 +137,6 @@ CancellableFuture<CatalogVersionResponse> CatalogClientImpl::GetLatestVersion(
       static_cast<client::CancellationToken (CatalogClientImpl::*)(
           CatalogVersionRequest, CatalogVersionCallback)>(
           &CatalogClientImpl::GetLatestVersion));
-}
-
-client::CancellationToken CatalogClientImpl::GetData(
-    const DataRequest& request, const DataResponseCallback& callback) {
-  CancellationToken token;
-  int64_t request_key = pending_requests_->GenerateRequestPlaceholder();
-  auto pending_requests = pending_requests_;
-  auto request_callback = [pending_requests, request_key,
-                           callback](DataResponse response) {
-    if (pending_requests->Remove(request_key)) {
-      callback(response);
-    }
-  };
-  if (CacheWithUpdate == request.GetFetchOption()) {
-    auto req = request;
-    token =
-        data_repo_->GetData(req.WithFetchOption(CacheOnly), request_callback);
-    auto onlineKey = pending_requests_->GenerateRequestPlaceholder();
-    pending_requests_->Insert(
-        data_repo_->GetData(req.WithFetchOption(OnlineIfNotFound),
-                            [pending_requests, onlineKey](DataResponse) {
-                              pending_requests->Remove(onlineKey);
-                            }),
-        onlineKey);
-  } else {
-    token = data_repo_->GetData(request, request_callback);
-  }
-  pending_requests_->Insert(token, request_key);
-  return token;
-}
-
-client::CancellableFuture<DataResponse> CatalogClientImpl::GetData(
-    const DataRequest& request) {
-  return AsFuture<DataRequest, DataResponse>(
-      request, static_cast<client::CancellationToken (CatalogClientImpl::*)(
-                   const DataRequest&, const DataResponseCallback&)>(
-                   &CatalogClientImpl::GetData));
 }
 }  // namespace read
 }  // namespace dataservice

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.h
@@ -67,11 +67,6 @@ class CatalogClientImpl final {
   client::CancellableFuture<CatalogVersionResponse> GetLatestVersion(
       CatalogVersionRequest request);
 
-  client::CancellationToken GetData(const DataRequest& request,
-                                    const DataResponseCallback& callback);
-
-  client::CancellableFuture<DataResponse> GetData(const DataRequest& request);
-
  private:
   client::HRN catalog_;
   std::shared_ptr<client::OlpClientSettings> settings_;


### PR DESCRIPTION
Remove deprecated method CatalogClient::GetData. 

Relates-To: OLPEDGE-1015
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>