### PR TITLE
Add log on error when Autorefreshing token

### DIFF
--- a/tests/integration/olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
@@ -169,6 +169,45 @@ TEST_F(HereAccountOauth2Test, AutoRefreshingTokenCancelSync) {
       });
 }
 
+TEST_F(HereAccountOauth2Test, AutoRefreshingTokenBackendError) {
+  EXPECT_CALL(*network_, Send(_, _, _, _, _))
+      .WillOnce([&](olp::http::NetworkRequest request,
+                          olp::http::Network::Payload payload,
+                          olp::http::Network::Callback callback,
+                          olp::http::Network::HeaderCallback header_callback,
+                          olp::http::Network::DataCallback data_callback) {
+        olp::http::RequestId request_id(5);
+        if (payload) {
+          *payload << kResponseUnauthorized;
+        }
+        callback(olp::http::NetworkResponse()
+                     .WithRequestId(request_id)
+                     .WithStatus(olp::http::HttpStatusCode::UNAUTHORIZED)
+                     .WithError(kErrorOk));
+        if (data_callback) {
+          auto raw = const_cast<char*>(kResponseUnauthorized.c_str());
+          data_callback(reinterpret_cast<uint8_t*>(raw), 0,
+                        kResponseUnauthorized.size());
+        }
+
+        return olp::http::SendOutcome(request_id);
+      });
+
+  Settings settings({key_, secret_});
+  settings.network_request_handler = network_;
+  TokenEndpoint token_endpoint(settings);
+  olp::client::CancellationToken cancellationToken;
+
+  auto token = GetTokenFromSyncRequest(
+      cancellationToken, token_endpoint.RequestAutoRefreshingToken(),
+      kDefaultMinimumValiditySeconds);
+
+  EXPECT_TRUE(token.IsSuccessful());
+  EXPECT_NE(token.GetResult().GetErrorResponse().code, 0);
+  EXPECT_EQ(token.GetResult().GetHttpStatus(),
+            olp::http::HttpStatusCode::UNAUTHORIZED);
+}
+
 TEST_F(HereAccountOauth2Test, AutoRefreshingTokenCancelAsync) {
   EXPECT_CALL(*network_, Send(_, _, _, _, _))
       .Times(2)


### PR DESCRIPTION
Add check for for online error in AutoRefreshingToken. Add log for such
case with http status, error code and message. Add test.

Relates-To: OLPEDGE-1025
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>