### PR TITLE
Fix retry mechanism in FV/Nv online tests

### DIFF
--- a/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test.sh
+++ b/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test.sh
@@ -33,32 +33,12 @@ do
         sleep 0.15
         set -e
 done
-result=0
+
 echo ">>> Functional Test ... >>>"
 source $FV_HOME/olp-cpp-sdk-functional-test.variables
 $REPO_HOME/build/tests/functional/olp-cpp-sdk-functional-tests \
     --gtest_output="xml:$REPO_HOME/reports/olp-functional-test-report.xml" \
     --gtest_filter="-ArcGisAuthenticationTest.SignInArcGis":"FacebookAuthenticationTest.SignInFacebook"
-result=$?
-echo "Last return code in $result"
-
-# Add retry to functional/online tests. Some online tests are flaky due to third party reason
-# Test failure should return code 1
-retry_count=0
-while [[ ${result} = 1 ]];
-do
-    retry_count=$((retry_count+1)) && echo "This is ${retry_count} time retry ..."
-    $REPO_HOME/build/tests/functional/olp-cpp-sdk-functional-tests \
-        --gtest_output="xml:$REPO_HOME/reports/olp-functional-test-report.xml" \
-        --gtest_filter="-ArcGisAuthenticationTest.SignInArcGis":"FacebookAuthenticationTest.SignInFacebook"
-    result=$?
-
-    # Stop after 3 retry
-    if [[ ${retry_count} = 3 ]]; then
-        break
-    fi
-done
-# End of retry part. This part can be removed anytime.
 
 # Kill local server
 kill -15 ${SERVER_PID}


### PR DESCRIPTION
Changed way we call retry in shell

Relates-to: OLPEDGE-1144

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>