### PR TITLE
Add network wrapper for performance test

### DIFF
--- a/tests/performance/CMakeLists.txt
+++ b/tests/performance/CMakeLists.txt
@@ -23,6 +23,7 @@ endif()
 set(OLP_SDK_PERFORMANCE_TESTS_SOURCES
     ./MemoryTest.cpp
     ./NullCache.h
+    ./NetworkWrapper.h
 )
 
 add_executable(olp-cpp-sdk-performance-tests ${OLP_SDK_PERFORMANCE_TESTS_SOURCES})

--- a/tests/performance/MemoryTest.cpp
+++ b/tests/performance/MemoryTest.cpp
@@ -32,6 +32,7 @@
 #include <olp/dataservice/read/VersionedLayerClient.h>
 #include <testutils/CustomParameters.hpp>
 
+#include "NetworkWrapper.h"
 #include "NullCache.h"
 
 namespace {
@@ -62,8 +63,7 @@ const std::string kVersionedLayerId("versioned_test_layer");
 class MemoryTest : public ::testing::TestWithParam<TestConfiguration> {
  public:
   static void SetUpTestSuite() {
-    s_network = olp::client::OlpClientSettingsFactory::
-        CreateDefaultNetworkRequestHandler();
+    s_network = std::make_shared<olp::tests::http::Http2HttpNetworkWrapper>();
   }
   static void TearDownTestSuite() { s_network.reset(); }
 

--- a/tests/performance/NetworkWrapper.h
+++ b/tests/performance/NetworkWrapper.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <olp/core/http/Network.h>
+
+namespace olp {
+namespace tests {
+namespace http {
+
+using namespace olp::http;
+
+/*
+ * Node test server is limited to http proxy. Wrapper alters ongoing requests
+ * from https to http.
+ */
+class Http2HttpNetworkWrapper : public Network {
+ public:
+  SendOutcome Send(NetworkRequest request, Payload payload, Callback callback,
+                   HeaderCallback header_callback = nullptr,
+                   DataCallback data_callback = nullptr) override {
+    auto url = request.GetUrl();
+    auto pos = url.find("https");
+    if (pos != std::string::npos) {
+      url.replace(pos, 5, "http");
+      request.WithUrl(url);
+    }
+
+    return network_->Send(std::move(request), std::move(payload),
+                          std::move(callback), std::move(header_callback),
+                          std::move(data_callback));
+  }
+
+  void Cancel(RequestId id) override { network_->Cancel(id); }
+
+  Http2HttpNetworkWrapper()
+      : network_{std::move(olp::http::CreateDefaultNetwork(32))} {}
+
+ private:
+  std::shared_ptr<Network> network_;
+};
+}  // namespace http
+}  // namespace tests
+}  // namespace olp


### PR DESCRIPTION
Node server s limited to http, and to run performance tests code should
be modified accordingly. Wrapper alter ongoing requests to use http.

Relates-To: OLPEDGE-1050
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>