### PR TITLE
Add CURLOPT_NOSIGNAL options to Curl easy handles

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -286,7 +286,7 @@ endif()
 if(CURL_FOUND)
     include(CheckIncludeFile)
     check_include_file(signal.h HAVE_SIGNAL_H)
-    if(HAVE_SIGNAL_H AND Thread_FOUND)
+    if(HAVE_SIGNAL_H)
         target_compile_definitions(${PROJECT_NAME}
             PRIVATE HAVE_SIGNAL_H IGNORE_SIGPIPE)
     endif()

--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
@@ -34,6 +34,10 @@
 
 #include <curl/curl.h>
 
+#if defined(HAVE_SIGNAL_H)
+#include <signal.h>
+#endif
+
 #ifdef NETWORK_HAS_OPENSSL
 #include <openssl/crypto.h>
 #endif
@@ -101,6 +105,35 @@ std::string CaBundlePath() {
   return bundle_path;
 }
 #endif
+
+#if defined(IGNORE_SIGPIPE)
+
+// Block SIGPIPE signals for the current thread and all threads it creates.
+int BlockSigpipe() {
+  sigset_t sigset;
+  int err;
+
+  if (0 != (err = sigemptyset(&sigset))) {
+    return err;
+  }
+
+  if (0 != (err = sigaddset(&sigset, SIGPIPE))) {
+    return err;
+  }
+
+  err = pthread_sigmask(SIG_BLOCK, &sigset, NULL);
+
+  return err;
+}
+
+// Curl7.35+OpenSSL can write into closed sockets sometimes which results
+// in the process being terminated with SIGPIPE on Linux. Here's
+// a workaround for that bug. It block SIGPIPE for the startup thread and
+// hence for all other threads in the application. The variable itself is
+// not used but can be examined.
+int BlockSigpipeResult = BlockSigpipe();
+
+#endif  // IGNORE_SIGPIPE
 
 // To avoid static_cast and possible values changes in CURL
 curl_proxytype ToCurlProxyType(olp::http::NetworkProxySettings::Type type) {
@@ -256,6 +289,7 @@ bool NetworkCurl::Initialize() {
   for (int i = 0; i < handles_.size(); ++i) {
     if (i < static_handle_count_) {
       handles_[i].handle = curl_easy_init();
+      curl_easy_setopt(handles_[i].handle, CURLOPT_NOSIGNAL, 1);
     } else {
       handles_[i].handle = nullptr;
     }
@@ -626,6 +660,7 @@ NetworkCurl::RequestHandle* NetworkCurl::GetHandle(
           OLP_SDK_LOG_ERROR(kLogTag, "curl_easy_init returns nullptr");
           return nullptr;
         }
+        curl_easy_setopt(handle.handle, CURLOPT_NOSIGNAL, 1);
       }
       handle.in_use = true;
       handle.callback = callback;
@@ -1000,8 +1035,8 @@ void NetworkCurl::Run() {
                       .WithError("CURL error");
               handles_[handle_index].callback(response);
               lock.lock();
-              curl_multi_remove_handle(curl_, handles_[handle_index].handle);
             }
+            curl_multi_remove_handle(curl_, handles_[handle_index].handle);
           } else {
             OLP_SDK_LOG_ERROR(
                 kLogTag,


### PR DESCRIPTION
Curl may raise SIGPIPE in few situations. Add option for curl to not
use any signal logic. Add signal mask to ignore situation, where SIGPIPE
may be raised as result of write in closed socket. Remove check for
Threads on cmake, as Threads are required.

Relates-To: OLPSUP-8508
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>