### PR TITLE
Add reference to installation process in GettingStarted.md

### DIFF
--- a/docs/GettingStartedGuide.md
+++ b/docs/GettingStartedGuide.md
@@ -28,7 +28,7 @@ The HERE OLP SDK for C++ is composed of separate libraries with their own distin
 
 ## HERE OLP SDK for C++ in CMake Projects
 
-Once the libraries are installed, you can find them using `find_package()` within your project:
+Once the libraries are installed, you can find them using the `find_package()` function within your project. For more information on how to install libraries, see [the related section](../README.md#Install) in the README.md file.
 
 ```CMake
 find_package(olp-cpp-sdk-core REQUIRED)


### PR DESCRIPTION
Installation details should be taken into account when integrating
SDK into a project, to reflect that add reference to readme, where
installation process is described.

Relates-To: OLPEDGE-1080

Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>