### PR TITLE
Add errors and timeouts to mock server

### DIFF
--- a/tests/performance/MemoryTest.cpp
+++ b/tests/performance/MemoryTest.cpp
@@ -97,7 +97,10 @@ class MemoryTest : public ::testing::TestWithParam<TestConfiguration> {
 std::shared_ptr<olp::http::Network> MemoryTest::s_network;
 
 void MemoryTest::SetUpTestSuite() {
-  s_network = std::make_shared<olp::tests::http::Http2HttpNetworkWrapper>();
+  auto network = std::make_shared<olp::tests::http::Http2HttpNetworkWrapper>();
+  network->EnableErrors(true);
+  network->EnableTimeouts(true);
+  s_network = std::move(network);
 }
 
 void MemoryTest::TearDownTestSuite() { s_network.reset(); }

--- a/tests/utils/olp_server/errors_generator.js
+++ b/tests/utils/olp_server/errors_generator.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+function generateErrorAtRandom() {
+  const errorList = [
+    {
+      status: 403,
+      text: JSON.stringify(
+        '{"error":"Forbidden","error_description":"These credentials do not authorize access"}'),
+      headers: { 'Content-Type': 'application/json' }
+    },
+    {
+      status: 404,
+      text: JSON.stringify(
+        '{"error":"Resource not Found","error_description":"Requested resource not found"}'),
+      headers: { 'Content-Type': 'application/json' }
+    },
+    {
+      status: 401,
+      text: JSON.stringify(
+        '{"errorId":"ERROR-3aaaa33b-3fb6-41cc-a238-7ff97c17bca7","httpStatus":401,"errorCode":401202,"message":"Invalid Client Authorization header, expecting signed request format."}'),
+      headers: { 'Content-Type': 'application/json' }
+    },
+    {
+      status: 404,
+      text: JSON.stringify(
+        '{"title":"Not Found","detail":[{"name":"other","error":"API not found blob/v10"}],"status":404}'),
+      headers: { 'Content-Type': 'application/json' }
+    },
+    {
+      status: 500,
+      text: JSON.stringify('{"title":"Internal Server Error","status":500}'),
+      headers: { 'Content-Type': 'application/json' }
+    }
+  ];
+
+  const index = Math.floor(Math.random() * errorList.length);
+  return errorList[index];
+}
+
+exports.handler = generateErrorAtRandom

--- a/tests/utils/olp_server/server.js
+++ b/tests/utils/olp_server/server.js
@@ -26,14 +26,42 @@ const config_service_handler = require('./config_service.js')
 const metadata_service_handler = require('./metadata_service.js')
 const query_service_handler = require('./query_service.js')
 const blob_service_handler = require('./blob_service.js')
+const errors_generator = require('./errors_generator.js')
 
 const port = 3000
 
-const sleep = (milliseconds) => {
-    return new Promise(resolve => setTimeout(resolve, milliseconds))
+function sleep(milliseconds) {
+  var waitTill = new Date(new Date().getTime() + milliseconds);
+  while (waitTill > new Date()) {
+  }
 }
 
-const handlers = {}
+function handleRequest(response, pathname, request, handler) {
+  const result = handler(pathname, request)
+  response.writeHead(result.status, result.headers)
+  response.end(result.text)
+}
+
+function errorsDecorator(processor) {
+  return function (response, pathname, request, handler) {
+    if (Math.floor(Math.random() * 100) > 10) {
+      processor(response, pathname, request, handler);
+    } else {
+      processor(response, pathname, request, errors_generator.handler);
+    }
+  }
+}
+
+function timeoutDecorator(processor) {
+  return function (response, pathname, request, handler) {
+    milliseconds = Math.floor(Math.random() * 250);
+    console.log('Waiting for ' + milliseconds + 'ms');
+    sleep(milliseconds);
+    processor(response, pathname, request, handler);
+  }
+}
+
+const handlers = {};
 handlers[services.lookup] = lookup_service_handler.handler
 handlers[services.config] = config_service_handler.handler
 handlers[services.metadata] = metadata_service_handler.handler
@@ -42,54 +70,64 @@ handlers[services.blob] = blob_service_handler.handler
 
 const requestHandler = async (request, response) => {
 
-    request.on('error', (err) => {
-        console.error(err);
-        response.writeHead(400, {}).end();
-    });
-    response.on('error', (err) => {
-        console.error(err);
-    });
+  request.on('error', (err) => {
+    console.error(err);
+    response.writeHead(400, {}).end();
+  });
+  response.on('error', (err) => {
+    console.error(err);
+  });
 
-    const { headers, method, url } = request;
-    
-    // Currently we support only read operations
-    if (method != 'GET') {
-        response.writeHead(404, {})
-        response.end('Not Found')
-        return
-    }
-    
-    // For debug purpose
-    console.log(url)
-    
-    const { host, query, pathname } = URL.parse(url, true)
-    
-    const handler = handlers[host]
-    if (handler) {
-        const result = handler(pathname, query)
-        response.writeHead(result.status, result.headers)
-        response.end(result.text)
-        return
-    }
-    
-    response.writeHead(400, {})
-    response.end('Not implemented')
+  const { headers, method, url } = request;
+
+  // Currently we support only read operations
+  if (method != 'GET') {
+    response.writeHead(404, {})
+    response.end('Not Found')
+    return
+  }
+
+  // For debug purpose
+  console.log(url)
+
+  processor = handleRequest
+
+  if (headers['debug-with-errors']) {
+    console.log('This one will be decorated with errors')
+    processor = errorsDecorator(processor)
+  }
+
+  if (headers['debug-with-timeouts']) {
+    console.log('This one will be decorated with timeouts')
+    processor = timeoutDecorator(processor)
+  }
+
+  const { host, query, pathname } = URL.parse(url, true)
+
+  const handler = handlers[host]
+  if (handler) {
+    processor(response, pathname, query, handler)
+    return
+  }
+
+  response.writeHead(400, {})
+  response.end('Not implemented')
 }
 
 const server = http.createServer(requestHandler)
 
 server.listen(port, (err) => {
-    if (err) {
-        return console.log('something bad happened', err)
-    }
+  if (err) {
+    return console.log('something bad happened', err)
+  }
 
-    console.log(`server is listening on ${port}`)
+  console.log(`server is listening on ${port}`)
 })
 
 // Handle termination by Travis
 process.on('SIGTERM', function () {
-    server.close(function () {
-        console.log(`Graceful shutdown`)
-        process.exit(0);
-    });
+  server.close(function () {
+    console.log(`Graceful shutdown`)
+    process.exit(0);
+  });
 });


### PR DESCRIPTION
Add emulation of errors and timeouts for mock server. This behavior is
controlled by 'debug' header in http requests. Network wrapper for
performance test implements interface to set this header.

Relates-To: OLPEDGE-1115