### PR TITLE
Added sync version of LookupApiClient in dataservice-write

### DIFF
--- a/olp-cpp-sdk-dataservice-write/src/ApiClientLookup.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/ApiClientLookup.cpp
@@ -20,8 +20,10 @@
 #include "ApiClientLookup.h"
 
 #include <olp/core/client/ApiError.h>
+#include <olp/core/client/Condition.h>
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClient.h>
+#include <olp/core/cache/KeyValueCache.h>
 #include <olp/core/logging/Log.h>
 #include "generated/PlatformApi.h"
 #include "generated/ResourcesApi.h"
@@ -45,6 +47,13 @@ std::string GetDatastoreServerUrl(const std::string& partition) {
              ? "https://api-lookup." + server_url->second + "/lookup/v1"
              : "";
 }
+
+std::string CreateKeyForCache(const std::string& hrn,
+                              const std::string& service,
+                              const std::string& service_version) {
+  return hrn + "::" + service + "::" + service_version + "::api";
+}
+
 }  // namespace
 
 client::CancellationToken ApiClientLookup::LookupApi(
@@ -124,6 +133,110 @@ client::CancellationToken ApiClientLookup::LookupApiClient(
           callback(*client);
         }
       });
+}
+
+ApiClientLookup::ApiClientResponse ApiClientLookup::LookupApiClient(
+    const client::HRN& catalog,
+    client::CancellationContext cancellation_context, std::string service,
+    std::string service_version, client::OlpClientSettings settings) {
+  auto cache_key =
+      CreateKeyForCache(catalog.ToCatalogHRNString(), service, service_version);
+  // first, try to find the corresponding Base URL from cache
+  auto cache = settings.cache;
+  if (cache) {
+    auto url =
+        cache->Get(cache_key, [](const std::string& value) { return value; });
+    if (!url.empty()) {
+      auto base_url = boost::any_cast<std::string>(url);
+      OLP_SDK_LOG_INFO_F(kLogTag, "LookupApiClient(%s, %s) -> from cache",
+                         service.c_str(), service_version.c_str());
+      client::OlpClient client;
+      client.SetSettings(settings);
+      client.SetBaseUrl(base_url);
+      return ApiClientResponse{client};
+    }
+  }
+
+  client::Condition condition;
+  // when the network operation took too much time we cancel it and exit
+  // execution, to make sure that network callback will not access dangling
+  // references we protect them with atomic bool flag.
+  auto flag = std::make_shared<std::atomic_bool>(true);
+
+  ApiClientResponse api_response;
+  auto api_callback = [&, flag](ApiClientResponse response) {
+    if (flag->exchange(false)) {
+      api_response = std::move(response);
+      condition.Notify();
+    }
+  };
+
+  cancellation_context.ExecuteOrCancelled(
+      [&, flag]() {
+        auto client_ptr = std::make_shared<olp::client::OlpClient>();
+        client_ptr->SetSettings(settings);
+
+        auto token = ApiClientLookup::LookupApiClient(
+            client_ptr, service, service_version, catalog, api_callback);
+        return client::CancellationToken([&, token, flag]() {
+          if (flag->exchange(false)) {
+            token.Cancel();
+            condition.Notify();
+          }
+        });
+      },
+      [&]() {
+        // if context was cancelled before the execution setup, unblock the
+        // upcoming wait routine.
+        condition.Notify();
+      });
+  if (!condition.Wait(std::chrono::seconds(settings.retry_settings.timeout))) {
+    cancellation_context.CancelOperation();
+    OLP_SDK_LOG_INFO_F(kLogTag, "LookupApi(%s/%s): %s - timeout",
+                       service.c_str(), service_version.c_str(),
+                       catalog.partition.c_str());
+    return client::ApiError(client::ErrorCode::RequestTimeout,
+                            "Network request timed out.");
+  }
+
+  flag->store(false);
+
+  if (cancellation_context.IsCancelled()) {
+    // We can't use api response here because it could potentially be
+    // uninitialized.
+    OLP_SDK_LOG_INFO_F(kLogTag, "LookupApi(%s/%s): %s - cancelled",
+                       service.c_str(), service_version.c_str(),
+                       catalog.partition.c_str());
+    return client::ApiError(client::ErrorCode::Cancelled,
+                            "Operation cancelled.");
+  }
+
+  if (!api_response.IsSuccessful()) {
+    return api_response.GetError();
+  }
+
+  auto client = api_response.GetResult();
+  if (client.GetBaseUrl().empty()) {
+    OLP_SDK_LOG_WARNING_F(kLogTag, "LookupApi(%s/%s): %s - empty base URL",
+                          service.c_str(), service_version.c_str(),
+                          catalog.partition.c_str());
+  }
+
+  if (cache) {
+    const auto& base_url = client.GetBaseUrl();
+
+    constexpr time_t kExpiryTimeInSecs = 3600;
+    if (cache->Put(cache_key, base_url, [base_url]() { return base_url; },
+                   kExpiryTimeInSecs)) {
+      OLP_SDK_LOG_TRACE_F(kLogTag, "Put '%s' to cache", cache_key.c_str());
+    } else {
+      OLP_SDK_LOG_WARNING_F(kLogTag, "Failed to put '%s' to cache",
+                            cache_key.c_str());
+    }
+  }
+
+  client.SetSettings(settings);
+  return ApiClientResponse{std::move(client)};
 }
 
 }  // namespace write

--- a/olp-cpp-sdk-dataservice-write/src/ApiClientLookup.h
+++ b/olp-cpp-sdk-dataservice-write/src/ApiClientLookup.h
@@ -51,6 +51,11 @@ class ApiClientLookup {
       std::shared_ptr<client::OlpClient> client, const std::string& service,
       const std::string& service_version, const client::HRN& hrn,
       const ApiClientCallback& callback);
+
+  static ApiClientResponse LookupApiClient(
+      const client::HRN& catalog,
+      client::CancellationContext cancellation_context, std::string service,
+      std::string service_version, client::OlpClientSettings settings);
 };
 
 }  // namespace write

--- a/olp-cpp-sdk-dataservice-write/tests/ApiClientLookupTest.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/ApiClientLookupTest.cpp
@@ -1,0 +1,333 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gmock/gmock.h>
+#include <matchers/NetworkUrlMatchers.h>
+#include <mocks/CacheMock.h>
+#include <mocks/NetworkMock.h>
+#include "ApiClientLookup.h"
+
+namespace {
+
+using namespace testing;
+using namespace olp::dataservice::write;
+using namespace olp::tests::common;
+
+const std::string kCatalog = "hrn:here:data:::some_test_catalog";
+
+const std::string kConfigServiceName = "config";
+const std::string kPublishServiceName = "publish";
+
+const std::string kConfigRequestUrl =
+    "https://api-lookup.data.api.platform.here.com/lookup/v1/"
+    "platform/apis/config/v1";
+const std::string kPublishRequestUrl =
+    "https://api-lookup.data.api.platform.here.com/lookup/v1/"
+    "resources/" +
+    kCatalog + "/apis/publish/v1";
+
+const std::string kConfigBaseUrl =
+    "https://config.data.api.platform.here.com/config/v1";
+const std::string kPublishBaseUrl =
+    "https://publish.data.api.platform.here.com/publish/v1/"
+    "catalogs/" +
+    kCatalog;
+
+const std::string kConfigHttpResponse =
+    R"jsonString([{"api":"config","version":"v1","baseURL":")jsonString" +
+    kConfigBaseUrl + R"jsongString(","parameters":{}}])jsongString";
+
+const std::string kPublishHttpResponse =
+    R"jsonString([{"api":"publish","version":"v1","baseURL":")jsonString" +
+    kPublishBaseUrl + R"jsonString(","parameters":{}}])jsonString";
+
+// Enum which controls the which Lookup API will be tested
+enum LookupApiType {
+  // 'config' service - PlatformApi::GetApis
+  Config,
+  // 'publish' service - ResourcesApi::GetApis
+  Resources
+};
+
+class ApiClientLookupTest : public ::testing::TestWithParam<LookupApiType> {
+ protected:
+  void SetUp() override {
+    network_ = std::make_shared<
+        testing::StrictMock<olp::tests::common::NetworkMock>>();
+
+    settings_.network_request_handler = network_;
+    settings_.retry_settings.timeout = 1;
+  }
+
+  void TearDown() override {
+    network_.reset();
+    auto network = std::move(settings_.network_request_handler);
+    settings_ = olp::client::OlpClientSettings();
+    // when test ends we must be sure that network pointer is not captured
+    // anywhere
+    EXPECT_EQ(network.use_count(), 1);
+  }
+
+  const std::string GetServiceName() {
+    switch (GetParam()) {
+      case LookupApiType::Config:
+        return kConfigServiceName;
+      case LookupApiType::Resources:
+        return kPublishServiceName;
+      default:
+        assert(false);
+    }
+  }
+
+  const std::string GetLookupApiRequestUrl() {
+    switch (GetParam()) {
+      case LookupApiType::Config:
+        return kConfigRequestUrl;
+      case LookupApiType::Resources:
+        return kPublishRequestUrl;
+      default:
+        assert(false);
+    }
+  }
+
+  const std::string GetLookupApiBaseUrl() {
+    switch (GetParam()) {
+      case LookupApiType::Config:
+        return kConfigBaseUrl;
+      case LookupApiType::Resources:
+        return kPublishBaseUrl;
+      default:
+        assert(false);
+    }
+  }
+
+  const std::string GetLookupApiHttpResponse() {
+    switch (GetParam()) {
+      case LookupApiType::Config:
+        return kConfigHttpResponse;
+      case LookupApiType::Resources:
+        return kPublishHttpResponse;
+      default:
+        assert(false);
+    }
+  }
+
+ protected:
+  olp::client::OlpClientSettings settings_;
+  std::shared_ptr<testing::StrictMock<olp::tests::common::NetworkMock>>
+      network_;
+};
+
+TEST_P(ApiClientLookupTest, LookupApiClientSync) {
+  const std::string kServiceName = GetServiceName();
+  const std::string kServiceUrl = "http://random_service.com";
+  const std::string kServiceVersion = "v1";
+
+  const std::string kCacheKey =
+      kCatalog + "::" + kServiceName + "::" + kServiceVersion + "::api";
+  const auto kHRN = olp::client::HRN::FromString(kCatalog);
+
+  {
+    SCOPED_TRACE("Fetch from cache positive");
+    auto cache =
+        std::make_shared<testing::StrictMock<olp::tests::common::CacheMock>>();
+    EXPECT_CALL(*cache, Get(kCacheKey, _))
+        .Times(1)
+        .WillOnce(Return(kServiceUrl));
+    auto settings_with_cache = settings_;
+    settings_with_cache.cache = cache;
+
+    auto response = ApiClientLookup::LookupApiClient(
+        kHRN, olp::client::CancellationContext{}, kServiceName, kServiceVersion,
+        settings_with_cache);
+    EXPECT_TRUE(response.IsSuccessful());
+    EXPECT_EQ(response.GetResult().GetBaseUrl(), kServiceUrl);
+  }
+
+  {
+    SCOPED_TRACE("Fetch from cache negative and fetch from network_");
+    auto cache =
+        std::make_shared<testing::StrictMock<olp::tests::common::CacheMock>>();
+    EXPECT_CALL(*cache, Get(kCacheKey, _)).Times(1);
+    EXPECT_CALL(*cache, Put(kCacheKey, _, _, _))
+        .Times(1)
+        .WillOnce(Return(true));
+    auto settings_with_cache = settings_;
+    settings_with_cache.cache = cache;
+
+    EXPECT_CALL(*network_,
+                Send(IsGetRequest(GetLookupApiRequestUrl()), _, _, _, _))
+        .Times(1)
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     GetLookupApiHttpResponse()));
+
+    auto response = ApiClientLookup::LookupApiClient(
+        kHRN, olp::client::CancellationContext{}, kServiceName, kServiceVersion,
+        settings_with_cache);
+    EXPECT_TRUE(response.IsSuccessful());
+    EXPECT_EQ(response.GetResult().GetBaseUrl(), GetLookupApiBaseUrl());
+    Mock::VerifyAndClearExpectations(network_.get());
+  }
+
+  {
+    SCOPED_TRACE("Fetch from network_ without cache");
+    EXPECT_CALL(*network_,
+                Send(IsGetRequest(GetLookupApiRequestUrl()), _, _, _, _))
+        .Times(1)
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     GetLookupApiHttpResponse()));
+
+    auto response = ApiClientLookup::LookupApiClient(
+        kHRN, olp::client::CancellationContext{}, kServiceName, kServiceVersion,
+        settings_);
+    EXPECT_TRUE(response.IsSuccessful());
+    EXPECT_EQ(response.GetResult().GetBaseUrl(), GetLookupApiBaseUrl());
+    Mock::VerifyAndClearExpectations(network_.get());
+  }
+
+  {
+    SCOPED_TRACE("Network error propagated to the user");
+    EXPECT_CALL(*network_,
+                Send(IsGetRequest(GetLookupApiRequestUrl()), _, _, _, _))
+        .Times(1)
+        .WillOnce(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                   olp::http::HttpStatusCode::UNAUTHORIZED),
+                               "Failed"));
+
+    auto response = ApiClientLookup::LookupApiClient(
+        kHRN, olp::client::CancellationContext{}, kServiceName, kServiceVersion,
+        settings_);
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(),
+              olp::client::ErrorCode::AccessDenied);
+    Mock::VerifyAndClearExpectations(network_.get());
+  }
+
+  {
+    SCOPED_TRACE("Network request timed out");
+    EXPECT_CALL(*network_,
+                Send(IsGetRequest(GetLookupApiRequestUrl()), _, _, _, _))
+        .Times(1)
+        .WillOnce([=](olp::http::NetworkRequest request,
+                      olp::http::Network::Payload payload,
+                      olp::http::Network::Callback callback,
+                      olp::http::Network::HeaderCallback header_callback,
+                      olp::http::Network::DataCallback data_callback)
+                      -> olp::http::SendOutcome {
+          // note no network_ response thread spawns
+          constexpr auto kUnusedRequestId = 42;
+          return olp::http::SendOutcome(kUnusedRequestId);
+        });
+    EXPECT_CALL(*network_, Cancel(_)).Times(1).WillOnce(Return());
+
+    auto response = ApiClientLookup::LookupApiClient(
+        kHRN, olp::client::CancellationContext{}, kServiceName, kServiceVersion,
+        settings_);
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(),
+              olp::client::ErrorCode::RequestTimeout);
+    Mock::VerifyAndClearExpectations(network_.get());
+  }
+
+  {
+    SCOPED_TRACE("Network request cancelled by network_ internally");
+    EXPECT_CALL(*network_,
+                Send(IsGetRequest(GetLookupApiRequestUrl()), _, _, _, _))
+        .Times(1)
+        .WillOnce([=](olp::http::NetworkRequest request,
+                      olp::http::Network::Payload payload,
+                      olp::http::Network::Callback callback,
+                      olp::http::Network::HeaderCallback header_callback,
+                      olp::http::Network::DataCallback data_callback)
+                      -> olp::http::SendOutcome {
+          return olp::http::SendOutcome(olp::http::ErrorCode::CANCELLED_ERROR);
+        });
+
+    auto response = ApiClientLookup::LookupApiClient(
+        kHRN, olp::client::CancellationContext{}, kServiceName, kServiceVersion,
+        settings_);
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(),
+              olp::client::ErrorCode::Cancelled);
+    Mock::VerifyAndClearExpectations(network_.get());
+  }
+
+  {
+    olp::client::CancellationContext context;
+    SCOPED_TRACE("Network request cancelled by user");
+    EXPECT_CALL(*network_,
+                Send(IsGetRequest(GetLookupApiRequestUrl()), _, _, _, _))
+        .Times(1)
+        .WillOnce([=](olp::http::NetworkRequest request,
+                      olp::http::Network::Payload payload,
+                      olp::http::Network::Callback callback,
+                      olp::http::Network::HeaderCallback header_callback,
+                      olp::http::Network::DataCallback data_callback) mutable
+                  -> olp::http::SendOutcome {
+          std::thread([context]() mutable { context.CancelOperation(); })
+              .detach();
+          constexpr auto kUnusedRequestId = 42;
+          return olp::http::SendOutcome(kUnusedRequestId);
+        });
+    EXPECT_CALL(*network_, Cancel(_)).Times(1).WillOnce(Return());
+    auto response = ApiClientLookup::LookupApiClient(
+        kHRN, context, kServiceName, kServiceVersion, settings_);
+    EXPECT_FALSE(response.IsSuccessful());
+    auto err_code = response.GetError().GetErrorCode();
+    EXPECT_EQ(err_code, olp::client::ErrorCode::Cancelled);
+    Mock::VerifyAndClearExpectations(network_.get());
+  }
+
+  {
+    SCOPED_TRACE("Network request cancelled before execution setup");
+    olp::client::CancellationContext context;
+    context.CancelOperation();
+    auto response = ApiClientLookup::LookupApiClient(
+        kHRN, context, kServiceName, kServiceVersion, settings_);
+
+    EXPECT_FALSE(response.IsSuccessful());
+    auto err_code = response.GetError().GetErrorCode();
+    EXPECT_EQ(err_code, olp::client::ErrorCode::Cancelled);
+    Mock::VerifyAndClearExpectations(network_.get());
+  }
+
+  {
+    SCOPED_TRACE("Pass HRN with bad catalog");
+
+    const auto kBadHrn = olp::client::HRN::FromString("hrn:wrong:data:catalog");
+
+    auto response = ApiClientLookup::LookupApiClient(
+        kBadHrn, olp::client::CancellationContext{}, kServiceName,
+        kServiceVersion, settings_);
+
+    EXPECT_FALSE(response.IsSuccessful());
+    auto err_code = response.GetError().GetErrorCode();
+    EXPECT_EQ(err_code, olp::client::ErrorCode::NotFound);
+    Mock::VerifyAndClearExpectations(network_.get());
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(, ApiClientLookupTest,
+                         ::testing::Values(LookupApiType::Config,
+                                           LookupApiType::Resources));
+
+}  // namespace

--- a/olp-cpp-sdk-dataservice-write/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-write/tests/CMakeLists.txt
@@ -16,6 +16,7 @@
 # License-Filename: LICENSE
 
 set(OLP_SDK_DATASERVICE_WRITE_TEST_SOURCES
+    ApiClientLookupTest.cpp
     CancellationTokenListTest.cpp
     ParserTest.cpp
     SerializerTest.cpp


### PR DESCRIPTION
Implemented the sync version of ApiClientLookup::LookupApiClient in dataservice-write component in the same way it is done in dataservice-read component.
Also, covered this new function with unit tests.

Relates to: OLPEDGE-1103

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>