### PR TITLE
Modify retry mechanism for NV/FV online tests

### DIFF
--- a/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test.sh
+++ b/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test.sh
@@ -33,26 +33,28 @@ do
         sleep 0.15
         set -e
 done
-
 result=0
 echo ">>> Functional Test ... >>>"
 source $FV_HOME/olp-cpp-sdk-functional-test.variables
 $REPO_HOME/build/tests/functional/olp-cpp-sdk-functional-tests \
     --gtest_output="xml:$REPO_HOME/reports/olp-functional-test-report.xml" \
-    --gtest_filter="-ArcGisAuthenticationTest.SignInArcGis":"FacebookAuthenticationTest.SignInFacebook" || result=1
-
-# Add retry to functional/online tests. Some online tests are flaky due to third party reason.
+    --gtest_filter="-ArcGisAuthenticationTest.SignInArcGis":"FacebookAuthenticationTest.SignInFacebook"
+result=$?
 echo "Last return code in $result"
-count=0
-while [[ ${result} -ne 0 ]];
+
+# Add retry to functional/online tests. Some online tests are flaky due to third party reason
+# Test failure should return code 1
+retry_count=0
+while [[ ${result} = 1 ]];
 do
-    count=$((count+1)) && echo "This is ${count} time retry ..."
+    retry_count=$((retry_count+1)) && echo "This is ${retry_count} time retry ..."
     $REPO_HOME/build/tests/functional/olp-cpp-sdk-functional-tests \
         --gtest_output="xml:$REPO_HOME/reports/olp-functional-test-report.xml" \
-        --gtest_filter="-ArcGisAuthenticationTest.SignInArcGis":"FacebookAuthenticationTest.SignInFacebook" || result=1
+        --gtest_filter="-ArcGisAuthenticationTest.SignInArcGis":"FacebookAuthenticationTest.SignInFacebook"
+    result=$?
 
     # Stop after 3 retry
-    if [[ ${count} = 3 ]]; then
+    if [[ ${retry_count} = 3 ]]; then
         break
     fi
 done

--- a/scripts/linux/fv/gitlab_test_fv.sh
+++ b/scripts/linux/fv/gitlab_test_fv.sh
@@ -41,11 +41,11 @@ ${FV_HOME}/gitlab-olp-cpp-sdk-core-test.sh 2>> errors.txt || TEST_FAILURE=1
 ${FV_HOME}/gitlab-olp-cpp-sdk-dataservice-read-test.sh 2>> errors.txt || TEST_FAILURE=1
 ${FV_HOME}/gitlab-olp-cpp-sdk-dataservice-write-test.sh 2>> errors.txt || TEST_FAILURE=1
 
-# Run integration tests
-${FV_HOME}/gitlab-olp-cpp-sdk-integration-test.sh 2>> errors.txt || TEST_FAILURE=1
-
 # Run functional tests
 ${FV_HOME}/gitlab-olp-cpp-sdk-functional-test.sh 2>> errors.txt || TEST_FAILURE=1
+
+# Run integration tests
+${FV_HOME}/gitlab-olp-cpp-sdk-integration-test.sh 2>> errors.txt || TEST_FAILURE=1
 
 # Lines below are added for pretty data sum-up and finalize results of this script is case of FAILURE
 if [[ ${TEST_FAILURE} == 1 ]]; then

--- a/scripts/linux/nv/gitlab_test_valgrind.sh
+++ b/scripts/linux/nv/gitlab_test_valgrind.sh
@@ -56,7 +56,6 @@ do
         set -e
 done
 echo ">>> Local Server started for further functional test ... >>>"
-result=0
 
 ### Running two auto-test groups
 for test_group_name in integration functional
@@ -81,20 +80,23 @@ do
     test_command="export GLIBCXX_FORCE_NEW=; ${valgrind_command} ${test_command}"
 
     echo "-----> Calling \"${test_command}\" for ${test_group_name} : "
-    eval "${test_command}" || result=1
+    eval "${test_command}"
+    result=$?
     echo "-----> Finished ${test_group_name} - Result=${result}"
 
-    # Add retry to functional/online tests. Some online tests are flaky due to third party reason.
-    count=0
-    while [[ ${result} -ne 0 && ${test_group_name} == "functional" ]];
+    # Add retry to functional/online tests. Some online tests are flaky due to third party reason
+    # Test failure should return code 1
+    retry_count=0
+    while [[ ${result} = 1 && ${test_group_name} == "functional" ]];
     do
-        count=$((count+1)) && echo "This is ${count} time retry ..."
+        retry_count=$((retry_count+1)) && echo "This is ${retry_count} time retry ..."
         echo "-----> Calling \"${test_command}\" for ${test_group_name} : "
-        eval "${test_command}" || result=1
+        eval "${test_command}"
+        result=$?
         echo "-----> Finished ${test_group_name} - Result=${result}"
 
         # Stop after 3 retry
-        if [[ ${count} = 3 ]]; then
+        if [[ ${retry_count} = 3 ]]; then
             break
         fi
     done
@@ -124,7 +126,8 @@ do
     test_command="export GLIBCXX_FORCE_NEW=; $valgrind_command $test_command"
 
     echo "-----> Calling $test_command for $test_name : "
-    eval "${test_command}" || result=1
+    eval "${test_command}"
+    result=$?
     echo "-----> Finished $test_name - Result=$result"
 }
 done


### PR DESCRIPTION
Retry will run only for return code 1. Means will run only in gtest failure. Crashes will not be retried.
Also changed order FV test groups running.

Relates-to: OLPEDGE-1144

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>