### PR TITLE
Remove deprecated CatalogClient::GetData

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogClient.h
@@ -129,37 +129,6 @@ class DATASERVICE_READ_API CatalogClient final {
   client::CancellableFuture<CatalogVersionResponse> GetCatalogMetadataVersion(
       CatalogVersionRequest request);
 
-  /**
-   * @brief fetches data for a partition or data handle asynchronously. If the
-   * specified partition or data handle cannot be found in the layer, the
-   * callback will be invoked with an empty DataResponse (nullptr for result and
-   * error). If neither Partition Id or Data Handle were set in the request, the
-   * callback will be invoked with an error with ErrorCode::InvalidRequest.
-   * @param request contains the complete set of request parameters.
-   * @param callback will be invoked once the DataResult is available, or an
-   * error is encountered.
-   * @return A token that can be used to cancel this request
-   * @deprecated Will be removed in 1.0
-   */
-  OLP_SDK_DEPRECATED("Will be removed in 1.0")
-  client::CancellationToken GetData(const DataRequest& request,
-                                    const DataResponseCallback& callback);
-
-  /**
-   * @brief fetches data for a partition or data handle asynchronously. If the
-   * specified partition or data handle cannot be found in the layer, an empty
-   * DataResponse (nullptr for result and error) will be returned. If neither
-   * Partition Id or Data Handle were set in the request, an error with code
-   * ErrorCode::InvalidRequest will be returned.
-   * @param request contains the complete set of request parameters.
-   * @return CancellableFuture of type DataResponse, which when complete will
-   * contain the data or an error. Alternatively, the CancellableFuture can be
-   * used to cancel this request.
-   * @deprecated Will be removed in 1.0
-   */
-  OLP_SDK_DEPRECATED("Will be removed in 1.0")
-  client::CancellableFuture<DataResponse> GetData(const DataRequest& request);
-
  private:
   std::shared_ptr<CatalogClientImpl> impl_;
 };

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClient.cpp
@@ -76,16 +76,6 @@ client::CancellableFuture<CatalogVersionResponse>
 CatalogClient::GetCatalogMetadataVersion(CatalogVersionRequest request) {
   return impl_->GetLatestVersion(std::move(request));
 }
-
-client::CancellationToken CatalogClient::GetData(
-    const DataRequest& request, const DataResponseCallback& callback) {
-  return impl_->GetData(request, callback);
-}
-
-client::CancellableFuture<DataResponse> CatalogClient::GetData(
-    const DataRequest& request) {
-  return impl_->GetData(request);
-}
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.h
@@ -67,18 +67,10 @@ class CatalogClientImpl final {
   client::CancellableFuture<CatalogVersionResponse> GetLatestVersion(
       CatalogVersionRequest request);
 
-  client::CancellationToken GetData(const DataRequest& request,
-                                    const DataResponseCallback& callback);
-
-  client::CancellableFuture<DataResponse> GetData(const DataRequest& request);
-
  private:
   client::HRN catalog_;
-  std::shared_ptr<client::OlpClientSettings> settings_;
+  client::OlpClientSettings settings_;
   std::shared_ptr<thread::TaskScheduler> task_scheduler_;
-  std::shared_ptr<repository::CatalogRepository> catalog_repo_;
-  std::shared_ptr<repository::PartitionsRepository> partition_repo_;
-  std::shared_ptr<repository::DataRepository> data_repo_;
   std::shared_ptr<client::PendingRequests> pending_requests_;
 
   template <typename Request, typename Response>


### PR DESCRIPTION
Remove deprecated method GetData from CatalogClient

Relates-To: OLPEDGE-984
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>