### PR TITLE
Update CacheSettings structure.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/cache/CacheSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/CacheSettings.h
@@ -23,6 +23,8 @@
 
 #include <boost/optional.hpp>
 
+#include <olp/core/porting/deprecated.h>
+
 namespace olp {
 
 namespace cache {
@@ -40,7 +42,14 @@ struct CacheSettings {
   /**
    * @brief Path to save contents on disk
    */
+  OLP_SDK_DEPRECATED("Use disk_path_mutable instead. Will be removed 03.2020")
   boost::optional<std::string> disk_path = boost::none;
+
+  /**
+   * @brief Path to the mutable (read-write) cache, where SDK will cache and
+   * lookup the content. User should have write permissions.
+   */
+  boost::optional<std::string> disk_path_mutable = boost::none;
 
   /**
    * @brief Set the upper limit of disk space to use for persistent stores in

--- a/olp-cpp-sdk-core/tests/cache/DefaultCacheTest.cpp
+++ b/olp-cpp-sdk-core/tests/cache/DefaultCacheTest.cpp
@@ -29,7 +29,7 @@
 
 TEST(DefaultCacheTest, BasicTest) {
   olp::cache::CacheSettings settings;
-  settings.disk_path = olp::utils::Dir::TempDirectory() + "/unittest";
+  settings.disk_path_mutable = olp::utils::Dir::TempDirectory() + "/unittest";
   olp::cache::DefaultCache cache(settings);
   ASSERT_EQ(olp::cache::DefaultCache::Success, cache.Open());
   ASSERT_TRUE(cache.Clear());
@@ -129,7 +129,7 @@ TEST(DefaultCacheTest, RemoveWithPrefix) {
 TEST(DefaultCacheTest, BasicDiskTest) {
   olp::cache::CacheSettings settings;
   settings.max_memory_cache_size = 0;
-  settings.disk_path = olp::utils::Dir::TempDirectory() + "/unittest";
+  settings.disk_path_mutable = olp::utils::Dir::TempDirectory() + "/unittest";
   olp::cache::DefaultCache cache(settings);
   ASSERT_EQ(olp::cache::DefaultCache::Success, cache.Open());
   ASSERT_TRUE(cache.Clear());
@@ -146,7 +146,7 @@ TEST(DefaultCacheTest, BasicDiskTest) {
 TEST(DefaultCacheTest, ExpiredDiskTest) {
   olp::cache::CacheSettings settings;
   settings.max_memory_cache_size = 0;
-  settings.disk_path = olp::utils::Dir::TempDirectory() + "/unittest";
+  settings.disk_path_mutable = olp::utils::Dir::TempDirectory() + "/unittest";
   olp::cache::DefaultCache cache(settings);
   ASSERT_EQ(olp::cache::DefaultCache::Success, cache.Open());
   ASSERT_TRUE(cache.Clear());
@@ -196,7 +196,7 @@ TEST(DefaultCacheTest, ExpiredMemTest) {
 
 TEST(DefaultCacheTest, BadPath) {
   olp::cache::CacheSettings settings;
-  settings.disk_path = std::string("/////this/is/a/bad/path");
+  settings.disk_path_mutable = std::string("/////this/is/a/bad/path");
   olp::cache::DefaultCache cache(settings);
   ASSERT_EQ(olp::cache::DefaultCache::OpenDiskPathFailure, cache.Open());
 
@@ -212,7 +212,7 @@ TEST(DefaultCacheTest, BadPath) {
 
 TEST(DefaultCacheTest, AlreadyInUsePath) {
   olp::cache::CacheSettings settings;
-  settings.disk_path = olp::utils::Dir::TempDirectory() + "/unittest";
+  settings.disk_path_mutable = olp::utils::Dir::TempDirectory() + "/unittest";
   olp::cache::DefaultCache cache(settings);
   ASSERT_EQ(olp::cache::DefaultCache::Success, cache.Open());
 

--- a/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientCacheTest.cpp
@@ -39,15 +39,15 @@ class CatalogClientCacheTest : public CatalogClientTestBase {
       }
       case CacheType::DISK: {
         settings.max_memory_cache_size = 0;
-        settings.disk_path =
+        settings.disk_path_mutable =
             olp::utils::Dir::TempDirectory() + kClientTestCacheDir;
-        ClearCache(settings.disk_path.get());
+        ClearCache(settings.disk_path_mutable.get());
         break;
       }
       case CacheType::BOTH: {
-        settings.disk_path =
+        settings.disk_path_mutable =
             olp::utils::Dir::TempDirectory() + kClientTestCacheDir;
-        ClearCache(settings.disk_path.get());
+        ClearCache(settings.disk_path_mutable.get());
         break;
       }
       case CacheType::NONE: {

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientCacheTest.cpp
@@ -43,15 +43,15 @@ class VersionedLayerClientCacheTest : public CatalogClientTestBase {
       }
       case CacheType::DISK: {
         settings.max_memory_cache_size = 0;
-        settings.disk_path =
+        settings.disk_path_mutable =
             olp::utils::Dir::TempDirectory() + kClientTestCacheDir;
-        ClearCache(settings.disk_path.get());
+        ClearCache(settings.disk_path_mutable.get());
         break;
       }
       case CacheType::BOTH: {
-        settings.disk_path =
+        settings.disk_path_mutable =
             olp::utils::Dir::TempDirectory() + kClientTestCacheDir;
-        ClearCache(settings.disk_path.get());
+        ClearCache(settings.disk_path_mutable.get());
         break;
       }
       case CacheType::NONE: {

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientCacheTest.cpp
@@ -43,15 +43,15 @@ class VolatileLayerClientCacheTest : public CatalogClientTestBase {
       }
       case CacheType::DISK: {
         settings.max_memory_cache_size = 0;
-        settings.disk_path =
+        settings.disk_path_mutable =
             olp::utils::Dir::TempDirectory() + kClientTestCacheDir;
-        ClearCache(settings.disk_path.get());
+        ClearCache(settings.disk_path_mutable.get());
         break;
       }
       case CacheType::BOTH: {
-        settings.disk_path =
+        settings.disk_path_mutable =
             olp::utils::Dir::TempDirectory() + kClientTestCacheDir;
-        ClearCache(settings.disk_path.get());
+        ClearCache(settings.disk_path_mutable.get());
         break;
       }
       case CacheType::NONE: {

--- a/tests/performance/MemoryTest.cpp
+++ b/tests/performance/MemoryTest.cpp
@@ -415,7 +415,7 @@ TestConfiguration ShortRunningTestWithDiskCache() {
   if (location.empty()) {
     location = utils::Dir::TempDirectory() + "/performance_test";
   }
-  settings.disk_path = location;
+  settings.disk_path_mutable = location;
 
   TestConfiguration configuration;
   configuration.configuration_name = "short_test_disk_cache";


### PR DESCRIPTION
* Add disk_path_mutable.
* Deprecate the disk_path in favor of a new disk_path_mutable.
* Update the SDK to use a new disk_path_mutable.
* When disk_path_mutable is empty, disk_path is used (backwards compatibility).

Resolves: OLPEDGE-1039

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>