### PR TITLE
Fix a crash in WinHttp client

### DIFF
--- a/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.cpp
+++ b/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.cpp
@@ -903,8 +903,10 @@ void NetworkWinHttp::CompletionThread() {
       if (result->completed) {
         std::unique_lock<std::recursive_mutex> lock(mutex_);
         auto request = FindHandle(result->request_id);
-        WinHttpCloseHandle(request->http_request);
-        request->http_request = NULL;
+        if (request) {
+          WinHttpCloseHandle(request->http_request);
+          request->http_request = NULL;
+        }
       }
     }
 


### PR DESCRIPTION
The crash happens when the request is canceled in the middle, and the handle is already reset.

Resolves: OLPEDGE-1098

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>