### PR TITLE
Fixed test CancelPendingRequestsCatalog

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/PendingRequests.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/PendingRequests.h
@@ -40,10 +40,18 @@ class PendingRequests final {
   ~PendingRequests();
 
   /**
-   * @brief Cancels all pending requests.
+   * @brief Cancels all pending tasks
+   * @note This call does not wait for the tasks to finalize, use
+   * CancelAllAndWait() to also wait for the tasks to finalize..
    * @return True on success
    */
-  bool CancelPendingRequests();
+  bool CancelAll();
+  
+  /**
+   * @brief Cancels all pending tasks and waits for all beeing finalized.
+   * @return True on success
+   */
+  bool CancelAllAndWait();
 
   /**
    * @brief Generates a placehoder for request cancellation token and returns a
@@ -82,11 +90,15 @@ class PendingRequests final {
 
  private:
   int64_t key_ = 0;
-  std::unordered_map<int64_t, client::CancellationToken> requests_map_;
-  std::unordered_set<client::TaskContext, client::TaskContextHash>
-      task_contexts_;
+  using RequestMap = std::unordered_map<int64_t, client::CancellationToken>;
+  using ContextMap =
+      std::unordered_set<client::TaskContext, client::TaskContextHash>;
+  RequestMap requests_map_;
+  ContextMap task_contexts_;
+
   std::mutex requests_lock_;
 };
 
 }  // namespace client
 }  // namespace olp
+

--- a/olp-cpp-sdk-core/include/olp/core/client/TaskContext.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/TaskContext.h
@@ -143,7 +143,9 @@ class TaskContext {
         auto response = function(context_);
         // Cancel could occur during function execution, in that case we ignore
         // the response.
-        if (!context_.IsCancelled()) {
+        if (!context_.IsCancelled() ||
+            (!response.IsSuccessful() &&
+             response.GetError().GetErrorCode() == ErrorCode::RequestTimeout)) {
           user_response = std::move(response);
         }
       }
@@ -163,7 +165,9 @@ class TaskContext {
       }
 
       // Cancel operation and wait for notification
-      context_.CancelOperation();
+      if (!context_.IsCancelled()) {
+        context_.CancelOperation();
+      }
 
       {
         std::lock_guard<std::mutex> lock(mutex_);

--- a/olp-cpp-sdk-core/tests/client/PendingRequestsTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/PendingRequestsTest.cpp
@@ -36,13 +36,13 @@ TEST(PendingRequestsTest, RemoveMissingKeyWillFail) {
   EXPECT_FALSE(pending_request.Remove(0));
 }
 
-TEST(PendingRequestsTest, CancelAllPendingRequest) {
+TEST(PendingRequestsTest, CancelAll) {
   PendingRequests pending_request;
   auto key = pending_request.GenerateRequestPlaceholder();
   bool cancelled = false;
   auto token = olp::client::CancellationToken([&]() { cancelled = true; });
   EXPECT_TRUE(pending_request.Insert(token, key));
-  EXPECT_TRUE(pending_request.CancelPendingRequests());
+  EXPECT_TRUE(pending_request.CancelAll());
   EXPECT_TRUE(cancelled);
 }
 

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
@@ -23,6 +23,7 @@
 #include <olp/core/client/OlpClientSettingsFactory.h>
 #include <olp/core/client/PendingRequests.h>
 #include <olp/core/logging/Log.h>
+
 #include "Common.h"
 #include "PrefetchTilesProvider.h"
 #include "repositories/ApiRepository.h"
@@ -55,11 +56,13 @@ CatalogClientImpl::CatalogClientImpl(HRN catalog, OlpClientSettings settings)
   pending_requests_ = std::make_shared<client::PendingRequests>();
 }
 
-CatalogClientImpl::~CatalogClientImpl() { CancelPendingRequests(); }
+CatalogClientImpl::~CatalogClientImpl() {
+  pending_requests_->CancelAllAndWait();
+}
 
 bool CatalogClientImpl::CancelPendingRequests() {
   OLP_SDK_LOG_TRACE(kLogTag, "CancelPendingRequests");
-  return pending_requests_->CancelPendingRequests();
+  return pending_requests_->CancelAll();
 }
 
 CancellationToken CatalogClientImpl::GetCatalog(

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -75,7 +75,7 @@ VersionedLayerClientImpl::VersionedLayerClientImpl(
 }
 
 VersionedLayerClientImpl::~VersionedLayerClientImpl() {
-  pending_requests_->CancelPendingRequests();
+  pending_requests_->CancelAllAndWait();
 }
 
 client::CancellationToken VersionedLayerClientImpl::GetPartitions(

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -68,7 +68,7 @@ VolatileLayerClientImpl::VolatileLayerClientImpl(
 }
 
 VolatileLayerClientImpl::~VolatileLayerClientImpl() {
-  pending_requests_->CancelPendingRequests();
+  pending_requests_->CancelAllAndWait();
 }
 
 client::CancellationToken VolatileLayerClientImpl::GetPartitions(


### PR DESCRIPTION
Made PendingRequests::CancelPendingRequests() to first cancel all requests then check for completion
Now ErrorCode::RequestTimeout is propagated properly to user

Resolves: OLPEDGE-678

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>