### PR TITLE
Fix a scenario when network do not trigger user callback 

### DIFF
--- a/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.cpp
+++ b/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.cpp
@@ -577,6 +577,7 @@ void NetworkWinHttp::RequestCallback(HINTERNET, DWORD_PTR context, DWORD status,
       OLP_SDK_LOG_WARNING(kLogTag, "WinHttpReceiveResponse failed, id="
                                        << handle->request_id
                                        << ", error=" << GetLastError());
+      handle->Complete();
     }
   } else if (status == WINHTTP_CALLBACK_STATUS_HEADERS_AVAILABLE) {
     Network::HeaderCallback callback = nullptr;
@@ -773,6 +774,7 @@ void NetworkWinHttp::RequestCallback(HINTERNET, DWORD_PTR context, DWORD status,
         OLP_SDK_LOG_WARNING(kLogTag, "WinHttpReadData failed, id="
                                          << handle->request_id
                                          << ", error=" << GetLastError());
+        handle->Complete();
       }
     } else {
       // Request is complete
@@ -875,6 +877,7 @@ void NetworkWinHttp::RequestCallback(HINTERNET, DWORD_PTR context, DWORD status,
       OLP_SDK_LOG_WARNING(kLogTag, "WinHttpQueryDataAvailable failed, id="
                                        << handle->request_id
                                        << ", error=" << GetLastError());
+      handle->Complete();
     }
   } else if (status == WINHTTP_CALLBACK_STATUS_HANDLE_CLOSING) {
     // Only now is it safe to free the handle


### PR DESCRIPTION
Fix a scenario when the network is destroyed and user callback is not triggered.

Resolves: OLPEDGE-1160

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>