### PR TITLE
Remove usage of deprecated GetLayerId

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/DataRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/DataRequest.h
@@ -42,38 +42,6 @@ namespace read {
 class DATASERVICE_READ_API DataRequest final {
  public:
   /**
-   * @brief GetLayerId gets the request's layer id.
-   * @return the layer id.
-   * @deprecated Will be removed in 1.0
-   */
-  OLP_SDK_DEPRECATED("Will be removed in 1.0")
-  inline const std::string& GetLayerId() const { return layer_id_; }
-
-  /**
-   * @brief WithLayerId sets the layer id of the request.
-   * @param layerId the layer the requested partitions belong to.
-   * @return a reference to the updated DataRequest.
-   * @deprecated Will be removed in 1.0
-   */
-  OLP_SDK_DEPRECATED("Will be removed in 1.0")
-  inline DataRequest& WithLayerId(const std::string& layerId) {
-    layer_id_ = layerId;
-    return *this;
-  }
-
-  /**
-   * @brief WithLayerId sets the layer id of the request.
-   * @param layerId the layer the requested partitions belong to.
-   * @return a reference to the updated DataRequest.
-   * @deprecated Will be removed in 1.0
-   */
-  OLP_SDK_DEPRECATED("Will be removed in 1.0")
-  inline DataRequest& WithLayerId(std::string&& layerId) {
-    layer_id_ = std::move(layerId);
-    return *this;
-  }
-
-  /**
    * @brief GetPartitionId gets the request's Partition Id.
    * @return the partition id.
    */
@@ -212,12 +180,12 @@ class DATASERVICE_READ_API DataRequest final {
 
   /**
    * @brief Creates readable format for the request.
-   * @param none
-   * @return string representation of the request
+   * @param layer_id Layer ID request is used for.
+   * @return string representation of the request.
    */
-  inline std::string CreateKey() const {
+  inline std::string CreateKey(const std::string& layer_id) const {
     std::stringstream out;
-    out << GetLayerId();
+    out << layer_id;
 
     out << "[";
 

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PartitionsRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PartitionsRequest.h
@@ -38,38 +38,6 @@ namespace read {
 class DATASERVICE_READ_API PartitionsRequest final {
  public:
   /**
-   * @brief GetLayerId gets the request's layer id.
-   * @return the layer id.
-   * @deprecated Will be removed in 1.0
-   */
-  OLP_SDK_DEPRECATED("Will be removed in 1.0")
-  inline const std::string& GetLayerId() const { return layer_id_; }
-
-  /**
-   * @brief WithLayerId sets the layer id of the request.
-   * @param layerId the layer the requested partitions belong to.
-   * @return a reference to the updated PartitionsRequest.
-   * @deprecated Will be removed in 1.0
-   */
-  OLP_SDK_DEPRECATED("Will be removed in 1.0")
-  inline PartitionsRequest& WithLayerId(const std::string& layerId) {
-    layer_id_ = layerId;
-    return *this;
-  }
-
-  /**
-   * @brief WithLayerId sets the layer id of the request.
-   * @param layerId the layer the requested partitions belong to.
-   * @return a reference to the updated PartitionsRequest.
-   * @deprecated Will be removed in 1.0
-   */
-  OLP_SDK_DEPRECATED("Will be removed in 1.0")
-  inline PartitionsRequest& WithLayerId(std::string&& layerId) {
-    layer_id_ = std::move(layerId);
-    return *this;
-  }
-
-  /**
    * @brief WithVersion sets the catalog metadata version of the request.
    * @param catalogMetadataVersion The catalog metadta version of the requested
    * partions. If no version is specified, the latest will be retrieved.
@@ -143,12 +111,12 @@ class DATASERVICE_READ_API PartitionsRequest final {
 
   /**
    * @brief Creates readable format for the request.
-   * @param none
-   * @return string representation of the request
+   * @param layer_id Layer ID request is used for.
+   * @return string representation of the request.
    */
-  std::string CreateKey() const {
+  std::string CreateKey(const std::string& layer_id) const {
     std::stringstream out;
-    out << GetLayerId();
+    out << layer_id;
 
     if (GetVersion()) {
       out << "@" << GetVersion().get();

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
@@ -44,38 +44,6 @@ namespace read {
 class DATASERVICE_READ_API PrefetchTilesRequest final {
  public:
   /**
-   * @brief GetLayerId gets the request's layer id.
-   * @return the layer id.
-   * @deprecated Will be removed in 1.0
-   */
-  OLP_SDK_DEPRECATED("Will be removed in 1.0")
-  inline const std::string& GetLayerId() const { return layer_id_; }
-
-  /**
-   * @brief WithLayerId sets the layer id of the request.
-   * @param layerId the layer id the requested tiles belong to.
-   * @return a reference to the updated PrefetchTilesRequest.
-   * @deprecated Will be removed in 1.0
-   */
-  OLP_SDK_DEPRECATED("Will be removed in 1.0")
-  inline PrefetchTilesRequest& WithLayerId(const std::string& layerId) {
-    layer_id_ = layerId;
-    return *this;
-  }
-
-  /**
-   * @brief WithLayerId sets the layer id of the request.
-   * @param layerId the layer id the requested tiles belong to.
-   * @return a reference to the updated PrefetchTilesRequest.
-   * @deprecated Will be removed in 1.0
-   */
-  OLP_SDK_DEPRECATED("Will be removed in 1.0")
-  inline PrefetchTilesRequest& WithLayerId(std::string&& layerId) {
-    layer_id_ = std::move(layerId);
-    return *this;
-  }
-
-  /**
    * @brief GetPartitionId gets the request's Partition Id.
    * @return the partition id.
    */
@@ -156,12 +124,12 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
 
   /**
    * @brief Creates readable format for the request.
-   * @param none
-   * @return string representation of the request
+   * @param layer_id Layer ID request is used for.
+   * @return string representation of the request.
    */
-  inline std::string CreateKey() const {
+  inline std::string CreateKey(const std::string& layer_id) const {
     std::stringstream out;
-    out << GetLayerId();
+    out << layer_id;
 
     out << "[" << GetMinLevel() << "/" << GetMaxLevel() << "]";
 

--- a/olp-cpp-sdk-dataservice-read/src/PrefetchTilesProvider.h
+++ b/olp-cpp-sdk-dataservice-read/src/PrefetchTilesProvider.h
@@ -41,7 +41,7 @@ class DataRepository;
 class PrefetchTilesProvider final {
  public:
   PrefetchTilesProvider(
-      const client::HRN& hrn,
+      const client::HRN& hrn, std::string layer_id,
       std::shared_ptr<repository::ApiRepository> apiRepo,
       std::shared_ptr<repository::CatalogRepository> catalogRepo,
       std::shared_ptr<repository::DataRepository> dataRepo,
@@ -81,6 +81,7 @@ class PrefetchTilesProvider final {
   std::shared_ptr<repository::DataRepository> dataRepo_;
   std::shared_ptr<repository::PrefetchTilesRepository> prefetchTilesRepo_;
   std::shared_ptr<olp::client::OlpClientSettings> settings_;
+  const std::string layer_id_;
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -61,17 +61,19 @@ VersionedLayerClientImpl::VersionedLayerClientImpl(
       catalog_, api_repo, settings_->cache);
 
   partition_repo_ = std::make_shared<repository::PartitionsRepository>(
-      catalog_, api_repo, catalog_repo, settings_->cache);
+      catalog_, layer_id_, api_repo, catalog_repo, settings_->cache);
 
   auto data_repo = std::make_shared<repository::DataRepository>(
-      catalog_, api_repo, catalog_repo, partition_repo_, settings_->cache);
+      catalog_, layer_id_, api_repo, catalog_repo, partition_repo_,
+      settings_->cache);
 
   auto prefetch_repo = std::make_shared<repository::PrefetchTilesRepository>(
-      catalog_, api_repo, partition_repo_->GetPartitionsCacheRepository(),
-      settings_);
+      catalog_, layer_id_, api_repo,
+      partition_repo_->GetPartitionsCacheRepository(), settings_);
 
   prefetch_provider_ = std::make_shared<PrefetchTilesProvider>(
-      catalog_, api_repo, catalog_repo, data_repo, prefetch_repo, settings_);
+      catalog_, layer_id_, api_repo, catalog_repo, data_repo, prefetch_repo,
+      settings_);
 }
 
 VersionedLayerClientImpl::~VersionedLayerClientImpl() {
@@ -80,7 +82,6 @@ VersionedLayerClientImpl::~VersionedLayerClientImpl() {
 
 client::CancellationToken VersionedLayerClientImpl::GetPartitions(
     PartitionsRequest request, PartitionsResponseCallback callback) {
-  request.WithLayerId(layer_id_);
   auto schedule_get_partitions = [&](PartitionsRequest request,
                                      PartitionsResponseCallback callback) {
     auto catalog = catalog_;
@@ -173,7 +174,6 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
     }
   };
 
-  request.WithLayerId(layer_id_);
   auto token = prefetch_provider_->PrefetchTiles(request, request_callback);
   pending_requests->Insert(token, request_key);
   return token;

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -64,7 +64,7 @@ VolatileLayerClientImpl::VolatileLayerClientImpl(
       catalog_, api_repo, cache);
 
   partition_repo_ = std::make_shared<repository::PartitionsRepository>(
-      catalog_, api_repo, catalog_repo, cache);
+      catalog_, layer_id_, api_repo, catalog_repo, cache);
 }
 
 VolatileLayerClientImpl::~VolatileLayerClientImpl() {

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
@@ -40,7 +40,8 @@ class DataCacheRepository;
 
 class DataRepository final {
  public:
-  DataRepository(const client::HRN& hrn, std::shared_ptr<ApiRepository> apiRepo,
+  DataRepository(const client::HRN& hrn, std::string layer_id,
+                 std::shared_ptr<ApiRepository> apiRepo,
                  std::shared_ptr<CatalogRepository> catalogRepo,
                  std::shared_ptr<PartitionsRepository> partitionsRepo,
                  std::shared_ptr<cache::KeyValueCache> cache);
@@ -76,6 +77,7 @@ class DataRepository final {
 
  private:
   client::HRN hrn_;
+  std::string layer_id_;
   std::shared_ptr<ApiRepository> apiRepo_;
   std::shared_ptr<CatalogRepository> catalogRepo_;
   std::shared_ptr<PartitionsRepository> partitionsRepo_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
@@ -43,13 +43,15 @@ class PartitionsCacheRepository final {
   ~PartitionsCacheRepository() = default;
 
   void Put(const PartitionsRequest& request,
-           const model::Partitions& partitions,
+           const model::Partitions& partitions, const std::string& layer_id,
            const boost::optional<time_t>& expiry, bool allLayer = false);
 
   model::Partitions Get(const PartitionsRequest& request,
-                        const std::vector<std::string>& partitionIds);
+                        const std::vector<std::string>& partitionIds,
+                        const std::string& layer_id);
 
-  boost::optional<model::Partitions> Get(const PartitionsRequest& request);
+  boost::optional<model::Partitions> Get(const PartitionsRequest& request,
+                                         const std::string& layer_id);
 
   void Put(int64_t catalogVersion, const model::LayerVersions& layerVersions);
 
@@ -58,8 +60,8 @@ class PartitionsCacheRepository final {
   void Clear(const std::string& layer_id);
 
   void ClearPartitions(const PartitionsRequest& request,
-                       const std::vector<std::string>& partitionIds);
-
+                       const std::vector<std::string>& partitionIds,
+                       const std::string& layer_id);
 
  private:
   client::HRN hrn_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -43,7 +43,7 @@ class PartitionsCacheRepository;
 
 class PartitionsRepository final {
  public:
-  PartitionsRepository(const client::HRN& hrn,
+  PartitionsRepository(const client::HRN& hrn, std::string layer_id,
                        std::shared_ptr<ApiRepository> apiRepo,
                        std::shared_ptr<CatalogRepository> catalogRepo,
                        std::shared_ptr<cache::KeyValueCache> cache_);
@@ -81,7 +81,8 @@ class PartitionsRepository final {
       read::PartitionsRequest request, client::OlpClientSettings settings,
       boost::optional<time_t> expiry = boost::none);
 
-  client::HRN hrn_;
+  const client::HRN hrn_;
+  const std::string layer_id_;
   std::shared_ptr<ApiRepository> apiRepo_;
   std::shared_ptr<CatalogRepository> catalogRepo_;
   std::shared_ptr<PartitionsCacheRepository> cache_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
@@ -51,7 +51,8 @@ using SubTilesResponseCallback =
 class PrefetchTilesRepository final {
  public:
   PrefetchTilesRepository(
-      const client::HRN& hrn, std::shared_ptr<ApiRepository> apiRepo,
+      const client::HRN& hrn, std::string layer_id,
+      std::shared_ptr<ApiRepository> apiRepo,
       std::shared_ptr<PartitionsCacheRepository> partitionsCache,
       std::shared_ptr<olp::client::OlpClientSettings> settings);
 
@@ -83,7 +84,7 @@ class PrefetchTilesRepository final {
       PartitionsCacheRepository& partitionsCache,
       const PrefetchTilesRequest& prefetchRequest, geo::TileKey tile,
       int64_t version, boost::optional<time_t> expiry, int32_t depth,
-      const SubQuadsResponseCallback& callback);
+      const std::string& layer_id, const SubQuadsResponseCallback& callback);
 
  private:
   static SubQuadsRequest EffectiveTileKeys(const geo::TileKey& tilekey,
@@ -99,6 +100,7 @@ class PrefetchTilesRepository final {
 
  private:
   client::HRN hrn_;
+  std::string layer_id_;
   std::shared_ptr<ApiRepository> apiRepo_;
   std::shared_ptr<PartitionsCacheRepository> partitionsCache_;
   std::shared_ptr<olp::client::OlpClientSettings> settings_;


### PR DESCRIPTION
Pass layer_id in constructors of Repositories, or pass as argument from
repositories. Pass layer_id as parameter for key generation and as
explicit parameter in cache operations.

Relates-To: OLPEDGE-984
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>