### PR TITLE
Remove usage of deprecated GetLayerId

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/DataRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/DataRequest.h
@@ -42,38 +42,6 @@ namespace read {
 class DATASERVICE_READ_API DataRequest final {
  public:
   /**
-   * @brief GetLayerId gets the request's layer id.
-   * @return the layer id.
-   * @deprecated Will be removed in 1.0
-   */
-  OLP_SDK_DEPRECATED("Will be removed in 1.0")
-  inline const std::string& GetLayerId() const { return layer_id_; }
-
-  /**
-   * @brief WithLayerId sets the layer id of the request.
-   * @param layerId the layer the requested partitions belong to.
-   * @return a reference to the updated DataRequest.
-   * @deprecated Will be removed in 1.0
-   */
-  OLP_SDK_DEPRECATED("Will be removed in 1.0")
-  inline DataRequest& WithLayerId(const std::string& layerId) {
-    layer_id_ = layerId;
-    return *this;
-  }
-
-  /**
-   * @brief WithLayerId sets the layer id of the request.
-   * @param layerId the layer the requested partitions belong to.
-   * @return a reference to the updated DataRequest.
-   * @deprecated Will be removed in 1.0
-   */
-  OLP_SDK_DEPRECATED("Will be removed in 1.0")
-  inline DataRequest& WithLayerId(std::string&& layerId) {
-    layer_id_ = std::move(layerId);
-    return *this;
-  }
-
-  /**
    * @brief GetPartitionId gets the request's Partition Id.
    * @return the partition id.
    */
@@ -215,9 +183,9 @@ class DATASERVICE_READ_API DataRequest final {
    * @param none
    * @return string representation of the request
    */
-  inline std::string CreateKey() const {
+  inline std::string CreateKey(const std::string& layer_id) const {
     std::stringstream out;
-    out << GetLayerId();
+    out << layer_id;
 
     out << "[";
 

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PartitionsRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PartitionsRequest.h
@@ -38,38 +38,6 @@ namespace read {
 class DATASERVICE_READ_API PartitionsRequest final {
  public:
   /**
-   * @brief GetLayerId gets the request's layer id.
-   * @return the layer id.
-   * @deprecated Will be removed in 1.0
-   */
-  OLP_SDK_DEPRECATED("Will be removed in 1.0")
-  inline const std::string& GetLayerId() const { return layer_id_; }
-
-  /**
-   * @brief WithLayerId sets the layer id of the request.
-   * @param layerId the layer the requested partitions belong to.
-   * @return a reference to the updated PartitionsRequest.
-   * @deprecated Will be removed in 1.0
-   */
-  OLP_SDK_DEPRECATED("Will be removed in 1.0")
-  inline PartitionsRequest& WithLayerId(const std::string& layerId) {
-    layer_id_ = layerId;
-    return *this;
-  }
-
-  /**
-   * @brief WithLayerId sets the layer id of the request.
-   * @param layerId the layer the requested partitions belong to.
-   * @return a reference to the updated PartitionsRequest.
-   * @deprecated Will be removed in 1.0
-   */
-  OLP_SDK_DEPRECATED("Will be removed in 1.0")
-  inline PartitionsRequest& WithLayerId(std::string&& layerId) {
-    layer_id_ = std::move(layerId);
-    return *this;
-  }
-
-  /**
    * @brief WithVersion sets the catalog metadata version of the request.
    * @param catalogMetadataVersion The catalog metadta version of the requested
    * partions. If no version is specified, the latest will be retrieved.
@@ -146,9 +114,9 @@ class DATASERVICE_READ_API PartitionsRequest final {
    * @param none
    * @return string representation of the request
    */
-  std::string CreateKey() const {
+  std::string CreateKey(const std::string& layer_id) const {
     std::stringstream out;
-    out << GetLayerId();
+    out << layer_id;
 
     if (GetVersion()) {
       out << "@" << GetVersion().get();

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
@@ -44,38 +44,6 @@ namespace read {
 class DATASERVICE_READ_API PrefetchTilesRequest final {
  public:
   /**
-   * @brief GetLayerId gets the request's layer id.
-   * @return the layer id.
-   * @deprecated Will be removed in 1.0
-   */
-  OLP_SDK_DEPRECATED("Will be removed in 1.0")
-  inline const std::string& GetLayerId() const { return layer_id_; }
-
-  /**
-   * @brief WithLayerId sets the layer id of the request.
-   * @param layerId the layer id the requested tiles belong to.
-   * @return a reference to the updated PrefetchTilesRequest.
-   * @deprecated Will be removed in 1.0
-   */
-  OLP_SDK_DEPRECATED("Will be removed in 1.0")
-  inline PrefetchTilesRequest& WithLayerId(const std::string& layerId) {
-    layer_id_ = layerId;
-    return *this;
-  }
-
-  /**
-   * @brief WithLayerId sets the layer id of the request.
-   * @param layerId the layer id the requested tiles belong to.
-   * @return a reference to the updated PrefetchTilesRequest.
-   * @deprecated Will be removed in 1.0
-   */
-  OLP_SDK_DEPRECATED("Will be removed in 1.0")
-  inline PrefetchTilesRequest& WithLayerId(std::string&& layerId) {
-    layer_id_ = std::move(layerId);
-    return *this;
-  }
-
-  /**
    * @brief GetPartitionId gets the request's Partition Id.
    * @return the partition id.
    */
@@ -159,9 +127,9 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
    * @param none
    * @return string representation of the request
    */
-  inline std::string CreateKey() const {
+  inline std::string CreateKey(const std::string& layer_id) const {
     std::stringstream out;
-    out << GetLayerId();
+    out << layer_id;
 
     out << "[" << GetMinLevel() << "/" << GetMaxLevel() << "]";
 

--- a/olp-cpp-sdk-dataservice-read/src/PrefetchTilesProvider.h
+++ b/olp-cpp-sdk-dataservice-read/src/PrefetchTilesProvider.h
@@ -41,7 +41,7 @@ class DataRepository;
 class PrefetchTilesProvider final {
  public:
   PrefetchTilesProvider(
-      const client::HRN& hrn,
+      const client::HRN& hrn, std::string layer_id,
       std::shared_ptr<repository::ApiRepository> apiRepo,
       std::shared_ptr<repository::CatalogRepository> catalogRepo,
       std::shared_ptr<repository::DataRepository> dataRepo,
@@ -81,6 +81,7 @@ class PrefetchTilesProvider final {
   std::shared_ptr<repository::DataRepository> dataRepo_;
   std::shared_ptr<repository::PrefetchTilesRepository> prefetchTilesRepo_;
   std::shared_ptr<olp::client::OlpClientSettings> settings_;
+  std::string layer_id_;
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -61,17 +61,19 @@ VersionedLayerClientImpl::VersionedLayerClientImpl(
       catalog_, api_repo, settings_->cache);
 
   partition_repo_ = std::make_shared<repository::PartitionsRepository>(
-      catalog_, api_repo, catalog_repo, settings_->cache);
+      catalog_, layer_id, api_repo, catalog_repo, settings_->cache);
 
   auto data_repo = std::make_shared<repository::DataRepository>(
-      catalog_, api_repo, catalog_repo, partition_repo_, settings_->cache);
+      catalog_, layer_id, api_repo, catalog_repo, partition_repo_,
+      settings_->cache);
 
   auto prefetch_repo = std::make_shared<repository::PrefetchTilesRepository>(
-      catalog_, api_repo, partition_repo_->GetPartitionsCacheRepository(),
-      settings_);
+      catalog_, layer_id, api_repo,
+      partition_repo_->GetPartitionsCacheRepository(), settings_);
 
   prefetch_provider_ = std::make_shared<PrefetchTilesProvider>(
-      catalog_, api_repo, catalog_repo, data_repo, prefetch_repo, settings_);
+      catalog_, layer_id, api_repo, catalog_repo, data_repo, prefetch_repo,
+      settings_);
 }
 
 VersionedLayerClientImpl::~VersionedLayerClientImpl() {
@@ -80,7 +82,6 @@ VersionedLayerClientImpl::~VersionedLayerClientImpl() {
 
 client::CancellationToken VersionedLayerClientImpl::GetPartitions(
     PartitionsRequest request, PartitionsResponseCallback callback) {
-  request.WithLayerId(layer_id_);
   auto schedule_get_partitions = [&](PartitionsRequest request,
                                      PartitionsResponseCallback callback) {
     auto catalog = catalog_;
@@ -173,7 +174,6 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
     }
   };
 
-  request.WithLayerId(layer_id_);
   auto token = prefetch_provider_->PrefetchTiles(request, request_callback);
   pending_requests->Insert(token, request_key);
   return token;

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -64,7 +64,7 @@ VolatileLayerClientImpl::VolatileLayerClientImpl(
       catalog_, api_repo, cache);
 
   partition_repo_ = std::make_shared<repository::PartitionsRepository>(
-      catalog_, api_repo, catalog_repo, cache);
+      catalog_, layer_id, api_repo, catalog_repo, cache);
 }
 
 VolatileLayerClientImpl::~VolatileLayerClientImpl() {

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
@@ -40,7 +40,8 @@ class DataCacheRepository;
 
 class DataRepository final {
  public:
-  DataRepository(const client::HRN& hrn, std::shared_ptr<ApiRepository> apiRepo,
+  DataRepository(const client::HRN& hrn, std::string layer_id,
+                 std::shared_ptr<ApiRepository> apiRepo,
                  std::shared_ptr<CatalogRepository> catalogRepo,
                  std::shared_ptr<PartitionsRepository> partitionsRepo,
                  std::shared_ptr<cache::KeyValueCache> cache);
@@ -76,6 +77,7 @@ class DataRepository final {
 
  private:
   client::HRN hrn_;
+  std::string layer_id_;
   std::shared_ptr<ApiRepository> apiRepo_;
   std::shared_ptr<CatalogRepository> catalogRepo_;
   std::shared_ptr<PartitionsRepository> partitionsRepo_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
@@ -43,13 +43,15 @@ class PartitionsCacheRepository final {
   ~PartitionsCacheRepository() = default;
 
   void Put(const PartitionsRequest& request,
-           const model::Partitions& partitions,
+           const model::Partitions& partitions, const std::string& layer_id,
            const boost::optional<time_t>& expiry, bool allLayer = false);
 
   model::Partitions Get(const PartitionsRequest& request,
-                        const std::vector<std::string>& partitionIds);
+                        const std::vector<std::string>& partitionIds,
+                        const std::string& layer_id);
 
-  boost::optional<model::Partitions> Get(const PartitionsRequest& request);
+  boost::optional<model::Partitions> Get(const PartitionsRequest& request,
+                                         const std::string& layer_id);
 
   void Put(int64_t catalogVersion, const model::LayerVersions& layerVersions);
 
@@ -58,8 +60,8 @@ class PartitionsCacheRepository final {
   void Clear(const std::string& layer_id);
 
   void ClearPartitions(const PartitionsRequest& request,
-                       const std::vector<std::string>& partitionIds);
-
+                       const std::vector<std::string>& partitionIds,
+                       const std::string& layer_id);
 
  private:
   client::HRN hrn_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
@@ -49,9 +49,10 @@ using LayerVersionReponse = ApiResponse<int64_t, client::ApiError>;
 using LayerVersionCallback = std::function<void(LayerVersionReponse)>;
 
 std::string GetKey(const PartitionsRequest& request,
-                   const std::vector<std::string>& partitions) {
+                   const std::vector<std::string>& partitions,
+                   const std::string& layer_id) {
   std::stringstream ss;
-  ss << request.GetLayerId();
+  ss << layer_id;
 
   ss << "[";
   bool first = true;
@@ -98,13 +99,14 @@ void GetLayerVersion(std::shared_ptr<CancellationContext> cancel_context,
                      const OlpClient& client, const PartitionsRequest& request,
                      const LayerVersionCallback& callback,
                      std::shared_ptr<PartitionsCacheRepository> cache,
-                     std::shared_ptr<ApiRepository> apiRepo) {
-  auto key = request.CreateKey();
+                     std::shared_ptr<ApiRepository> apiRepo,
+                     const std::string& layer_id) {
+  auto key = request.CreateKey(layer_id);
   auto layerVersionsCallback = [=](model::LayerVersions layerVersions) {
     auto& versionLayers = layerVersions.GetLayerVersions();
     auto itr = std::find_if(versionLayers.begin(), versionLayers.end(),
                             [&](const model::LayerVersion& layer) {
-                              return layer.GetLayer() == request.GetLayerId();
+                              return layer.GetLayer() == layer_id;
                             });
 
     if (itr != versionLayers.end()) {
@@ -155,7 +157,7 @@ void GetLayerVersion(std::shared_ptr<CancellationContext> cancel_context,
 }
 
 void appendPartitionsRequest(
-    const PartitionsRequest& request,
+    const PartitionsRequest& request, const std::string& layer_id,
     const std::shared_ptr<CatalogRepository>& catalogRepo,
     const std::shared_ptr<CancellationContext>& cancel_context,
     const std::function<void()>& cancel_callback,
@@ -179,7 +181,7 @@ void appendPartitionsRequest(
               auto itr =
                   std::find_if(catalogLayers.begin(), catalogLayers.end(),
                                [&](const model::Layer& layer) {
-                                 return layer.GetId() == request.GetLayerId();
+                                 return layer.GetId() == layer_id;
                                });
 
               if (itr == catalogLayers.end()) {
@@ -232,10 +234,12 @@ void appendPartitionsRequest(
 }  // namespace
 
 PartitionsRepository::PartitionsRepository(
-    const HRN& hrn, std::shared_ptr<ApiRepository> apiRepo,
+    const HRN& hrn, std::string layer_id,
+    std::shared_ptr<ApiRepository> apiRepo,
     std::shared_ptr<CatalogRepository> catalogRepo,
     std::shared_ptr<cache::KeyValueCache> cache)
     : hrn_(hrn),
+      layer_id_(std::move(layer_id)),
       apiRepo_(apiRepo),
       catalogRepo_(catalogRepo),
       cache_(std::make_shared<PartitionsCacheRepository>(hrn, cache)) {
@@ -387,8 +391,9 @@ CancellationToken PartitionsRepository::GetPartitionsById(
   auto apiRepo = apiRepo_;
   auto cache = cache_;
   auto cancel_context = std::make_shared<CancellationContext>();
+  auto layer_id = layer_id_;
 
-  auto requestKey = GetKey(request, partitions);
+  auto requestKey = GetKey(request, partitions, layer_id);
   OLP_SDK_LOG_TRACE_F(kLogTag, "GetPartitionsById '%s'", requestKey.c_str());
 
   auto cancel_callback = [callback, requestKey]() {
@@ -403,7 +408,8 @@ CancellationToken PartitionsRepository::GetPartitionsById(
           [=]() {
             /* Check the cache first */
             if (OnlineOnly != request.GetFetchOption()) {
-              auto cachedPartitions = cache->Get(appendedRequest, partitions);
+              auto cachedPartitions =
+                  cache->Get(appendedRequest, partitions, layer_id);
               // Only used cache if we have all requested ids.
               if (cachedPartitions.GetPartitions().size() ==
                   partitions.size()) {
@@ -430,14 +436,16 @@ CancellationToken PartitionsRepository::GetPartitionsById(
                   if (response.IsSuccessful()) {
                     OLP_SDK_LOG_INFO_F(kLogTag, "put '%s' to cache",
                                        requestKey.c_str());
-                    cache->Put(appendedRequest, response.GetResult(), expiry);
+                    cache->Put(appendedRequest, response.GetResult(), layer_id,
+                               expiry);
                   } else {
                     if (response.GetError().GetHttpStatusCode() ==
                         http::HttpStatusCode::FORBIDDEN) {
                       OLP_SDK_LOG_INFO_F(kLogTag, "clear '%s' cache",
                                          requestKey.c_str());
                       // Delete partitions only but not the layer
-                      cache->ClearPartitions(appendedRequest, partitions);
+                      cache->ClearPartitions(appendedRequest, partitions,
+                                             layer_id);
                     }
                   }
                   callback(response);
@@ -459,9 +467,9 @@ CancellationToken PartitionsRepository::GetPartitionsById(
                                            "getApiClient '%s' getting catalog",
                                            requestKey.c_str());
                         return QueryApi::GetPartitionsbyId(
-                            response.GetResult(), appendedRequest.GetLayerId(),
-                            partitions, appendedRequest.GetVersion(),
-                            boost::none, appendedRequest.GetBillingTag(),
+                            response.GetResult(), layer_id, partitions,
+                            appendedRequest.GetVersion(), boost::none,
+                            appendedRequest.GetBillingTag(),
                             cachePartitionsResponseCallback);
                       },
                       cancel_callback);
@@ -470,7 +478,7 @@ CancellationToken PartitionsRepository::GetPartitionsById(
           cancel_callback);
     };
 
-    appendPartitionsRequest(request, catalogRepo_, cancel_context,
+    appendPartitionsRequest(request, layer_id, catalogRepo_, cancel_context,
                             cancel_callback, callback, fetchPartitions);
 
     return CancellationToken(
@@ -507,7 +515,6 @@ PartitionsResponse PartitionsRepository::GetVolatilePartitions(
     client::HRN catalog, std::string layer,
     client::CancellationContext cancellation_context,
     read::PartitionsRequest request, client::OlpClientSettings settings) {
-  request.WithLayerId(layer);
   request.WithVersion(boost::none);
 
   CatalogRequest catalog_request;
@@ -545,14 +552,14 @@ PartitionsResponse PartitionsRepository::GetPartitions(
   repository::PartitionsCacheRepository repository(catalog, settings.cache);
 
   if (fetch_option != OnlineOnly) {
-    auto cached_partitions = repository.Get(request);
+    auto cached_partitions = repository.Get(request, layer);
     if (cached_partitions) {
       OLP_SDK_LOG_INFO_F(kLogTag, "cache data '%s' found!",
-                         request.CreateKey().c_str());
+                         request.CreateKey(layer).c_str());
       return cached_partitions.get();
     } else if (fetch_option == CacheOnly) {
       OLP_SDK_LOG_INFO_F(kLogTag, "cache catalog '%s' not found!",
-                         request.CreateKey().c_str());
+                         request.CreateKey(layer).c_str());
       return ApiError(ErrorCode::NotFound,
                       "Cache only resource not found in cache (partition).");
     }
@@ -610,13 +617,13 @@ PartitionsResponse PartitionsRepository::GetPartitions(
 
   if (metadata_response.IsSuccessful()) {
     OLP_SDK_LOG_INFO_F(kLogTag, "put '%s' to cache",
-                       request.CreateKey().c_str());
-    repository.Put(request, metadata_response.GetResult(), expiry, true);
+                       request.CreateKey(layer).c_str());
+    repository.Put(request, metadata_response.GetResult(), layer, expiry, true);
   } else {
     const auto& error = metadata_response.GetError();
     if (error.GetHttpStatusCode() == http::HttpStatusCode::FORBIDDEN) {
       OLP_SDK_LOG_INFO_F(kLogTag, "clear '%s' cache",
-                         request.CreateKey().c_str());
+                         request.CreateKey(layer).c_str());
       repository.Clear(layer);
     }
   }
@@ -640,21 +647,21 @@ QueryApi::PartitionsResponse PartitionsRepository::GetPartitionById(
 
   const std::vector<std::string> partitions{partition_id.value()};
   PartitionsRequest partition_request;
-  partition_request.WithLayerId(layer)
-      .WithBillingTag(data_request.GetBillingTag())
+  partition_request.WithBillingTag(data_request.GetBillingTag())
       .WithVersion(version);
 
   auto fetch_option = data_request.GetFetchOption();
 
   if (fetch_option != OnlineOnly) {
-    auto cached_partitions = repository.Get(partition_request, partitions);
+    auto cached_partitions =
+        repository.Get(partition_request, partitions, layer);
     if (cached_partitions.GetPartitions().size() == partitions.size()) {
       OLP_SDK_LOG_INFO_F(kLogTag, "cache data '%s' found!",
-                         data_request.CreateKey().c_str());
+                         data_request.CreateKey(layer).c_str());
       return cached_partitions;
     } else if (fetch_option == CacheOnly) {
       OLP_SDK_LOG_INFO_F(kLogTag, "cache catalog '%s' not found!",
-                         data_request.CreateKey().c_str());
+                         data_request.CreateKey(layer).c_str());
       return ApiError(ErrorCode::NotFound,
                       "Cache only resource not found in cache (partition).");
     }
@@ -717,16 +724,16 @@ QueryApi::PartitionsResponse PartitionsRepository::GetPartitionById(
 
   if (query_response.IsSuccessful()) {
     OLP_SDK_LOG_INFO_F(kLogTag, "put '%s' to cache",
-                       data_request.CreateKey().c_str());
-    repository.Put(partition_request, query_response.GetResult(),
+                       data_request.CreateKey(layer).c_str());
+    repository.Put(partition_request, query_response.GetResult(), layer,
                    boost::none /* TODO: expiration */);
   } else {
     const auto& error = query_response.GetError();
     if (error.GetHttpStatusCode() == http::HttpStatusCode::FORBIDDEN) {
       OLP_SDK_LOG_INFO_F(kLogTag, "clear '%s' cache",
-                         data_request.CreateKey().c_str());
+                         data_request.CreateKey(layer).c_str());
       // Delete partitions only but not the layer
-      repository.ClearPartitions(partition_request, partitions);
+      repository.ClearPartitions(partition_request, partitions, layer);
     }
   }
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -43,7 +43,7 @@ class PartitionsCacheRepository;
 
 class PartitionsRepository final {
  public:
-  PartitionsRepository(const client::HRN& hrn,
+  PartitionsRepository(const client::HRN& hrn, std::string layer_id,
                        std::shared_ptr<ApiRepository> apiRepo,
                        std::shared_ptr<CatalogRepository> catalogRepo,
                        std::shared_ptr<cache::KeyValueCache> cache_);
@@ -86,6 +86,7 @@ class PartitionsRepository final {
       boost::optional<time_t> expiry = boost::none);
 
   client::HRN hrn_;
+  std::string layer_id_;
   std::shared_ptr<ApiRepository> apiRepo_;
   std::shared_ptr<CatalogRepository> catalogRepo_;
   std::shared_ptr<PartitionsCacheRepository> cache_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
@@ -51,7 +51,8 @@ using SubTilesResponseCallback =
 class PrefetchTilesRepository final {
  public:
   PrefetchTilesRepository(
-      const client::HRN& hrn, std::shared_ptr<ApiRepository> apiRepo,
+      const client::HRN& hrn, std::string layer_id,
+      std::shared_ptr<ApiRepository> apiRepo,
       std::shared_ptr<PartitionsCacheRepository> partitionsCache,
       std::shared_ptr<olp::client::OlpClientSettings> settings);
 
@@ -83,7 +84,7 @@ class PrefetchTilesRepository final {
       PartitionsCacheRepository& partitionsCache,
       const PrefetchTilesRequest& prefetchRequest, geo::TileKey tile,
       int64_t version, boost::optional<time_t> expiry, int32_t depth,
-      const SubQuadsResponseCallback& callback);
+      const std::string& layer_id, const SubQuadsResponseCallback& callback);
 
  private:
   static SubQuadsRequest EffectiveTileKeys(const geo::TileKey& tilekey,
@@ -99,6 +100,7 @@ class PrefetchTilesRepository final {
 
  private:
   client::HRN hrn_;
+  std::string layer_id_;
   std::shared_ptr<ApiRepository> apiRepo_;
   std::shared_ptr<PartitionsCacheRepository> partitionsCache_;
   std::shared_ptr<olp::client::OlpClientSettings> settings_;


### PR DESCRIPTION
Pass layer_id in constructors of Repositories, or pass as argument from repositories. Pass layer_id as parameter for key generation and as explicit parameter in cache operations.
    
Relates-To: OLPEDGE-1015
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>