### PR TITLE
Add fix to retry mechanism for NV/FV online tests.

### DIFF
--- a/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test.sh
+++ b/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test.sh
@@ -34,23 +34,22 @@ do
         set -e
 done
 
+result=0
 echo ">>> Functional Test ... >>>"
 source $FV_HOME/olp-cpp-sdk-functional-test.variables
 $REPO_HOME/build/tests/functional/olp-cpp-sdk-functional-tests \
     --gtest_output="xml:$REPO_HOME/reports/olp-functional-test-report.xml" \
-    --gtest_filter="-ArcGisAuthenticationTest.SignInArcGis":"FacebookAuthenticationTest.SignInFacebook"
+    --gtest_filter="-ArcGisAuthenticationTest.SignInArcGis":"FacebookAuthenticationTest.SignInFacebook" || result=1
 
 # Add retry to functional/online tests. Some online tests are flaky due to third party reason.
-result=$?
+echo "Last return code in $result"
 count=0
 while [[ ${result} -ne 0 ]];
 do
-    count=count+1
-    echo "This is ${count} time retry ..."
+    count=$((count+1)) && echo "This is ${count} time retry ..."
     $REPO_HOME/build/tests/functional/olp-cpp-sdk-functional-tests \
         --gtest_output="xml:$REPO_HOME/reports/olp-functional-test-report.xml" \
-        --gtest_filter="-ArcGisAuthenticationTest.SignInArcGis":"FacebookAuthenticationTest.SignInFacebook"
-    result=$?
+        --gtest_filter="-ArcGisAuthenticationTest.SignInArcGis":"FacebookAuthenticationTest.SignInFacebook" || result=1
 
     # Stop after 3 retry
     if [[ ${count} = 3 ]]; then

--- a/scripts/linux/nv/gitlab_test_valgrind.sh
+++ b/scripts/linux/nv/gitlab_test_valgrind.sh
@@ -56,6 +56,7 @@ do
         set -e
 done
 echo ">>> Local Server started for further functional test ... >>>"
+result=0
 
 ### Running two auto-test groups
 for test_group_name in integration functional
@@ -80,19 +81,16 @@ do
     test_command="export GLIBCXX_FORCE_NEW=; ${valgrind_command} ${test_command}"
 
     echo "-----> Calling \"${test_command}\" for ${test_group_name} : "
-    eval "${test_command}"
-    result=$?
+    eval "${test_command}" || result=1
     echo "-----> Finished ${test_group_name} - Result=${result}"
 
     # Add retry to functional/online tests. Some online tests are flaky due to third party reason.
     count=0
     while [[ ${result} -ne 0 && ${test_group_name} == "functional" ]];
     do
-        count=count+1
-        echo "This is ${count} time retry ..."
+        count=$((count+1)) && echo "This is ${count} time retry ..."
         echo "-----> Calling \"${test_command}\" for ${test_group_name} : "
-        eval "${test_command}"
-        result=$?
+        eval "${test_command}" || result=1
         echo "-----> Finished ${test_group_name} - Result=${result}"
 
         # Stop after 3 retry
@@ -126,8 +124,7 @@ do
     test_command="export GLIBCXX_FORCE_NEW=; $valgrind_command $test_command"
 
     echo "-----> Calling $test_command for $test_name : "
-    eval "${test_command}"
-    result=$?
+    eval "${test_command}" || result=1
     echo "-----> Finished $test_name - Result=$result"
 }
 done


### PR DESCRIPTION
Add echo about last return code for debug online tests

Relates-to: OLPEDGE-1144

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>