### PR TITLE
Add CancelPendingRequests in VersionedLayerClient

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -107,6 +107,12 @@ class DATASERVICE_READ_API VersionedLayerClient final {
   ~VersionedLayerClient();
 
   /**
+   * @brief Cancels all active and pending requests.
+   * @return True on success.
+   */
+  bool CancelPendingRequests();
+
+  /**
    * @brief Fetches data for a partition ID or data handle asynchronously.
    *
    * If the specified partition ID or data handle cannot be found in the layer,

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
@@ -40,6 +40,10 @@ VersionedLayerClient& VersionedLayerClient::operator=(
 
 VersionedLayerClient::~VersionedLayerClient() = default;
 
+bool VersionedLayerClient::CancelPendingRequests() {
+  return impl_->CancelPendingRequests();
+}
+
 client::CancellationToken VersionedLayerClient::GetData(
     DataRequest data_request, DataResponseCallback callback) {
   return impl_->GetData(std::move(data_request), std::move(callback));

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -39,6 +39,10 @@ namespace olp {
 namespace dataservice {
 namespace read {
 
+namespace {
+constexpr auto kLogTag = "VersionedLayerClientImpl";
+}  // namespace
+
 VersionedLayerClientImpl::VersionedLayerClientImpl(
     client::HRN catalog, std::string layer_id,
     client::OlpClientSettings settings)
@@ -78,6 +82,11 @@ VersionedLayerClientImpl::VersionedLayerClientImpl(
 
 VersionedLayerClientImpl::~VersionedLayerClientImpl() {
   pending_requests_->CancelAllAndWait();
+}
+
+bool VersionedLayerClientImpl::CancelPendingRequests() {
+  OLP_SDK_LOG_TRACE(kLogTag, "CancelPendingRequests");
+  return pending_requests_->CancelAll();
 }
 
 client::CancellationToken VersionedLayerClientImpl::GetPartitions(

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -51,6 +51,8 @@ class VersionedLayerClientImpl {
 
   virtual ~VersionedLayerClientImpl();
 
+  virtual bool CancelPendingRequests();
+
   virtual client::CancellationToken GetData(DataRequest data_request,
                                             DataResponseCallback callback);
 


### PR DESCRIPTION
Add Add CancelPendingRequests in VersionedLayerClient and provide it
implementation. Enable test DataserviceReadVersionedLayerClientTest.CancelPendingRequestsPartitions.

Resolves: OLPEDGE-1093