### PR TITLE
Add CORE_API macro for TaskContext and PendingRequests

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/PendingRequests.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/PendingRequests.h
@@ -34,7 +34,7 @@ namespace client {
 /**
  * @brief Container for not yet finished requests.
  */
-class PendingRequests final {
+class CORE_API PendingRequests final {
  public:
   /**
    * @brief Cancels all pending tasks

--- a/olp-cpp-sdk-core/include/olp/core/client/TaskContext.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/TaskContext.h
@@ -37,7 +37,7 @@ namespace client {
  * result of provided task became available or error occurs, callback is
  * invoked.
  */
-class TaskContext {
+class CORE_API TaskContext {
  public:
   /**
    * @brief Constructs TaskContext with provided task and callback.


### PR DESCRIPTION
Add exports for classes to fix Windows exports in dynamic libraries.

Resolves: OLPEDGE-1159
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>