### PR TITLE
Small changes needed for VersionedLayerClient::PrefetchTiles.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/ApiResponse.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/ApiResponse.h
@@ -45,9 +45,9 @@ class ApiResponse {
   ApiResponse() = default;
 
   /**
-   * @brief ApiResponse Constructor for a successfully executed request.
+   * @brief ApiResponse Constructor for moving a successfully executed request.
    */
-  ApiResponse(const ResultType& result) : result_(result), success_(true) {}
+  ApiResponse(ResultType result) : result_(std::move(result)), success_(true) {}
 
   /**
    * @brief ApiResponse Constructor if request unsuccessfully executed
@@ -83,7 +83,7 @@ class ApiResponse {
  private:
   ResultType result_{};
   ErrorType error_{};
-  bool success_ {false};
+  bool success_{false};
 };
 
 template <typename T>

--- a/olp-cpp-sdk-core/include/olp/core/client/CancellationContext.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/CancellationContext.h
@@ -50,9 +50,11 @@ class CORE_API CancellationContext {
    * CancellationContext will propogate a cancel request to.
    * @param cancel_fn A function which will be called if this operation is
    * already cancelled.
+   * @return true in case of successfull execution, false in case context was
+   * cancelled.
    * @deprecated Will be removed once TaskScheduler will be used.
    */
-  void ExecuteOrCancelled(const ExecuteFuncType& execute_fn,
+  bool ExecuteOrCancelled(const ExecuteFuncType& execute_fn,
                           const CancelFuncType& cancel_fn = nullptr);
 
   /**

--- a/olp-cpp-sdk-core/include/olp/core/client/CancellationContext.inl
+++ b/olp-cpp-sdk-core/include/olp/core/client/CancellationContext.inl
@@ -25,11 +25,11 @@ namespace client {
 inline CancellationContext::CancellationContext()
     : impl_(std::make_shared<CancellationContextImpl>()) {}
 
-inline void CancellationContext::ExecuteOrCancelled(
+inline bool CancellationContext::ExecuteOrCancelled(
     const std::function<CancellationToken()>& execute_fn,
     const std::function<void()>& cancel_fn) {
   if (!impl_) {
-    return;
+    return true;
   }
 
   std::lock_guard<std::recursive_mutex> lock(impl_->mutex_);
@@ -38,12 +38,14 @@ inline void CancellationContext::ExecuteOrCancelled(
     if (cancel_fn) {
       cancel_fn();
     }
-    return;
+    return false;
   }
 
   if (execute_fn) {
     impl_->sub_operation_cancel_token_ = execute_fn();
   }
+
+  return true;
 }
 
 inline void CancellationContext::CancelOperation() {

--- a/olp-cpp-sdk-core/tests/client/TaskContextTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/TaskContextTest.cpp
@@ -38,19 +38,23 @@ class TaskContextTestable : public TaskContext {
   std::function<void(void)> notify;
 
   template <typename Exec, typename Callback>
-  static TaskContextTestable Create(Exec execute_func, Callback callback) {
-    TaskContextTestable context;
-    context.SetExecutors(std::move(execute_func), std::move(callback));
-    return context;
+  static TaskContextTestable Create(
+      Exec execute_func, Callback callback,
+      CancellationContext context = CancellationContext()) {
+    TaskContextTestable task;
+    task.SetExecutors(std::move(execute_func), std::move(callback),
+                      std::move(context));
+    return task;
   }
 
   template <typename Exec, typename Callback,
             typename ExecResult = typename std::result_of<
                 Exec(olp::client::CancellationContext)>::type>
-  void SetExecutors(Exec execute_func, Callback callback) {
+  void SetExecutors(Exec execute_func, Callback callback,
+                    CancellationContext context) {
     auto impl =
         std::make_shared<TaskContextImpl<typename ExecResult::ResultType>>(
-            std::move(execute_func), std::move(callback));
+            std::move(execute_func), std::move(callback), std::move(context));
     notify = [=]() { impl->condition_.Notify(); };
     impl_ = impl;
   }


### PR DESCRIPTION
Allows injecting CancellationContext into TaskContext so that we can
share a single CancellationContext for multiple tasks. This is mandatory
for the PrefetchTiles where one CancellationToken, resp. CancellationContext,
is handed over to the caller and should be able to cancelled all scheduled
tasks.
Changes ApiResponse from const reference on the ResultType to by copy passing
so that we can move effectively OLP responses.
Modifies CancellationContext::ExecuteOrCancelled() to return bool denoting
if operation was successfully executed or cancelled.

Relates-to: OLPEDGE-1005

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>