### PR TITLE
Refactor stream layer into using sync api

### DIFF
--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
@@ -45,6 +45,9 @@
 #include <olp/core/generated/parser/JsonParser.h>
 // clang-format on
 
+#include <olp/core/client/TaskContext.h>
+#include <olp/core/client/PendingRequests.h>
+
 using namespace olp::client;
 using namespace olp::dataservice::write::model;
 
@@ -61,171 +64,94 @@ std::string GenerateUuid() {
   return boost::uuids::to_string(gen());
 }
 
-void ExecuteOrSchedule(const OlpClientSettings& settings,
-                       thread::TaskScheduler::CallFuncType&& func) {
-  if (!settings.task_scheduler) {
+using CallFuncType = thread::TaskScheduler::CallFuncType;
+
+inline void ExecuteOrSchedule(
+    const std::shared_ptr<thread::TaskScheduler>& task_scheduler,
+    CallFuncType&& func) {
+  if (!task_scheduler) {
     // User didn't specify a TaskScheduler, execute sync
     func();
-    return;
+  } else {
+    task_scheduler->ScheduleTask(std::move(func));
+  }
+}
+
+inline void ExecuteOrSchedule(const client::OlpClientSettings* settings,
+                              CallFuncType&& func) {
+  ExecuteOrSchedule(settings ? settings->task_scheduler : nullptr,
+                    std::move(func));
+}
+
+template <typename API, typename Response, typename... Args>
+Response AsyncApi(API api, Response unused_resp, client::HRN catalog,
+                  client::CancellationContext context,
+                  client::OlpClientSettings settings, std::string service,
+                  std::string version, Args... args) {
+  auto api_response = ApiClientLookup::LookupApiClient(
+      catalog, context, service, version, settings);
+
+  if (!api_response.IsSuccessful()) {
+    return api_response.GetError();
   }
 
-  // Schedule for async execution
-  settings.task_scheduler->ScheduleTask(std::move(func));
+  auto client = api_response.GetResult();
+
+  olp::client::Condition condition;
+  auto flag = std::make_shared<std::atomic_bool>(true);
+  Response response;
+
+  auto callback = [&, flag](Response inner_response) {
+    if (flag->exchange(false)) {
+      response = std::move(inner_response);
+      condition.Notify();
+    }
+  };
+
+  context.ExecuteOrCancelled(
+      [&, flag]() {
+        auto token = api(client, args..., callback);
+        return olp::client::CancellationToken([&, token, flag]() {
+          if (flag->exchange(false)) {
+            token.Cancel();
+            condition.Notify();
+          }
+        });
+      },
+      [&]() { condition.Notify(); });
+
+  if (!condition.Wait()) {
+    context.CancelOperation();
+    OLP_SDK_LOG_INFO_F(kLogTag, "timeout");
+    return {{ErrorCode::RequestTimeout, "Network request timed out."}};
+  }
+
+  flag->store(false);
+
+  if (context.IsCancelled()) {
+    return {{ErrorCode::Cancelled, "Operation cancelled."}};
+  }
+
+  return response;
 }
+
 }  // namespace
 
 StreamLayerClientImpl::StreamLayerClientImpl(
     HRN catalog, StreamLayerClientSettings client_settings,
     OlpClientSettings settings)
     : catalog_(std::move(catalog)),
-      catalog_model_(),
       settings_(std::move(settings)),
-      apiclient_config_(nullptr),
-      apiclient_ingest_(nullptr),
-      apiclient_blob_(nullptr),
-      apiclient_publish_(nullptr),
-      init_mutex_(),
-      init_cv_(),
-      init_inprogress_(false),
       cache_(settings_.cache),
       cache_mutex_(),
-      stream_client_settings_(std::move(client_settings)) {}
-
-CancellationToken StreamLayerClientImpl::InitApiClients(
-    const std::shared_ptr<CancellationContext>& cancel_context,
-    InitApiClientsCallback callback) {
-  if (apiclient_config_ && !apiclient_config_->GetBaseUrl().empty()) {
-    callback(boost::none);
-    return CancellationToken();
-  }
-
-  apiclient_ingest_ = OlpClientFactory::Create(settings_);
-
-  auto self = shared_from_this();
-  return ApiClientLookup::LookupApi(
-      apiclient_ingest_, "ingest", "v1", catalog_,
-      [=](ApiClientLookup::ApisResponse apis) {
-        if (!apis.IsSuccessful()) {
-          callback(std::move(apis.GetError()));
-          return;
-        }
-        self->apiclient_ingest_->SetBaseUrl(
-            apis.GetResult().at(0).GetBaseUrl());
-
-        cancel_context->ExecuteOrCancelled(
-            [=]() -> CancellationToken {
-              self->apiclient_config_ = OlpClientFactory::Create(settings_);
-
-              return ApiClientLookup::LookupApi(
-                  apiclient_config_, "config", "v1", catalog_,
-                  [=](ApiClientLookup::ApisResponse apis) {
-                    if (!apis.IsSuccessful()) {
-                      callback(std::move(apis.GetError()));
-                      return;
-                    }
-                    self->apiclient_config_->SetBaseUrl(
-                        apis.GetResult().at(0).GetBaseUrl());
-
-                    callback(boost::none);
-                  });
-            },
-            [=]() {
-              callback(
-                  ApiError(ErrorCode::Cancelled, "Operation cancelled.", true));
-            });
-      });
-}
-
-CancellationToken StreamLayerClientImpl::InitApiClientsGreaterThanTwentyMib(
-    const std::shared_ptr<CancellationContext>& cancel_context,
-    InitApiClientsCallback callback) {
-  if (apiclient_blob_ && !apiclient_blob_->GetBaseUrl().empty()) {
-    callback(boost::none);
-    return CancellationToken();
-  }
-
-  apiclient_publish_ = OlpClientFactory::Create(settings_);
-
-  auto self = shared_from_this();
-  return ApiClientLookup::LookupApi(
-      apiclient_publish_, "publish", "v2", catalog_,
-      [=](ApiClientLookup::ApisResponse apis) {
-        if (!apis.IsSuccessful()) {
-          callback(std::move(apis.GetError()));
-          return;
-        }
-        self->apiclient_publish_->SetBaseUrl(
-            apis.GetResult().at(0).GetBaseUrl());
-
-        cancel_context->ExecuteOrCancelled(
-            [=]() -> CancellationToken {
-              self->apiclient_blob_ = OlpClientFactory::Create(settings_);
-
-              return ApiClientLookup::LookupApi(
-                  apiclient_blob_, "blob", "v1", catalog_,
-                  [=](ApiClientLookup::ApisResponse apis) {
-                    if (!apis.IsSuccessful()) {
-                      callback(std::move(apis.GetError()));
-                      return;
-                    }
-                    self->apiclient_blob_->SetBaseUrl(
-                        apis.GetResult().at(0).GetBaseUrl());
-
-                    callback(boost::none);
-                  });
-            },
-            [=]() {
-              callback(
-                  ApiError(ErrorCode::Cancelled, "Operation cancelled.", true));
-            });
-      });
-}
-
-CancellationToken StreamLayerClientImpl::InitCatalogModel(
-    const model::PublishDataRequest& request,
-    const InitCatalogModelCallback& callback) {
-  if (!catalog_model_.GetId().empty()) {
-    callback(boost::none);
-    return CancellationToken();
-  }
-
-  auto self = shared_from_this();
-  return ConfigApi::GetCatalog(
-      apiclient_config_, catalog_.ToString(), request.GetBillingTag(),
-      [=](CatalogResponse catalog_response) {
-        if (!catalog_response.IsSuccessful()) {
-          callback(std::move(catalog_response.GetError()));
-          return;
-        }
-
-        self->catalog_model_ = catalog_response.GetResult();
-
-        callback(boost::none);
-      });
-}
-
-void StreamLayerClientImpl::AquireInitLock() {
-  std::unique_lock<std::mutex> lock(init_mutex_);
-  init_cv_.wait(lock, [=] { return !init_inprogress_; });
-  init_inprogress_ = true;
-}
-
-void StreamLayerClientImpl::NotifyInitAborted() {
-  std::unique_lock<std::mutex> lock(init_mutex_);
-  init_inprogress_ = false;
-  init_cv_.notify_one();
-}
-
-void StreamLayerClientImpl::NotifyInitCompleted() {
-  std::unique_lock<std::mutex> lock(init_mutex_);
-  init_inprogress_ = false;
-  init_cv_.notify_all();
-}
+      stream_client_settings_(std::move(client_settings)),
+      pending_requests_(std::make_shared<client::PendingRequests>()),
+      task_scheduler_(std::move(settings_.task_scheduler)) {}
 
 std::string StreamLayerClientImpl::FindContentTypeForLayerId(
-    const std::string& layer_id) {
+    const model::Catalog& catalog, const std::string& layer_id) {
   std::string content_type;
-  for (auto layer : catalog_model_.GetLayers()) {
+  for (auto layer : catalog.GetLayers()) {
     if (layer.GetId() == layer_id) {
       // TODO optimization opportunity - cache
       // content-type for layer when found for O(1)
@@ -235,6 +161,10 @@ std::string StreamLayerClientImpl::FindContentTypeForLayerId(
     }
   }
   return content_type;
+}
+
+StreamLayerClientImpl::~StreamLayerClientImpl() {
+  pending_requests_->CancelAllAndWait();
 }
 
 std::string StreamLayerClientImpl::GetUuidListKey() const {
@@ -386,24 +316,9 @@ olp::client::CancellationToken StreamLayerClientImpl::Flush(
       if (publish_request == boost::none) {
         continue;
       }
-
-      // TODO: This needs a redesign as pushing multiple publishes also on the
-      // TaskScheduler would mean a dead-lock in case we have a single-thread
-      // pool and this is waiting on each publish to finish. So while this loop
-      // here is active we will not be able to redesign PublishData() internally
-      // to use the TaskScheduler.
-      std::promise<void> barrier;
-      cancel_context.ExecuteOrCancelled(
-          [&]() -> CancellationToken {
-            return self->PublishData(
-                *publish_request, [&](PublishDataResponse publish_response) {
-                  response.emplace_back(std::move(publish_response));
-                  barrier.set_value();
-                });
-          },
-          [&barrier]() { barrier.set_value(); });
-
-      barrier.get_future().get();
+      auto publish_response = PublishDataTask(catalog_, settings_,
+                                              *publish_request, cancel_context);
+      response.emplace_back(std::move(publish_response));
 
       // If cancelled queue back task
       if (cancel_context.IsCancelled()) {
@@ -418,335 +333,214 @@ olp::client::CancellationToken StreamLayerClientImpl::Flush(
     callback(std::move(response));
   };
 
-  ExecuteOrSchedule(settings_, func);
+  ExecuteOrSchedule(task_scheduler_, func);
   return CancellationToken([=]() mutable { cancel_context.CancelOperation(); });
 }
 
 CancellationToken StreamLayerClientImpl::PublishData(
     const model::PublishDataRequest& request, PublishDataCallback callback) {
+  using std::placeholders::_1;
+  auto context = olp::client::TaskContext::Create(
+      std::bind(&StreamLayerClientImpl::PublishDataTask, this, catalog_,
+                settings_, request, _1),
+      callback);
+
+  auto pending_requests = pending_requests_;
+  pending_requests->Insert(context);
+
+  ExecuteOrSchedule(task_scheduler_, [=]() {
+    context.Execute();
+    pending_requests->Remove(context);
+  });
+
+  return context.CancelToken();
+}
+
+PublishDataResponse StreamLayerClientImpl::PublishDataTask(
+    client::HRN catalog, client::OlpClientSettings settings,
+    model::PublishDataRequest request,
+    olp::client::CancellationContext context) {
   if (!request.GetData()) {
-    callback(PublishDataResponse(
-        ApiError(ErrorCode::InvalidArgument, "Request data null.")));
-    return CancellationToken();
+    return {{ErrorCode::InvalidArgument, "Request data null."}};
   }
 
   const int64_t data_size = request.GetData()->size() * sizeof(unsigned char);
   if (data_size <= kTwentyMib) {
-    return PublishDataLessThanTwentyMib(request, callback);
+    return PublishDataLessThanTwentyMibTask(catalog, settings, request,
+                                            context);
   } else {
-    return PublishDataGreaterThanTwentyMib(request, callback);
+    return PublishDataGreaterThanTwentyMibTask(catalog, settings, request,
+                                               context);
   }
 }
 
-CancellationToken StreamLayerClientImpl::PublishDataLessThanTwentyMib(
-    const model::PublishDataRequest& request,
-    const PublishDataCallback& callback) {
-  // Publish < 20MB init is complete when catalog model is valid
-  if (catalog_model_.GetId().empty()) {
-    AquireInitLock();
-  }
-
-  auto cancel_context = std::make_shared<CancellationContext>();
-  auto self = shared_from_this();
-  cancel_context->ExecuteOrCancelled(
-      [=]() -> CancellationToken {
-        return self->InitApiClients(
-            cancel_context, [=](boost::optional<ApiError> init_api_error) {
-              if (init_api_error) {
-                NotifyInitAborted();
-                callback(PublishDataResponse(init_api_error.get()));
-                return;
-              }
-
-              cancel_context->ExecuteOrCancelled(
-                  [=]() -> CancellationToken {
-                    return self->InitCatalogModel(
-                        request, [=](boost::optional<ApiError>
-                                         init_catalog_model_error) {
-                          if (init_catalog_model_error) {
-                            NotifyInitAborted();
-                            callback(PublishDataResponse(
-                                init_catalog_model_error.get()));
-                            return;
-                          }
-
-                          NotifyInitCompleted();
-
-                          auto content_type = self->FindContentTypeForLayerId(
-                              request.GetLayerId());
-                          if (content_type.empty()) {
-                            callback(PublishDataResponse(ApiError(
-                                ErrorCode::InvalidArgument,
-                                "Unable to find the Layer ID provided in "
-                                "the PublishDataRequest in the "
-                                "Catalog specified when creating this "
-                                "StreamLayerClient instance.")));
-                            return;
-                          }
-
-                          cancel_context->ExecuteOrCancelled(
-                              [=]() -> CancellationToken {
-                                return IngestApi::IngestData(
-                                    *self->apiclient_ingest_,
-                                    request.GetLayerId(), content_type,
-                                    request.GetData(), request.GetTraceId(),
-                                    request.GetBillingTag(),
-                                    request.GetChecksum(),
-                                    [callback](IngestDataResponse response) {
-                                      callback(std::move(response));
-                                    });
-                              },
-                              [=]() {
-                                callback(PublishDataResponse(
-                                    ApiError(ErrorCode::Cancelled,
-                                             "Operation cancelled.", true)));
-                                return;
-                              });
-                        });
-                  },
-                  [=]() {
-                    callback(PublishDataResponse(ApiError(
-                        ErrorCode::Cancelled, "Operation cancelled.", true)));
-                  });
-            });
-      },
-      [=]() {
-        callback(PublishDataResponse(
-            ApiError(ErrorCode::Cancelled, "Operation cancelled.", true)));
-      });
-
-  std::weak_ptr<StreamLayerClientImpl> weak_self{self};
-  return CancellationToken([cancel_context, weak_self]() {
-    cancel_context->CancelOperation();
-    if (auto strong_self = weak_self.lock()) {
-      strong_self->NotifyInitAborted();
-    }
-  });
+UploadPartitionsResponse StreamLayerClientImpl::UploadPartition(
+    client::HRN catalog, client::CancellationContext context,
+    model::PublishDataRequest request, std::string publication_id,
+    PublishPartitions partitions, std::string partition_id,
+    client::OlpClientSettings settings) {
+  return AsyncApi(&PublishApi::UploadPartitions, UploadPartitionsResponse{},
+                  catalog, context, settings, "publish", "v2", partitions,
+                  publication_id, request.GetLayerId(),
+                  request.GetBillingTag());
 }
 
-void StreamLayerClientImpl::InitPublishDataGreaterThanTwentyMib(
-    const std::shared_ptr<client::CancellationContext>& cancel_context,
-    const model::PublishDataRequest& request,
-    const PublishDataCallback& callback) {
-  // Publish > 20MB init is complete when catalog model AND apiclient_blob_ are
-  // valid
-  if (catalog_model_.GetId().empty() ||
-      (!apiclient_blob_ || apiclient_blob_->GetBaseUrl().empty())) {
-    AquireInitLock();
-  }
-
-  auto self = shared_from_this();
-  cancel_context->ExecuteOrCancelled(
-      [=]() -> CancellationToken {
-        return self->InitApiClients(
-            cancel_context, [=](boost::optional<ApiError> init_api_error) {
-              if (init_api_error) {
-                NotifyInitAborted();
-                callback(PublishDataResponse(init_api_error.get()));
-                return;
-              }
-
-              cancel_context->ExecuteOrCancelled(
-                  [=]() -> CancellationToken {
-                    return self->InitApiClientsGreaterThanTwentyMib(
-                        cancel_context,
-                        [=](boost::optional<ApiError> init_api_error) {
-                          if (init_api_error) {
-                            NotifyInitAborted();
-                            callback(PublishDataResponse(init_api_error.get()));
-                            return;
-                          }
-
-                          cancel_context->ExecuteOrCancelled(
-                              [=]() -> CancellationToken {
-                                return self->InitCatalogModel(
-                                    request, [=](boost::optional<ApiError>
-                                                     init_catalog_model_error) {
-                                      if (init_catalog_model_error) {
-                                        NotifyInitAborted();
-                                        callback(PublishDataResponse(
-                                            init_catalog_model_error.get()));
-                                        return;
-                                      }
-
-                                      NotifyInitCompleted();
-
-                                      // Empty success response indicates
-                                      // initialization completed successfully.
-                                      callback(PublishDataResponse(
-                                          ResponseOkSingle()));
-                                    });
-                              },
-                              [=]() {
-                                callback(PublishDataResponse(
-                                    ApiError(ErrorCode::Cancelled,
-                                             "Operation cancelled.", true)));
-                              });
-                        });
-                  },
-                  [=]() {
-                    callback(PublishDataResponse(ApiError(
-                        ErrorCode::Cancelled, "Operation cancelled.", true)));
-                  });
-            });
-      },
-      [=]() {
-        callback(PublishDataResponse(
-            ApiError(ErrorCode::Cancelled, "Operation cancelled.", true)));
-      });
+IngestDataResponse StreamLayerClientImpl::IngestData(
+    client::HRN catalog, client::CancellationContext context,
+    model::PublishDataRequest request, std::string content_type,
+    client::OlpClientSettings settings) {
+  return AsyncApi(&IngestApi::IngestData, IngestDataResponse{}, catalog,
+                  context, settings, "ingest", "v1", request.GetLayerId(),
+                  content_type, request.GetData(), request.GetTraceId(),
+                  request.GetBillingTag(), request.GetChecksum());
 }
 
-CancellationToken StreamLayerClientImpl::PublishDataGreaterThanTwentyMib(
-    const model::PublishDataRequest& request,
-    const PublishDataCallback& callback) {
-  auto self = shared_from_this();
-  auto cancel_context = std::make_shared<CancellationContext>();
-  auto cancel_function = [callback]() {
-    callback(PublishDataResponse(
-        ApiError(ErrorCode::Cancelled, "Operation cancelled.", true)));
-  };
+PublishSdiiResponse StreamLayerClientImpl::IngestSDII(
+    client::HRN catalog, client::CancellationContext context,
+    model::PublishSdiiRequest request, client::OlpClientSettings settings) {
+  return AsyncApi(&IngestApi::IngestSDII, PublishSdiiResponse{}, catalog,
+                  context, settings, "ingest", "v1", request.GetLayerId(),
+                  request.GetSdiiMessageList(), request.GetTraceId(),
+                  request.GetBillingTag(), request.GetChecksum());
+}
 
-  // Publishing data greater than 20MiBs requires several steps: 1.
-  // Initialze the Publication, 2. Upload the Data 3. Upload publication
-  // metadata 4. Submit the publication. The functions to perform these steps
-  // are decomposed into anonoymous functions to avoid callback hell. They are
-  // declared in order from last called to first called.
+PutBlobResponse StreamLayerClientImpl::PutBlob(
+    client::HRN catalog, client::CancellationContext context,
+    model::PublishDataRequest request, std::string content_type,
+    std::string data_handle, client::OlpClientSettings settings) {
+  return AsyncApi(&BlobApi::PutBlob, PutBlobResponse{}, catalog, context,
+                  settings, "blob", "v1", request.GetLayerId(), content_type,
+                  data_handle, request.GetData(), request.GetBillingTag());
+}
 
-  auto submit_publication_callback =
-      [=](SubmitPublicationResponse submit_publication_response,
-          std::string partition_id) {
-        if (!submit_publication_response.IsSuccessful()) {
-          callback(PublishDataResponse(submit_publication_response.GetError()));
-          return;
-        }
-        model::ResponseOkSingle response_ok_single;
-        response_ok_single.SetTraceID(partition_id);
-        callback(PublishDataResponse(response_ok_single));
-      };
+PublishDataResponse StreamLayerClientImpl::PublishDataLessThanTwentyMibTask(
+    client::HRN catalog, client::OlpClientSettings settings,
+    model::PublishDataRequest request,
+    olp::client::CancellationContext cancellation_context) {
+  auto catalog_responce =
+      GetCatalog(catalog, cancellation_context, request, settings);
 
-  auto submit_publication_function =
-      [=](std::string publication_id,
-          std::string partition_id) -> CancellationToken {
-    return PublishApi::SubmitPublication(
-        *self->apiclient_publish_, publication_id, request.GetBillingTag(),
-        std::bind(submit_publication_callback, std::placeholders::_1,
-                  partition_id));
-  };
+  if (!catalog_responce.IsSuccessful()) {
+    return catalog_responce.GetError();
+  }
+  auto content_type = FindContentTypeForLayerId(catalog_responce.GetResult(),
+                                                request.GetLayerId());
 
-  auto upload_partitions_callback =
-      [=](UploadPartitionsResponse upload_partitions_response,
-          std::string publication_id, std::string partition_id) {
-        if (!upload_partitions_response.IsSuccessful()) {
-          callback(PublishDataResponse(upload_partitions_response.GetError()));
-          return;
-        }
+  if (content_type.empty()) {
+    auto message = boost::format(
+                       "Unable to find the Layer ID (%1%) "
+                       "provided in the PublishDataRequest in the "
+                       "Catalog specified when creating this "
+                       "StreamLayerClient instance.") %
+                   request.GetLayerId();
 
-        cancel_context->ExecuteOrCancelled(
-            std::bind(submit_publication_function, publication_id,
-                      partition_id),
-            cancel_function);
-      };
+    return {{ErrorCode::InvalidArgument, message.str()}};
+  }
 
-  auto upload_partitions_function =
-      [=](std::string publication_id, PublishPartitions partitions,
-          std::string partition_id) -> CancellationToken {
-    return PublishApi::UploadPartitions(
-        *self->apiclient_publish_, partitions, publication_id,
-        request.GetLayerId(), request.GetBillingTag(),
-        std::bind(upload_partitions_callback, std::placeholders::_1,
-                  publication_id, partition_id));
-  };
+  auto ingest_data_response = IngestData(catalog, cancellation_context, request,
+                                         content_type, settings);
+  return ingest_data_response;
+}
 
-  auto put_blob_callback = [=](PutBlobResponse put_blob_response,
-                               std::string publication_id,
-                               std::string data_handle) {
-    if (!put_blob_response.IsSuccessful()) {
-      callback(PublishDataResponse(put_blob_response.GetError()));
-      return;
-    }
+PublishDataResponse StreamLayerClientImpl::PublishDataGreaterThanTwentyMibTask(
+    client::HRN catalog, client::OlpClientSettings settings,
+    model::PublishDataRequest request,
+    olp::client::CancellationContext cancellation_context) {
+  auto catalog_responce =
+      GetCatalog(catalog, cancellation_context, request, settings);
 
-    const auto partition_id = GenerateUuid();
-    PublishPartition publish_partition;
-    publish_partition.SetPartition(partition_id);
-    publish_partition.SetDataHandle(data_handle);
-    PublishPartitions partitions;
-    partitions.SetPartitions({publish_partition});
+  if (!catalog_responce.IsSuccessful()) {
+    return catalog_responce.GetError();
+  }
 
-    cancel_context->ExecuteOrCancelled(
-        std::bind(upload_partitions_function, publication_id, partitions,
-                  partition_id),
-        cancel_function);
-  };
+  auto publication_response =
+      InitPublication(catalog, cancellation_context, request, settings);
+  if (!publication_response.IsSuccessful() ||
+      !publication_response.GetResult().GetId()) {
+    return publication_response.GetError();
+  }
 
-  auto put_blob_function = [=](std::string publication_id,
-                               std::string content_type,
-                               std::string data_handle) -> CancellationToken {
-    return BlobApi::PutBlob(*self->apiclient_blob_, request.GetLayerId(),
-                            content_type, data_handle, request.GetData(),
-                            request.GetBillingTag(),
-                            std::bind(put_blob_callback, std::placeholders::_1,
-                                      publication_id, data_handle));
-  };
+  auto publication = publication_response.GetResult();
+  auto content_type = FindContentTypeForLayerId(catalog_responce.GetResult(),
+                                                request.GetLayerId());
 
-  auto init_publication_callback =
-      [=](InitPublicationResponse init_pub_response) {
-        if (!init_pub_response.IsSuccessful() ||
-            !init_pub_response.GetResult().GetId()) {
-          callback(PublishDataResponse(init_pub_response.GetError()));
-          return;
-        }
+  if (content_type.empty()) {
+    auto message = boost::format(
+                       "Unable to find the Layer ID (%1%) "
+                       "provided in the PublishDataRequest in the "
+                       "Catalog specified when creating this "
+                       "StreamLayerClient instance.") %
+                   request.GetLayerId();
 
-        auto content_type =
-            self->FindContentTypeForLayerId(request.GetLayerId());
-        if (content_type.empty()) {
-          auto errmsg = boost::format(
-                            "Unable to find the Layer ID (%1%) "
-                            "provided in the PublishDataRequest in the "
-                            "Catalog specified when creating this "
-                            "StreamLayerClient instance.") %
-                        request.GetLayerId();
-          callback(PublishDataResponse(
-              ApiError(ErrorCode::InvalidArgument, errmsg.str())));
-          return;
-        }
+    return {{ErrorCode::InvalidArgument, message.str()}};
+  }
 
-        const auto data_handle = GenerateUuid();
+  const auto data_handle = GenerateUuid();
+  const auto publication_id = publication.GetId().get();
 
-        cancel_context->ExecuteOrCancelled(
-            std::bind(put_blob_function,
-                      init_pub_response.GetResult().GetId().get(), content_type,
-                      data_handle),
-            cancel_function);
-      };
+  auto put_blob_response = PutBlob(catalog, cancellation_context, request,
+                                   content_type, data_handle, settings);
 
-  auto init_publication_function = [=]() -> CancellationToken {
-    Publication pub;
-    pub.SetLayerIds({request.GetLayerId()});
+  if (!put_blob_response.IsSuccessful()) {
+    return put_blob_response.GetError();
+  }
 
-    return PublishApi::InitPublication(*self->apiclient_publish_, pub,
-                                       request.GetBillingTag(),
-                                       init_publication_callback);
-  };
+  PublishPartition publish_partition;
+  const auto partition_id = GenerateUuid();
+  publish_partition.SetPartition(partition_id);
+  publish_partition.SetDataHandle(data_handle);
+  PublishPartitions partitions;
+  partitions.SetPartitions({publish_partition});
 
-  auto post_intialize_callback = [=](PublishDataResponse response) {
-    if (response.IsSuccessful()) {
-      cancel_context->ExecuteOrCancelled(init_publication_function,
-                                         cancel_function);
-    } else {
-      callback(response);
-    }
-  };
+  auto upload_partition_response =
+      UploadPartition(catalog, cancellation_context, request, publication_id,
+                      partitions, partition_id, settings);
 
-  InitPublishDataGreaterThanTwentyMib(cancel_context, request,
-                                      post_intialize_callback);
+  if (!upload_partition_response.IsSuccessful()) {
+    return upload_partition_response.GetError();
+  }
 
-  std::weak_ptr<StreamLayerClientImpl> weak_self{self};
-  return CancellationToken([cancel_context, weak_self]() {
-    cancel_context->CancelOperation();
-    if (auto strong_self = weak_self.lock()) {
-      strong_self->NotifyInitAborted();
-    }
-  });
+  auto submit_publication_response = SubmitPublication(
+      catalog, cancellation_context, request, publication_id, settings);
+
+  if (!submit_publication_response.IsSuccessful()) {
+    return submit_publication_response.GetError();
+  }
+  model::ResponseOkSingle response_ok_single;
+  response_ok_single.SetTraceID(partition_id);
+  return response_ok_single;
+}
+
+std::string CreateCatalogKey(const std::string& hrn) {
+  return hrn + "::catalog";
+}
+
+CatalogResponse StreamLayerClientImpl::GetCatalog(
+    client::HRN catalog, client::CancellationContext context,
+    model::PublishDataRequest request, client::OlpClientSettings settings) {
+  return AsyncApi(&ConfigApi::GetCatalogB, CatalogResponse{}, catalog, context,
+                  settings, "config", "v1", catalog.ToCatalogHRNString(),
+                  request.GetBillingTag());
+}
+
+InitPublicationResponse StreamLayerClientImpl::InitPublication(
+    client::HRN catalog, client::CancellationContext context,
+    model::PublishDataRequest request, client::OlpClientSettings settings) {
+  Publication pub;
+  pub.SetLayerIds({request.GetLayerId()});
+
+  return AsyncApi(&PublishApi::InitPublication, InitPublicationResponse{},
+                  catalog, context, settings, "publish", "v2", pub,
+                  request.GetBillingTag());
+}
+
+SubmitPublicationResponse StreamLayerClientImpl::SubmitPublication(
+    client::HRN catalog, client::CancellationContext context,
+    model::PublishDataRequest request, std::string publication_id,
+    client::OlpClientSettings settings) {
+  return AsyncApi(&PublishApi::SubmitPublication, SubmitPublicationResponse{},
+                  catalog, context, settings, "publish", "v2", publication_id,
+                  request.GetBillingTag());
 }
 
 CancellableFuture<PublishSdiiResponse> StreamLayerClientImpl::PublishSdii(
@@ -761,67 +555,41 @@ CancellableFuture<PublishSdiiResponse> StreamLayerClientImpl::PublishSdii(
 
 CancellationToken StreamLayerClientImpl::PublishSdii(
     const model::PublishSdiiRequest& request, PublishSdiiCallback callback) {
+  using std::placeholders::_1;
+  auto context = olp::client::TaskContext::Create(
+      std::bind(&StreamLayerClientImpl::PublishSdiiTask, this, catalog_,
+                settings_, request, _1),
+      callback);
+
+  auto pending_requests = pending_requests_;
+  pending_requests->Insert(context);
+
+  ExecuteOrSchedule(task_scheduler_, [=]() {
+    context.Execute();
+    pending_requests->Remove(context);
+  });
+
+  return context.CancelToken();
+}
+
+PublishSdiiResponse StreamLayerClientImpl::PublishSdiiTask(
+    client::HRN catalog, client::OlpClientSettings settings,
+    model::PublishSdiiRequest request,
+    olp::client::CancellationContext context) {
   if (!request.GetSdiiMessageList()) {
-    callback(PublishSdiiResponse(ApiError(ErrorCode::InvalidArgument,
-                                          "Request sdii message list null.")));
-    return CancellationToken();
+    return PublishSdiiResponse(ApiError(ErrorCode::InvalidArgument,
+                                        "Request sdii message list null."));
   }
 
   if (request.GetLayerId().empty()) {
-    callback(PublishSdiiResponse(
-        ApiError(ErrorCode::InvalidArgument, "Request layer id empty.")));
-    return CancellationToken();
+    return PublishSdiiResponse(
+        ApiError(ErrorCode::InvalidArgument, "Request layer id empty."));
   }
 
-  // Sdii publish init is complete when apiclient_config_ is valid
-  if (!apiclient_config_ || apiclient_config_->GetBaseUrl().empty()) {
-    AquireInitLock();
-  }
-
-  auto cancel_context = std::make_shared<CancellationContext>();
-  auto self = shared_from_this();
-
-  cancel_context->ExecuteOrCancelled(
-      [=]() -> CancellationToken {
-        return self->InitApiClients(
-            cancel_context, [=](boost::optional<ApiError> init_api_error) {
-              if (init_api_error) {
-                NotifyInitAborted();
-                callback(PublishSdiiResponse(init_api_error.get()));
-                return;
-              }
-
-              NotifyInitCompleted();
-
-              cancel_context->ExecuteOrCancelled(
-                  [=]() -> CancellationToken {
-                    return IngestApi::IngestSDII(
-                        *self->apiclient_ingest_, request.GetLayerId(),
-                        request.GetSdiiMessageList(), request.GetTraceId(),
-                        request.GetBillingTag(), request.GetChecksum(),
-                        [callback](IngestSdiiResponse response) {
-                          callback(std::move(response));
-                        });
-                  },
-                  [callback]() {
-                    callback(PublishSdiiResponse(ApiError(
-                        ErrorCode::Cancelled, "Operation cancelled.", true)));
-                  });
-            });
-        ;
-      },
-      [callback]() {
-        callback(PublishSdiiResponse(
-            ApiError(ErrorCode::Cancelled, "Operation cancelled.", true)));
-      });
-
-  std::weak_ptr<StreamLayerClientImpl> weak_self{self};
-  return CancellationToken([cancel_context, weak_self]() {
-    cancel_context->CancelOperation();
-    if (auto strong_self = weak_self.lock()) {
-      strong_self->NotifyInitAborted();
-    }
-  });
+  return AsyncApi(&IngestApi::IngestSDII, PublishSdiiResponse{}, catalog,
+                  context, settings, "ingest", "v1", request.GetLayerId(),
+                  request.GetSdiiMessageList(), request.GetTraceId(),
+                  request.GetBillingTag(), request.GetChecksum());
 }
 
 }  // namespace write

--- a/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.cpp
@@ -34,19 +34,6 @@ namespace olp {
 namespace dataservice {
 namespace write {
 
-CancellableFuture<PutBlobResponse> BlobApi::PutBlob(
-    const OlpClient& client, const std::string& layer_id,
-    const std::string& content_type, const std::string& data_handle,
-    const std::shared_ptr<std::vector<unsigned char>>& data,
-    const boost::optional<std::string>& billing_tag) {
-  auto promise = std::make_shared<std::promise<PutBlobResponse>>();
-  auto cancel_token = PutBlob(client, layer_id, content_type, data_handle, data,
-                              billing_tag, [promise](PutBlobResponse response) {
-                                promise->set_value(std::move(response));
-                              });
-  return CancellableFuture<PutBlobResponse>(cancel_token, promise);
-}
-
 CancellationToken BlobApi::PutBlob(
     const OlpClient& client, const std::string& layer_id,
     const std::string& content_type, const std::string& data_handle,

--- a/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.h
@@ -70,33 +70,6 @@ class BlobApi {
    * @param billing_tag Optional. An optional free-form tag which is used for
    * grouping billing records together. If supplied, it must be between 4 - 16
    * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
-   *
-   * @return A CancellableFuture containing the PutBlobResponse.
-   */
-  static client::CancellableFuture<PutBlobResponse> PutBlob(
-      const client::OlpClient& client, const std::string& layer_id,
-      const std::string& content_type, const std::string& data_handle,
-      const std::shared_ptr<std::vector<unsigned char>>& data,
-      const boost::optional<std::string>& billing_tag = boost::none);
-
-  /**
-   * @brief Publishes a data blob
-   * Persists the data blob in the underlying storage mechanism (volume). Use
-   * this upload mechanism for blobs smaller than 50 MB. The size limit for
-   * blobs uploaded this way is 5 GB but we do not recommend uploading blobs
-   * this large with this method. When the operation completes successfully
-   * there is no guarantee that the data blob will be immediately available
-   * although in most cases it will be. To check if the data blob is available
-   * use the HEAD method.
-   * @param client Instance of OlpClient used to make REST request.
-   * @param layer_id The ID of the layer that the data blob belongs to.
-   * @param content_type The content type configured for the target layer.
-   * @param data_handle The data handle (ID) represents an identifier for the
-   * data blob.
-   * @param data Content to be uploaded to OLP.
-   * @param billing_tag Optional. An optional free-form tag which is used for
-   * grouping billing records together. If supplied, it must be between 4 - 16
-   * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
    * @param callback PutBlobCallback which will be called with the
    * PutBlobResponse when the operation completes.
    *

--- a/olp-cpp-sdk-dataservice-write/src/generated/ConfigApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/ConfigApi.cpp
@@ -36,22 +36,15 @@ namespace dataservice {
 namespace write {
 using namespace olp::client;
 
-CancellableFuture<CatalogResponse> ConfigApi::GetCatalog(
-    std::shared_ptr<OlpClient> client, const std::string& catalog_hrn,
-    boost::optional<std::string> billing_tag) {
-  auto promise = std::make_shared<std::promise<CatalogResponse>>();
-
-  auto cancel_token =
-      ConfigApi::GetCatalog(client, catalog_hrn, billing_tag,
-                            [promise](CatalogResponse catalog_response) {
-                              promise->set_value(std::move(catalog_response));
-                            });
-
-  return client::CancellableFuture<CatalogResponse>(cancel_token, promise);
-}
-
 CancellationToken ConfigApi::GetCatalog(
     std::shared_ptr<OlpClient> client, const std::string& catalog_hrn,
+    boost::optional<std::string> billing_tag,
+    const CatalogCallback& catalogCallback) {
+  return GetCatalogB(*client, catalog_hrn, billing_tag, catalogCallback);
+}
+
+CancellationToken ConfigApi::GetCatalogB(
+    const OlpClient& client, const std::string& catalog_hrn,
     boost::optional<std::string> billing_tag,
     const CatalogCallback& catalogCallback) {
   std::multimap<std::string, std::string> headerParams;
@@ -75,7 +68,7 @@ CancellationToken ConfigApi::GetCatalog(
         }
       };
 
-  return client->CallApi(catalogUri, "GET", queryParams, headerParams,
+  return client.CallApi(catalogUri, "GET", queryParams, headerParams,
                          formParams, nullptr, "", callback);
 }
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/ConfigApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/ConfigApi.h
@@ -44,20 +44,6 @@ using CatalogCallback = std::function<void(CatalogResponse)>;
 class ConfigApi {
  public:
   /**
-   * @brief Call to retrieve the configuration of a catalog.
-   * @param client Instance of OlpClient used to make REST request.
-   * @param catalog_hrn Full catalog name.
-   * @param billing_tag An optional free-form tag which is used for grouping
-   * billing records together. If supplied, it must be between 4 - 16
-   * characters, contain only alpha/numeric ASCII characters  [A-Za-z0-9].
-   *
-   * @return A CancellableFuture containing the CatalogResponse
-   */
-  static client::CancellableFuture<CatalogResponse> GetCatalog(
-      std::shared_ptr<client::OlpClient> client, const std::string& catalog_hrn,
-      boost::optional<std::string> billing_tag);
-
-  /**
    * @brief Call to asynchronously retrieve the configuration of a catalog.
    * @param client Instance of OlpClient used to make REST request.
    * @param catalog_hrn Full catalog name.
@@ -71,6 +57,11 @@ class ConfigApi {
    */
   static client::CancellationToken GetCatalog(
       std::shared_ptr<client::OlpClient> client, const std::string& catalog_hrn,
+      boost::optional<std::string> billing_tag,
+      const CatalogCallback& callback);
+
+  static client::CancellationToken GetCatalogB(
+      const client::OlpClient& client, const std::string& catalog_hrn,
       boost::optional<std::string> billing_tag,
       const CatalogCallback& callback);
 };

--- a/olp-cpp-sdk-dataservice-write/src/generated/IngestApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/IngestApi.cpp
@@ -45,22 +45,6 @@ const std::string kQueryParamBillingTag = "billingTag";
 namespace olp {
 namespace dataservice {
 namespace write {
-olp::client::CancellableFuture<IngestDataResponse> IngestApi::IngestData(
-    const OlpClient& client, const std::string& layer_id,
-    const std::string& content_type,
-    const std::shared_ptr<std::vector<unsigned char>>& data,
-    const boost::optional<std::string>& trace_id,
-    const boost::optional<std::string>& billing_tag,
-    const boost::optional<std::string>& checksum) {
-  auto promise = std::make_shared<std::promise<IngestDataResponse>>();
-  auto cancel_token =
-      IngestData(client, layer_id, content_type, data, trace_id, billing_tag,
-                 checksum, [promise](IngestDataResponse response) {
-                   promise->set_value(std::move(response));
-                 });
-  return client::CancellableFuture<IngestDataResponse>(cancel_token, promise);
-}
-
 client::CancellationToken IngestApi::IngestData(
     const client::OlpClient& client, const std::string& layer_id,
     const std::string& content_type,
@@ -101,21 +85,6 @@ client::CancellationToken IngestApi::IngestData(
       });
 
   return cancel_token;
-}
-
-olp::client::CancellableFuture<IngestSdiiResponse> IngestApi::IngestSDII(
-    const OlpClient& client, const std::string& layer_id,
-    const std::shared_ptr<std::vector<unsigned char>>& sdii_message_list,
-    const boost::optional<std::string>& trace_id,
-    const boost::optional<std::string>& billing_tag,
-    const boost::optional<std::string>& checksum) {
-  auto promise = std::make_shared<std::promise<IngestSdiiResponse>>();
-  auto cancel_token =
-      IngestSDII(client, layer_id, sdii_message_list, trace_id, billing_tag,
-                 checksum, [promise](IngestSdiiResponse response) {
-                   promise->set_value(std::move(response));
-                 });
-  return client::CancellableFuture<IngestSdiiResponse>(cancel_token, promise);
 }
 
 client::CancellationToken IngestApi::IngestSDII(

--- a/olp-cpp-sdk-dataservice-write/src/generated/IngestApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/IngestApi.h
@@ -71,37 +71,6 @@ class IngestApi {
    * verifies the integrity of your request and prevents modification by a third
    * party.It will be created by the service if not provided. A SHA-256 hash
    * consists of 256 bits or 64 chars.
-   *
-   * @return A CancellableFuture containing the IngestDataResponse.
-   */
-  static olp::client::CancellableFuture<IngestDataResponse> IngestData(
-      const client::OlpClient& client, const std::string& layer_id,
-      const std::string& content_type,
-      const std::shared_ptr<std::vector<unsigned char>>& data,
-      const boost::optional<std::string>& trace_id = boost::none,
-      const boost::optional<std::string>& billing_tag = boost::none,
-      const boost::optional<std::string>& checksum = boost::none);
-
-  /**
-   * @brief Call to ingest data into an OLP Stream Layer.
-   * @param client Instance of OlpClient used to make REST request.
-   * @param layer_id Layer of the catalog where you want to store the data. The
-   * layer type must be Stream.
-   * @param content_type The content type configured for the target layer.
-   * @param data Content to be uploaded to OLP.
-   * @param trace_id Optional. A unique message ID, such as a UUID. This can be
-   * included in the request if you want to use an ID that you define. If you do
-   * not include an ID, one will be generated during ingestion and included in
-   * the response. You can use this ID to track your request and identify the
-   * message in the catalog.
-   * @param billing_tag Optional. An optional free-form tag which is used for
-   * grouping billing records together. If supplied, it must be between 4 - 16
-   * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
-   * @param checksum A SHA-256 hash you can provide for
-   * validation against the calculated value on the request body hash. This
-   * verifies the integrity of your request and prevents modification by a third
-   * party.It will be created by the service if not provided. A SHA-256 hash
-   * consists of 256 bits or 64 chars.
    * @param callback IngestDataCallback which will be called with the
    * IngestDataResponse when the operation completes.
    *
@@ -116,39 +85,6 @@ class IngestApi {
       const boost::optional<std::string>& billing_tag,
       const boost::optional<std::string>& checksum,
       IngestDataCallback callback);
-
-  /**
-   * @brief Send list of SDII messages to a stream layer.
-   * SDII message data must be in SDII MessageList protobuf format. For more
-   * information please see the OLP Sensor Data Ingestion Interface
-   * documentation and schemas.
-   * @note the Content-Type for this request is always "application/x-protobuf".
-   * @param client Instance of OlpClient used to make REST request.
-   * @param layer_id Layer of the catalog where you want to store the data.
-   * @param sdii_message_list SDII MessageList data encoded in protobuf format
-   * according to the OLP SDII Message List schema. The maximum size is 20 MB.
-   * @param trace_id Optional. A unique message ID, such as a UUID. This can be
-   * included in the request if you want to use an ID that you define. If you do
-   * not include an ID, one will be generated during ingestion and included in
-   * the response. You can use this ID to track your request and identify the
-   * message in the catalog.
-   * @param billing_tag Optional. An optional free-form tag which is used for
-   * grouping billing records together. If supplied, it must be between 4 - 16
-   * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
-   * @param checksum A SHA-256 hash you can provide for
-   * validation against the calculated value on the request body hash. This
-   * verifies the integrity of your request and prevents modification by a third
-   * party.It will be created by the service if not provided. A SHA-256 hash
-   * consists of 256 bits or 64 chars.
-   *
-   * @return A CancellableFuture containing the IngestSdiiResponse.
-   */
-  static olp::client::CancellableFuture<IngestSdiiResponse> IngestSDII(
-      const client::OlpClient& client, const std::string& layer_id,
-      const std::shared_ptr<std::vector<unsigned char>>& sdii_message_list,
-      const boost::optional<std::string>& trace_id = boost::none,
-      const boost::optional<std::string>& billing_tag = boost::none,
-      const boost::optional<std::string>& checksum = boost::none);
 
   /**
    * @brief Send list of SDII messages to a stream layer.

--- a/olp-cpp-sdk-dataservice-write/src/generated/PublishApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/PublishApi.cpp
@@ -43,18 +43,6 @@ namespace olp {
 namespace dataservice {
 namespace write {
 
-CancellableFuture<InitPublicationResponse> PublishApi::InitPublication(
-    const OlpClient& client, const model::Publication& publication,
-    const boost::optional<std::string>& billing_tag) {
-  auto promise = std::make_shared<std::promise<InitPublicationResponse>>();
-  auto cancel_token =
-      InitPublication(client, publication, billing_tag,
-                      [promise](InitPublicationResponse response) {
-                        promise->set_value(std::move(response));
-                      });
-  return CancellableFuture<InitPublicationResponse>(cancel_token, promise);
-}
-
 CancellationToken PublishApi::InitPublication(
     const OlpClient& client, const model::Publication& publication,
     const boost::optional<std::string>& billing_tag,
@@ -90,19 +78,6 @@ CancellationToken PublishApi::InitPublication(
       });
 
   return cancel_token;
-}
-
-CancellableFuture<UploadPartitionsResponse> PublishApi::UploadPartitions(
-    const OlpClient& client, const model::PublishPartitions& publish_partitions,
-    const std::string& publication_id, const std::string& layer_id,
-    const boost::optional<std::string>& billing_tag) {
-  auto promise = std::make_shared<std::promise<UploadPartitionsResponse>>();
-  auto cancel_token = UploadPartitions(
-      client, publish_partitions, publication_id, layer_id, billing_tag,
-      [promise](UploadPartitionsResponse response) {
-        promise->set_value(std::move(response));
-      });
-  return CancellableFuture<UploadPartitionsResponse>(cancel_token, promise);
 }
 
 CancellationToken PublishApi::UploadPartitions(
@@ -145,18 +120,6 @@ CancellationToken PublishApi::UploadPartitions(
   return cancel_token;
 }
 
-CancellableFuture<SubmitPublicationResponse> PublishApi::SubmitPublication(
-    const OlpClient& client, const std::string& publication_id,
-    const boost::optional<std::string>& billing_tag) {
-  auto promise = std::make_shared<std::promise<SubmitPublicationResponse>>();
-  auto cancel_token =
-      SubmitPublication(client, publication_id, billing_tag,
-                        [promise](SubmitPublicationResponse response) {
-                          promise->set_value(std::move(response));
-                        });
-  return CancellableFuture<SubmitPublicationResponse>(cancel_token, promise);
-}
-
 CancellationToken PublishApi::SubmitPublication(
     const OlpClient& client, const std::string& publication_id,
     const boost::optional<std::string>& billing_tag,
@@ -188,18 +151,6 @@ CancellationToken PublishApi::SubmitPublication(
       });
 
   return cancel_token;
-}
-
-CancellableFuture<GetPublicationResponse> PublishApi::GetPublication(
-    const OlpClient& client, const std::string& publication_id,
-    const boost::optional<std::string>& billing_tag) {
-  auto promise = std::make_shared<std::promise<GetPublicationResponse>>();
-  auto cancel_token =
-      GetPublication(client, publication_id, billing_tag,
-                     [promise](GetPublicationResponse response) {
-                       promise->set_value(std::move(response));
-                     });
-  return CancellableFuture<GetPublicationResponse>(cancel_token, promise);
 }
 
 CancellationToken PublishApi::GetPublication(
@@ -234,18 +185,6 @@ CancellationToken PublishApi::GetPublication(
       });
 
   return cancel_token;
-}
-
-CancellableFuture<CancelPublicationResponse> PublishApi::CancelPublication(
-    const client::OlpClient& client, const std::string& publication_id,
-    const boost::optional<std::string>& billing_tag) {
-  auto promise = std::make_shared<std::promise<CancelPublicationResponse>>();
-  auto cancel_token =
-      CancelPublication(client, publication_id, billing_tag,
-                        [promise](CancelPublicationResponse response) {
-                          promise->set_value(std::move(response));
-                        });
-  return CancellableFuture<CancelPublicationResponse>(cancel_token, promise);
 }
 
 CancellationToken PublishApi::CancelPublication(

--- a/olp-cpp-sdk-dataservice-write/src/generated/PublishApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/PublishApi.h
@@ -80,29 +80,6 @@ class PublishApi {
    * @param billing_tag Optional. An optional free-form tag which is used for
    * grouping billing records together. If supplied, it must be between 4 - 16
    * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
-   * @return A CancellableFuture containing the InitPublicationResponse.
-   */
-  static client::CancellableFuture<InitPublicationResponse> InitPublication(
-      const client::OlpClient& client, const model::Publication& publication,
-      const boost::optional<std::string>& billing_tag = boost::none);
-
-  /**
-   * @brief Initialize a new publication
-   * Initializes a new publication for publishing metadata. Determines the
-   * publication type based on the provided layer IDs. A publication can only
-   * consist of layer IDs that have the same layer type. For example, you can
-   * have a publication for multiple layers of type `versioned`, but you cannot
-   * have a single publication that publishes to both `versioned` and `stream`
-   * layers. In addition, you may only have one `versioned` or `volatile`
-   * publication in process at a time. You cannot have multiple active
-   * publications to the same catalog for `versioned` and `volatile` layer
-   * types. The body field `versionDependencies` is optional and is used for
-   * `versioned` layers to declare version dependencies.
-   * @param client Instance of OlpClient used to make REST request.
-   * @param publication Fields to initialize a publication.
-   * @param billing_tag Optional. An optional free-form tag which is used for
-   * grouping billing records together. If supplied, it must be between 4 - 16
-   * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
    * @param callback InitPublicationCallback which will be called with the
    * InitPublicationResponse when the operation completes.
    * @return A CancellationToken which can be used to cancel the ongoing
@@ -112,31 +89,6 @@ class PublishApi {
       const client::OlpClient& client, const model::Publication& publication,
       const boost::optional<std::string>& billing_tag,
       InitPublicationCallback callback);
-
-  /**
-   * @brief Upload partitions
-   * Upload partitions to the given layer. Dependending on the publication type,
-   * post processing may be required before the partitions are published. For
-   * better performance batch your partitions (e.g. 1000 per request), rather
-   * than uploading them individually.
-   * @param client Instance of OlpClient used to make REST request.
-   * @param publish_partitions Publication partitions. Data and DataHandle
-   * fields cannot be populated at the same time. See Partition object for more
-   * details on body fields
-   * @param publication_id The ID of publication to publish to.
-   * @param layer_id The ID of the layer to publish to.
-   * @param billing_tag Billing Tag is an optional free-form tag which is used
-   * for grouping billing records together. If supplied, it must be between 4 -
-   * 16 characters and contain only alphanumeric ASCII characters [A-Za-z0-9].
-   * Grouping billing records by billing tag will be available in future
-   * releases.
-   * @return A CancellableFuture containing the UploadPartitionsResponse.
-   */
-  static client::CancellableFuture<UploadPartitionsResponse> UploadPartitions(
-      const client::OlpClient& client,
-      const model::PublishPartitions& publish_partitions,
-      const std::string& publication_id, const std::string& layer_id,
-      const boost::optional<std::string>& billing_tag = boost::none);
 
   /**
    * @brief Upload partitions
@@ -180,26 +132,6 @@ class PublishApi {
    * 16 characters and contain only alphanumeric ASCII characters [A-Za-z0-9].
    * Grouping billing records by billing tag will be available in future
    * releases.
-   *
-   * @return A CancellableFuture containing the SubmitPublicationResponse.
-   */
-  static client::CancellableFuture<SubmitPublicationResponse> SubmitPublication(
-      const client::OlpClient& client, const std::string& publication_id,
-      const boost::optional<std::string>& billing_tag = boost::none);
-
-  /**
-   * @brief Submits a publication
-   * Submits the publication and initiates post processing if necessary.
-   * Publication state becomes `Submitted` directly after submission and
-   * `Succeeded` after successful processing. See Data API Developer’s Guide in
-   * the Documentation section for complete publication states diagram.
-   * @param client Instance of OlpClient used to make REST request.
-   * @param publication_id ID of publication to submit.
-   * @param billing_tag Billing Tag is an optional free-form tag which is used
-   * for grouping billing records together. If supplied, it must be between 4 -
-   * 16 characters and contain only alphanumeric ASCII characters [A-Za-z0-9].
-   * Grouping billing records by billing tag will be available in future
-   * releases.
    * @param client Instance of OlpClient used to make REST request.
    * @param callback SubmitPublicationCallback which will be called with the
    * SubmitPublicationResponse when the operation completes.
@@ -224,26 +156,6 @@ class PublishApi {
    * 16 characters and contain only alphanumeric ASCII characters [A-Za-z0-9].
    * Grouping billing records by billing tag will be available in future
    * releases.
-   *
-   * @return A CancellableFuture containing the GetPublicationResponse.
-   */
-  static client::CancellableFuture<GetPublicationResponse> GetPublication(
-      const client::OlpClient& client, const std::string& publication_id,
-      const boost::optional<std::string>& billing_tag = boost::none);
-
-  /**
-   * @brief Gets a publication
-   * Returns the details of the specified publication. Publication can be in one
-   * of these states: Initialized, Submitted, Cancelled, Failed, Succeeded,
-   * Expired. See Data API Developer’s Guide in the Documentation section for
-   * the publication state diagram.
-   * @param client Instance of OlpClient used to make REST request.
-   * @param publication_id The ID of the publication to retrieve.
-   * @param billing_tag Billing Tag is an optional free-form tag which is used
-   * for grouping billing records together. If supplied, it must be between 4 -
-   * 16 characters and contain only alphanumeric ASCII characters [A-Za-z0-9].
-   * Grouping billing records by billing tag will be available in future
-   * releases.
    * @param callback GetPublicationCallback which will be called with the
    * GetPublicationResponse when the operation completes.
    * @return A CancellationToken which can be used to cancel the ongoing
@@ -253,24 +165,6 @@ class PublishApi {
       const client::OlpClient& client, const std::string& publication_id,
       const boost::optional<std::string>& billing_tag,
       GetPublicationCallback callback);
-
-  /**
-   * @brief Cancels a publication
-   * Cancels the publication.
-   * Publication state becomes `Cancelled`.
-   * @param client Instance of OlpClient used to make REST request.
-   * @param publication_id ID of publication to submit.
-   * @param billing_tag Billing Tag is an optional free-form tag which is used
-   * for grouping billing records together. If supplied, it must be between 4 -
-   * 16 characters and contain only alphanumeric ASCII characters [A-Za-z0-9].
-   * Grouping billing records by billing tag will be available in future
-   * releases.
-   *
-   * @return A CancellableFuture containing the CancelPublicationResponse.
-   */
-  static client::CancellableFuture<CancelPublicationResponse> CancelPublication(
-      const client::OlpClient& client, const std::string& publication_id,
-      const boost::optional<std::string>& billing_tag = boost::none);
 
   /**
    * @brief Cancels a publication

--- a/olp-cpp-sdk-dataservice-write/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-write/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(OLP_SDK_DATASERVICE_WRITE_TEST_SOURCES
     ParserTest.cpp
     SerializerTest.cpp
     StartBatchRequestTest.cpp
+    StreamLayerClientImplTest.cpp
     ThreadSafeQueueTest.cpp
     TimeUtilsTest.cpp
     )

--- a/olp-cpp-sdk-dataservice-write/tests/StreamLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/StreamLayerClientImplTest.cpp
@@ -1,0 +1,256 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gmock/gmock.h>
+#include <matchers/NetworkUrlMatchers.h>
+#include <mocks/CacheMock.h>
+#include <mocks/NetworkMock.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/dataservice/write/generated/model/ResponseOkSingle.h>
+#include "StreamLayerClientImpl.h"
+
+namespace {
+
+using namespace testing;
+using namespace olp;
+using namespace olp::dataservice::write;
+using namespace olp::tests::common;
+
+constexpr int64_t kTwentyMib = 20971520;
+const olp::client::HRN kHRN{"hrn:here:data:::catalog"};
+constexpr auto kLayerName = "layer";
+constexpr auto kContentType = "application/json";
+
+struct ResponseOkWithTraceIdFrom {
+  template <typename Request>
+  model::ResponseOkSingle operator()(Request request) {
+    model::ResponseOkSingle response;
+    response.SetTraceID(*request.GetTraceId());
+    return response;
+  }
+};
+
+MATCHER_P(WithTraceId, trace_id, "") {
+  return arg.GetTraceId() && *arg.GetTraceId() == trace_id;
+}
+
+class MockStreamLayerClientImpl : public StreamLayerClientImpl {
+ public:
+  using StreamLayerClientImpl::StreamLayerClientImpl;
+
+  MockStreamLayerClientImpl(client::HRN catalog,
+                            StreamLayerClientSettings client_settings,
+                            client::OlpClientSettings settings)
+      : StreamLayerClientImpl{catalog, client_settings, settings} {
+    using namespace std::placeholders;
+
+    ON_CALL(*this, PublishDataLessThanTwentyMibTask)
+        .WillByDefault(Invoke(std::bind(
+            &MockStreamLayerClientImpl::PublishDataLessThanTwentyMibTaskParent,
+            this, _1, _2, _3, _4)));
+  }
+
+  MOCK_METHOD(PublishDataResponse, PublishDataLessThanTwentyMibTask,
+              (client::HRN catalog, client::OlpClientSettings settings,
+               model::PublishDataRequest request,
+               client::CancellationContext context),
+              (override));
+
+  MOCK_METHOD(PublishDataResponse, PublishDataGreaterThanTwentyMibTask,
+              (client::HRN catalog, client::OlpClientSettings settings,
+               model::PublishDataRequest request,
+               client::CancellationContext context),
+              (override));
+
+  MOCK_METHOD(CatalogResponse, GetCatalog,
+              (client::HRN catalog, client::CancellationContext context,
+               model::PublishDataRequest request,
+               client::OlpClientSettings settings),
+              (override));
+
+  MOCK_METHOD(IngestDataResponse, IngestData,
+              (client::HRN catalog, client::CancellationContext context,
+               model::PublishDataRequest request, std::string content_type,
+               client::OlpClientSettings settings),
+              (override));
+
+  PublishDataResponse PublishDataLessThanTwentyMibTaskParent(
+      client::HRN catalog, client::OlpClientSettings settings,
+      model::PublishDataRequest request, client::CancellationContext context) {
+    return StreamLayerClientImpl::PublishDataLessThanTwentyMibTask(
+        std::move(catalog), std::move(settings), std::move(request),
+        std::move(context));
+  }
+};
+
+class StreamLayerClientImplTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    cache_ = std::make_shared<CacheMock>();
+    network_ = std::make_shared<NetworkMock>();
+
+    settings_.network_request_handler = network_;
+    settings_.cache = cache_;
+    settings_.task_scheduler =
+        olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler(1);
+  }
+
+  void TearDown() override {
+    settings_.network_request_handler.reset();
+    settings_.cache.reset();
+
+    network_.reset();
+    cache_.reset();
+  }
+
+  std::shared_ptr<CacheMock> cache_;
+  std::shared_ptr<NetworkMock> network_;
+  olp::client::OlpClientSettings settings_;
+};
+
+TEST_F(StreamLayerClientImplTest, SmallPublishData) {
+  MockStreamLayerClientImpl client{kHRN, StreamLayerClientSettings{},
+                                   settings_};
+
+  EXPECT_CALL(client, PublishDataLessThanTwentyMibTask(_, _, _, _))
+      .WillOnce(Return(model::ResponseOkSingle{}));
+
+  model::PublishDataRequest request;
+  request.WithData(
+      std::make_shared<std::vector<unsigned char>>(kTwentyMib - 1, 0xff));
+
+  auto publish_data_future = client.PublishData(request).GetFuture();
+  auto result = publish_data_future.get();
+  EXPECT_TRUE(result.IsSuccessful()) << result.GetError().GetMessage();
+}
+
+TEST_F(StreamLayerClientImplTest, LargePublishData) {
+  MockStreamLayerClientImpl client{kHRN, StreamLayerClientSettings{},
+                                   settings_};
+
+  EXPECT_CALL(client, PublishDataGreaterThanTwentyMibTask(_, _, _, _))
+      .WillOnce(Return(model::ResponseOkSingle{}));
+
+  model::PublishDataRequest request;
+  request.WithData(
+      std::make_shared<std::vector<unsigned char>>(kTwentyMib + 1, 0xff));
+
+  auto publish_data_future = client.PublishData(request).GetFuture();
+  auto result = publish_data_future.get();
+  EXPECT_TRUE(result.IsSuccessful()) << result.GetError().GetMessage();
+}
+
+TEST_F(StreamLayerClientImplTest, IncorrectPublishData) {
+  MockStreamLayerClientImpl client{kHRN, StreamLayerClientSettings{},
+                                   settings_};
+
+  ON_CALL(client, PublishDataGreaterThanTwentyMibTask(_, _, _, _))
+      .WillByDefault(Return(model::ResponseOkSingle{}));
+
+  ON_CALL(client, PublishDataLessThanTwentyMibTask(_, _, _, _))
+      .WillByDefault(Return(model::ResponseOkSingle{}));
+
+  model::PublishDataRequest request;
+
+  auto publish_data_future = client.PublishData(request).GetFuture();
+  auto result = publish_data_future.get();
+  EXPECT_FALSE(result.IsSuccessful());
+}
+
+TEST_F(StreamLayerClientImplTest, QueueAndFlush) {
+  const auto batch_size = 10;
+  std::map<std::string, std::string> storage;
+  settings_.cache =
+      olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
+
+  auto client = std::make_shared<MockStreamLayerClientImpl>(
+      kHRN, StreamLayerClientSettings{}, settings_);
+
+  // Forward trace ID from request to response
+  ON_CALL(*client, PublishDataLessThanTwentyMibTask)
+      .WillByDefault(WithArg<2>(Invoke(ResponseOkWithTraceIdFrom{})));
+
+  EXPECT_CALL(*client, PublishDataLessThanTwentyMibTask(_, _, _, _))
+      .Times(batch_size);
+
+  for (int i = 0; i < batch_size; ++i) {
+    model::PublishDataRequest request;
+    request.WithTraceId(std::to_string(i));
+    request.WithData(std::make_shared<std::vector<unsigned char>>(16, 0xff));
+    request.WithLayerId("layer");
+
+    auto error = client->Queue(request);
+    EXPECT_EQ(boost::none, error) << *error;
+  }
+
+  EXPECT_EQ(client->QueueSize(), batch_size);
+
+  auto flushed = std::make_shared<std::promise<void>>();
+
+  auto response = client->Flush(model::FlushRequest()).GetFuture().get();
+  // client->Flush(model::FlushRequest(),
+  //               [=](StreamLayerClient::FlushResponse response) {
+  // Has 10 responses
+  EXPECT_EQ(response.size(), batch_size);
+  std::set<std::string> trace_ids;
+  // All they are successful
+  for (const auto &r : response) {
+    EXPECT_TRUE(r.IsSuccessful());
+    trace_ids.insert(r.GetResult().GetTraceID());
+  }
+  // And has different trace_ids
+  EXPECT_EQ(batch_size, trace_ids.size());
+  //                 flushed->set_value();
+  //               });
+
+  // flushed->get_future().get();
+}
+
+TEST_F(StreamLayerClientImplTest, SmallPublishDataWithApi) {
+  const auto trace_id = "123";
+
+  std::vector<model::Layer> layers(1);
+  layers[0].SetId(kLayerName);
+  layers[0].SetContentType(kContentType);
+
+  model::Catalog catalog;
+  catalog.SetLayers(layers);
+
+  auto client = std::make_shared<MockStreamLayerClientImpl>(
+      kHRN, StreamLayerClientSettings{}, settings_);
+
+  EXPECT_CALL(*client, PublishDataLessThanTwentyMibTask).Times(1);
+  EXPECT_CALL(*client, GetCatalog).WillOnce(Return(catalog));
+  EXPECT_CALL(*client,
+              IngestData(_, _, WithTraceId(trace_id), Eq(kContentType), _))
+      .WillOnce(WithArg<2>(Invoke(ResponseOkWithTraceIdFrom{})));
+
+  model::PublishDataRequest request;
+  request.WithTraceId(trace_id);
+  request.WithLayerId(kLayerName);
+  request.WithData(
+      std::make_shared<std::vector<unsigned char>>(kTwentyMib - 1, 0xff));
+
+  auto publish_data_future = client->PublishData(request).GetFuture();
+  auto result = publish_data_future.get();
+
+  EXPECT_TRUE(result.IsSuccessful()) << result.GetError().GetMessage();
+}
+
+}  // namespace

--- a/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
@@ -289,18 +289,14 @@ class StreamLayerClientCacheTest : public ::testing::Test {
 };
 
 TEST_F(StreamLayerClientCacheTest, FlushDataSingle) {
-  {
-    testing::InSequence dummy;
-
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INGEST), _, _, _, _))
-        .Times(1);
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .Times(1);
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
-        .Times(1);
-    EXPECT_CALL(*network_, Send(IsPostRequest(URL_INGEST_DATA), _, _, _, _))
-        .Times(1);
-  }
+  EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INGEST), _, _, _, _))
+      .Times(1);
+  EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
+      .Times(1);
+  EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
+      .Times(1);
+  EXPECT_CALL(*network_, Send(IsPostRequest(URL_INGEST_DATA), _, _, _, _))
+      .Times(1);
 
   auto error = client_->Queue(
       PublishDataRequest().WithData(data_).WithLayerId(GetTestLayer()));
@@ -314,18 +310,14 @@ TEST_F(StreamLayerClientCacheTest, FlushDataSingle) {
 }
 
 TEST_F(StreamLayerClientCacheTest, FlushDataMultiple) {
-  {
-    testing::InSequence dummy;
-
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INGEST), _, _, _, _))
-        .Times(1);
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .Times(1);
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
-        .Times(1);
-    EXPECT_CALL(*network_, Send(IsPostRequest(URL_INGEST_DATA), _, _, _, _))
-        .Times(5);
-  }
+  EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INGEST), _, _, _, _))
+      .Times(1);
+  EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
+      .Times(1);
+  EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
+      .Times(5);
+  EXPECT_CALL(*network_, Send(IsPostRequest(URL_INGEST_DATA), _, _, _, _))
+      .Times(5);
 
   ASSERT_NO_FATAL_FAILURE(QueueMultipleEvents(5));
 
@@ -348,17 +340,13 @@ TEST_F(StreamLayerClientCacheTest, DISABLED_FlushDataCancel) {
   std::tie(request_id, send_mock, cancel_mock) = GenerateNetworkMockActions(
       wait_for_cancel, pause_for_cancel, {200, HTTP_RESPONSE_LOOKUP_CONFIG});
 
-  {
-    testing::InSequence dummy;
-
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INGEST), _, _, _, _))
-        .Times(1);
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .Times(1)
-        .WillOnce(testing::Invoke(std::move(send_mock)));
-    EXPECT_CALL(*network_, Cancel(request_id))
-        .WillOnce(testing::Invoke(std::move(cancel_mock)));
-  }
+  EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INGEST), _, _, _, _))
+      .Times(1);
+  EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
+      .Times(1)
+      .WillOnce(testing::Invoke(std::move(send_mock)));
+  EXPECT_CALL(*network_, Cancel(request_id))
+      .WillOnce(testing::Invoke(std::move(cancel_mock)));
 
   auto error = client_->Queue(
       PublishDataRequest().WithData(data_).WithLayerId(GetTestLayer()));
@@ -378,18 +366,14 @@ TEST_F(StreamLayerClientCacheTest, DISABLED_FlushDataCancel) {
 }
 
 TEST_F(StreamLayerClientCacheTest, FlushDataMaxEventsDefaultSetting) {
-  {
-    testing::InSequence dummy;
-
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INGEST), _, _, _, _))
-        .Times(1);
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .Times(1);
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
-        .Times(1);
-    EXPECT_CALL(*network_, Send(IsPostRequest(URL_INGEST_DATA), _, _, _, _))
-        .Times(5);
-  }
+  EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INGEST), _, _, _, _))
+      .Times(1);
+  EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
+      .Times(1);
+  EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
+      .Times(5);
+  EXPECT_CALL(*network_, Send(IsPostRequest(URL_INGEST_DATA), _, _, _, _))
+      .Times(5);
   ASSERT_NO_FATAL_FAILURE(FlushDataOnSettingSuccessAssertions());
 }
 
@@ -397,18 +381,15 @@ TEST_F(StreamLayerClientCacheTest, FlushDataMaxEventsValidCustomSetting) {
   const int max_events_per_flush = 3;
   disk_cache_->Close();
   client_ = CreateStreamLayerClient();
-  {
-    testing::InSequence dummy;
 
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INGEST), _, _, _, _))
-        .Times(1);
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .Times(1);
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
-        .Times(1);
-    EXPECT_CALL(*network_, Send(IsPostRequest(URL_INGEST_DATA), _, _, _, _))
-        .Times(3);
-  }
+  EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INGEST), _, _, _, _))
+      .Times(1);
+  EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
+      .Times(1);
+  EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
+      .Times(3);
+  EXPECT_CALL(*network_, Send(IsPostRequest(URL_INGEST_DATA), _, _, _, _))
+      .Times(3);
 
   ASSERT_NO_FATAL_FAILURE(
       FlushDataOnSettingSuccessAssertions(max_events_per_flush));
@@ -418,18 +399,15 @@ TEST_F(StreamLayerClientCacheTest, FlushDataMaxEventsInvalidCustomSetting) {
   const int max_events_per_flush = -3;
   disk_cache_->Close();
   client_ = CreateStreamLayerClient();
-  {
-    testing::InSequence dummy;
 
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INGEST), _, _, _, _))
-        .Times(0);
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .Times(0);
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
-        .Times(0);
-    EXPECT_CALL(*network_, Send(IsPostRequest(URL_INGEST_DATA), _, _, _, _))
-        .Times(0);
-  }
+  EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INGEST), _, _, _, _))
+      .Times(0);
+  EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
+      .Times(0);
+  EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
+      .Times(0);
+  EXPECT_CALL(*network_, Send(IsPostRequest(URL_INGEST_DATA), _, _, _, _))
+      .Times(0);
 
   ASSERT_NO_FATAL_FAILURE(
       FlushDataOnSettingSuccessAssertions(max_events_per_flush));
@@ -440,18 +418,15 @@ TEST_F(StreamLayerClientCacheTest, FlushSettingsMaximumRequests) {
   const auto kMaxRequests = std::numeric_limits<size_t>::max();
   ASSERT_EQ(stream_client_settings_.maximum_requests, kMaxRequests);
   client_ = CreateStreamLayerClient();
-  {
-    testing::InSequence dummy;
 
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INGEST), _, _, _, _))
-        .Times(1);
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .Times(1);
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
-        .Times(1);
-    EXPECT_CALL(*network_, Send(IsPostRequest(URL_INGEST_DATA), _, _, _, _))
-        .Times(15);
-  }
+  EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INGEST), _, _, _, _))
+      .Times(1);
+  EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
+      .Times(1);
+  EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
+      .Times(15);
+  EXPECT_CALL(*network_, Send(IsPostRequest(URL_INGEST_DATA), _, _, _, _))
+      .Times(15);
 
   QueueMultipleEvents(15);
   auto response = client_->Flush(model::FlushRequest()).GetFuture().get();


### PR DESCRIPTION
Change internals of stream layer to use TaskContext and TaskSheduler,
now on api calls we schedult asyncronous task like in dataservice-read.
Calls to api lookup and olp client usage extracted to separate virtual
methods.
Add unit tests for StreamLayerClientImpl.
Remove unused API from BlobAPI, ConfigAPI, IngestAPI and PublishAPI.

Relates-To: OLPEDGE-1010
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>