### PR TITLE
Add improvement to retry mechanism for exit when success

### DIFF
--- a/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test.sh
+++ b/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 #
 # Copyright (C) 2019 HERE Europe B.V.
 #
@@ -39,6 +39,7 @@ source $FV_HOME/olp-cpp-sdk-functional-test.variables
 $REPO_HOME/build/tests/functional/olp-cpp-sdk-functional-tests \
     --gtest_output="xml:$REPO_HOME/reports/olp-functional-test-report.xml" \
     --gtest_filter="-ArcGisAuthenticationTest.SignInArcGis":"FacebookAuthenticationTest.SignInFacebook"
+export result=$?
 
 # Kill local server
 kill -15 ${SERVER_PID}

--- a/scripts/linux/fv/gitlab_test_fv.sh
+++ b/scripts/linux/fv/gitlab_test_fv.sh
@@ -60,7 +60,7 @@ do
 
     # Run functional tests
     ${FV_HOME}/gitlab-olp-cpp-sdk-functional-test.sh 2>> errors.txt
-    if [[ $? -eq 1 ]]; then
+    if [[ $? -eq 1 || ${result} -eq 1 ]]; then
         TEST_FAILURE=1
         continue
     else


### PR DESCRIPTION
Retry works, but gitlab-olp-cpp-sdk-functional-test.sh returns 0 not always when tests succeded, so retry work till the end of retry limit and does not end on success

Relates-to: OLPEDGE-1144

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>