### PR TITLE
Add timeout in performance test and add log on timeout error

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.cpp
@@ -199,6 +199,9 @@ ApiClientLookup::ApiClientResponse ApiClientLookup::LookupApi(
 
   if (!condition.Wait(std::chrono::seconds(settings.retry_settings.timeout))) {
     cancellation_context.CancelOperation();
+    OLP_SDK_LOG_INFO_F(kLogTag, "LookupApi(%s/%s): %s - timeout",
+                       service.c_str(), service_version.c_str(),
+                       catalog.partition.c_str());
     return client::ApiError(client::ErrorCode::RequestTimeout,
                             "Network request timed out.");
   }

--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.cpp
@@ -217,6 +217,7 @@ read::CatalogResponse CatalogRepository::GetCatalog(
 
   if (!condition.Wait(std::chrono::seconds{timeout})) {
     cancellation_context.CancelOperation();
+    OLP_SDK_LOG_INFO_F(kLogTag, "timeout");
     return ApiError(ErrorCode::RequestTimeout, "Network request timed out.");
   }
 
@@ -393,6 +394,7 @@ MetadataApi::CatalogVersionResponse CatalogRepository::GetLatestVersion(
 
   if (!condition.Wait(std::chrono::seconds{timeout})) {
     cancellation_context.CancelOperation();
+    OLP_SDK_LOG_INFO_F(kLogTag, "timeout");
     return ApiError(ErrorCode::RequestTimeout, "Network request timed out.");
   }
   interest_flag->store(false);

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
@@ -461,6 +461,7 @@ DataResponse DataRepository::GetBlobData(
     // We are just about exit the execution.
 
     cancellation_context.CancelOperation();
+    OLP_SDK_LOG_INFO_F(kLogTag, "timeout");
     return ApiError(ErrorCode::RequestTimeout, "Network request timed out.");
   }
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
@@ -470,6 +470,7 @@ PartitionsResponse PartitionsRepository::GetPartitions(
 
   if (!condition.Wait(timeout)) {
     cancellation_context.CancelOperation();
+    OLP_SDK_LOG_INFO_F(kLogTag, "timeout");
     return client::ApiError(client::ErrorCode::RequestTimeout,
                             "Network request timed out.");
   }
@@ -577,6 +578,7 @@ QueryApi::PartitionsResponse PartitionsRepository::GetPartitionById(
 
   if (!condition.Wait(timeout)) {
     cancellation_context.CancelOperation();
+    OLP_SDK_LOG_INFO_F(kLogTag, "timeout");
     return client::ApiError(client::ErrorCode::RequestTimeout,
                             "Network request timed out.");
   }

--- a/tests/performance/MemoryTest.cpp
+++ b/tests/performance/MemoryTest.cpp
@@ -133,6 +133,7 @@ olp::client::OlpClientSettings MemoryTest::CreateCatalogClientSettings() {
   client_settings.network_request_handler = s_network;
   client_settings.proxy_settings = GetLocalhostProxySettings();
   client_settings.cache = parameter.cache_factory();
+  client_settings.retry_settings.timeout = 1;
 
   return client_settings;
 }


### PR DESCRIPTION
Add 1 second timeout in performance test. Add log when wait on condition
is timeouted.

Relates-To: OLPEDGE-1133
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>