### PR TITLE
Remove unused API from BlobAPI, ConfigAPI, IngestAPI and PublishAPI.

### DIFF
--- a/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.cpp
@@ -34,19 +34,6 @@ namespace olp {
 namespace dataservice {
 namespace write {
 
-CancellableFuture<PutBlobResponse> BlobApi::PutBlob(
-    const OlpClient& client, const std::string& layer_id,
-    const std::string& content_type, const std::string& data_handle,
-    const std::shared_ptr<std::vector<unsigned char>>& data,
-    const boost::optional<std::string>& billing_tag) {
-  auto promise = std::make_shared<std::promise<PutBlobResponse>>();
-  auto cancel_token = PutBlob(client, layer_id, content_type, data_handle, data,
-                              billing_tag, [promise](PutBlobResponse response) {
-                                promise->set_value(std::move(response));
-                              });
-  return CancellableFuture<PutBlobResponse>(cancel_token, promise);
-}
-
 CancellationToken BlobApi::PutBlob(
     const OlpClient& client, const std::string& layer_id,
     const std::string& content_type, const std::string& data_handle,

--- a/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.h
@@ -70,33 +70,6 @@ class BlobApi {
    * @param billing_tag Optional. An optional free-form tag which is used for
    * grouping billing records together. If supplied, it must be between 4 - 16
    * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
-   *
-   * @return A CancellableFuture containing the PutBlobResponse.
-   */
-  static client::CancellableFuture<PutBlobResponse> PutBlob(
-      const client::OlpClient& client, const std::string& layer_id,
-      const std::string& content_type, const std::string& data_handle,
-      const std::shared_ptr<std::vector<unsigned char>>& data,
-      const boost::optional<std::string>& billing_tag = boost::none);
-
-  /**
-   * @brief Publishes a data blob
-   * Persists the data blob in the underlying storage mechanism (volume). Use
-   * this upload mechanism for blobs smaller than 50 MB. The size limit for
-   * blobs uploaded this way is 5 GB but we do not recommend uploading blobs
-   * this large with this method. When the operation completes successfully
-   * there is no guarantee that the data blob will be immediately available
-   * although in most cases it will be. To check if the data blob is available
-   * use the HEAD method.
-   * @param client Instance of OlpClient used to make REST request.
-   * @param layer_id The ID of the layer that the data blob belongs to.
-   * @param content_type The content type configured for the target layer.
-   * @param data_handle The data handle (ID) represents an identifier for the
-   * data blob.
-   * @param data Content to be uploaded to OLP.
-   * @param billing_tag Optional. An optional free-form tag which is used for
-   * grouping billing records together. If supplied, it must be between 4 - 16
-   * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
    * @param callback PutBlobCallback which will be called with the
    * PutBlobResponse when the operation completes.
    *

--- a/olp-cpp-sdk-dataservice-write/src/generated/ConfigApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/ConfigApi.cpp
@@ -36,20 +36,6 @@ namespace dataservice {
 namespace write {
 using namespace olp::client;
 
-CancellableFuture<CatalogResponse> ConfigApi::GetCatalog(
-    std::shared_ptr<OlpClient> client, const std::string& catalog_hrn,
-    boost::optional<std::string> billing_tag) {
-  auto promise = std::make_shared<std::promise<CatalogResponse>>();
-
-  auto cancel_token =
-      ConfigApi::GetCatalog(client, catalog_hrn, billing_tag,
-                            [promise](CatalogResponse catalog_response) {
-                              promise->set_value(std::move(catalog_response));
-                            });
-
-  return client::CancellableFuture<CatalogResponse>(cancel_token, promise);
-}
-
 CancellationToken ConfigApi::GetCatalog(
     std::shared_ptr<OlpClient> client, const std::string& catalog_hrn,
     boost::optional<std::string> billing_tag,

--- a/olp-cpp-sdk-dataservice-write/src/generated/ConfigApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/ConfigApi.h
@@ -44,20 +44,6 @@ using CatalogCallback = std::function<void(CatalogResponse)>;
 class ConfigApi {
  public:
   /**
-   * @brief Call to retrieve the configuration of a catalog.
-   * @param client Instance of OlpClient used to make REST request.
-   * @param catalog_hrn Full catalog name.
-   * @param billing_tag An optional free-form tag which is used for grouping
-   * billing records together. If supplied, it must be between 4 - 16
-   * characters, contain only alpha/numeric ASCII characters  [A-Za-z0-9].
-   *
-   * @return A CancellableFuture containing the CatalogResponse
-   */
-  static client::CancellableFuture<CatalogResponse> GetCatalog(
-      std::shared_ptr<client::OlpClient> client, const std::string& catalog_hrn,
-      boost::optional<std::string> billing_tag);
-
-  /**
    * @brief Call to asynchronously retrieve the configuration of a catalog.
    * @param client Instance of OlpClient used to make REST request.
    * @param catalog_hrn Full catalog name.

--- a/olp-cpp-sdk-dataservice-write/src/generated/IngestApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/IngestApi.cpp
@@ -45,22 +45,6 @@ const std::string kQueryParamBillingTag = "billingTag";
 namespace olp {
 namespace dataservice {
 namespace write {
-olp::client::CancellableFuture<IngestDataResponse> IngestApi::IngestData(
-    const OlpClient& client, const std::string& layer_id,
-    const std::string& content_type,
-    const std::shared_ptr<std::vector<unsigned char>>& data,
-    const boost::optional<std::string>& trace_id,
-    const boost::optional<std::string>& billing_tag,
-    const boost::optional<std::string>& checksum) {
-  auto promise = std::make_shared<std::promise<IngestDataResponse>>();
-  auto cancel_token =
-      IngestData(client, layer_id, content_type, data, trace_id, billing_tag,
-                 checksum, [promise](IngestDataResponse response) {
-                   promise->set_value(std::move(response));
-                 });
-  return client::CancellableFuture<IngestDataResponse>(cancel_token, promise);
-}
-
 client::CancellationToken IngestApi::IngestData(
     const client::OlpClient& client, const std::string& layer_id,
     const std::string& content_type,
@@ -101,21 +85,6 @@ client::CancellationToken IngestApi::IngestData(
       });
 
   return cancel_token;
-}
-
-olp::client::CancellableFuture<IngestSdiiResponse> IngestApi::IngestSDII(
-    const OlpClient& client, const std::string& layer_id,
-    const std::shared_ptr<std::vector<unsigned char>>& sdii_message_list,
-    const boost::optional<std::string>& trace_id,
-    const boost::optional<std::string>& billing_tag,
-    const boost::optional<std::string>& checksum) {
-  auto promise = std::make_shared<std::promise<IngestSdiiResponse>>();
-  auto cancel_token =
-      IngestSDII(client, layer_id, sdii_message_list, trace_id, billing_tag,
-                 checksum, [promise](IngestSdiiResponse response) {
-                   promise->set_value(std::move(response));
-                 });
-  return client::CancellableFuture<IngestSdiiResponse>(cancel_token, promise);
 }
 
 client::CancellationToken IngestApi::IngestSDII(

--- a/olp-cpp-sdk-dataservice-write/src/generated/IngestApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/IngestApi.h
@@ -71,37 +71,6 @@ class IngestApi {
    * verifies the integrity of your request and prevents modification by a third
    * party.It will be created by the service if not provided. A SHA-256 hash
    * consists of 256 bits or 64 chars.
-   *
-   * @return A CancellableFuture containing the IngestDataResponse.
-   */
-  static olp::client::CancellableFuture<IngestDataResponse> IngestData(
-      const client::OlpClient& client, const std::string& layer_id,
-      const std::string& content_type,
-      const std::shared_ptr<std::vector<unsigned char>>& data,
-      const boost::optional<std::string>& trace_id = boost::none,
-      const boost::optional<std::string>& billing_tag = boost::none,
-      const boost::optional<std::string>& checksum = boost::none);
-
-  /**
-   * @brief Call to ingest data into an OLP Stream Layer.
-   * @param client Instance of OlpClient used to make REST request.
-   * @param layer_id Layer of the catalog where you want to store the data. The
-   * layer type must be Stream.
-   * @param content_type The content type configured for the target layer.
-   * @param data Content to be uploaded to OLP.
-   * @param trace_id Optional. A unique message ID, such as a UUID. This can be
-   * included in the request if you want to use an ID that you define. If you do
-   * not include an ID, one will be generated during ingestion and included in
-   * the response. You can use this ID to track your request and identify the
-   * message in the catalog.
-   * @param billing_tag Optional. An optional free-form tag which is used for
-   * grouping billing records together. If supplied, it must be between 4 - 16
-   * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
-   * @param checksum A SHA-256 hash you can provide for
-   * validation against the calculated value on the request body hash. This
-   * verifies the integrity of your request and prevents modification by a third
-   * party.It will be created by the service if not provided. A SHA-256 hash
-   * consists of 256 bits or 64 chars.
    * @param callback IngestDataCallback which will be called with the
    * IngestDataResponse when the operation completes.
    *
@@ -116,39 +85,6 @@ class IngestApi {
       const boost::optional<std::string>& billing_tag,
       const boost::optional<std::string>& checksum,
       IngestDataCallback callback);
-
-  /**
-   * @brief Send list of SDII messages to a stream layer.
-   * SDII message data must be in SDII MessageList protobuf format. For more
-   * information please see the OLP Sensor Data Ingestion Interface
-   * documentation and schemas.
-   * @note the Content-Type for this request is always "application/x-protobuf".
-   * @param client Instance of OlpClient used to make REST request.
-   * @param layer_id Layer of the catalog where you want to store the data.
-   * @param sdii_message_list SDII MessageList data encoded in protobuf format
-   * according to the OLP SDII Message List schema. The maximum size is 20 MB.
-   * @param trace_id Optional. A unique message ID, such as a UUID. This can be
-   * included in the request if you want to use an ID that you define. If you do
-   * not include an ID, one will be generated during ingestion and included in
-   * the response. You can use this ID to track your request and identify the
-   * message in the catalog.
-   * @param billing_tag Optional. An optional free-form tag which is used for
-   * grouping billing records together. If supplied, it must be between 4 - 16
-   * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
-   * @param checksum A SHA-256 hash you can provide for
-   * validation against the calculated value on the request body hash. This
-   * verifies the integrity of your request and prevents modification by a third
-   * party.It will be created by the service if not provided. A SHA-256 hash
-   * consists of 256 bits or 64 chars.
-   *
-   * @return A CancellableFuture containing the IngestSdiiResponse.
-   */
-  static olp::client::CancellableFuture<IngestSdiiResponse> IngestSDII(
-      const client::OlpClient& client, const std::string& layer_id,
-      const std::shared_ptr<std::vector<unsigned char>>& sdii_message_list,
-      const boost::optional<std::string>& trace_id = boost::none,
-      const boost::optional<std::string>& billing_tag = boost::none,
-      const boost::optional<std::string>& checksum = boost::none);
 
   /**
    * @brief Send list of SDII messages to a stream layer.

--- a/olp-cpp-sdk-dataservice-write/src/generated/PublishApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/PublishApi.cpp
@@ -43,18 +43,6 @@ namespace olp {
 namespace dataservice {
 namespace write {
 
-CancellableFuture<InitPublicationResponse> PublishApi::InitPublication(
-    const OlpClient& client, const model::Publication& publication,
-    const boost::optional<std::string>& billing_tag) {
-  auto promise = std::make_shared<std::promise<InitPublicationResponse>>();
-  auto cancel_token =
-      InitPublication(client, publication, billing_tag,
-                      [promise](InitPublicationResponse response) {
-                        promise->set_value(std::move(response));
-                      });
-  return CancellableFuture<InitPublicationResponse>(cancel_token, promise);
-}
-
 CancellationToken PublishApi::InitPublication(
     const OlpClient& client, const model::Publication& publication,
     const boost::optional<std::string>& billing_tag,
@@ -90,19 +78,6 @@ CancellationToken PublishApi::InitPublication(
       });
 
   return cancel_token;
-}
-
-CancellableFuture<UploadPartitionsResponse> PublishApi::UploadPartitions(
-    const OlpClient& client, const model::PublishPartitions& publish_partitions,
-    const std::string& publication_id, const std::string& layer_id,
-    const boost::optional<std::string>& billing_tag) {
-  auto promise = std::make_shared<std::promise<UploadPartitionsResponse>>();
-  auto cancel_token = UploadPartitions(
-      client, publish_partitions, publication_id, layer_id, billing_tag,
-      [promise](UploadPartitionsResponse response) {
-        promise->set_value(std::move(response));
-      });
-  return CancellableFuture<UploadPartitionsResponse>(cancel_token, promise);
 }
 
 CancellationToken PublishApi::UploadPartitions(
@@ -145,18 +120,6 @@ CancellationToken PublishApi::UploadPartitions(
   return cancel_token;
 }
 
-CancellableFuture<SubmitPublicationResponse> PublishApi::SubmitPublication(
-    const OlpClient& client, const std::string& publication_id,
-    const boost::optional<std::string>& billing_tag) {
-  auto promise = std::make_shared<std::promise<SubmitPublicationResponse>>();
-  auto cancel_token =
-      SubmitPublication(client, publication_id, billing_tag,
-                        [promise](SubmitPublicationResponse response) {
-                          promise->set_value(std::move(response));
-                        });
-  return CancellableFuture<SubmitPublicationResponse>(cancel_token, promise);
-}
-
 CancellationToken PublishApi::SubmitPublication(
     const OlpClient& client, const std::string& publication_id,
     const boost::optional<std::string>& billing_tag,
@@ -188,18 +151,6 @@ CancellationToken PublishApi::SubmitPublication(
       });
 
   return cancel_token;
-}
-
-CancellableFuture<GetPublicationResponse> PublishApi::GetPublication(
-    const OlpClient& client, const std::string& publication_id,
-    const boost::optional<std::string>& billing_tag) {
-  auto promise = std::make_shared<std::promise<GetPublicationResponse>>();
-  auto cancel_token =
-      GetPublication(client, publication_id, billing_tag,
-                     [promise](GetPublicationResponse response) {
-                       promise->set_value(std::move(response));
-                     });
-  return CancellableFuture<GetPublicationResponse>(cancel_token, promise);
 }
 
 CancellationToken PublishApi::GetPublication(
@@ -234,18 +185,6 @@ CancellationToken PublishApi::GetPublication(
       });
 
   return cancel_token;
-}
-
-CancellableFuture<CancelPublicationResponse> PublishApi::CancelPublication(
-    const client::OlpClient& client, const std::string& publication_id,
-    const boost::optional<std::string>& billing_tag) {
-  auto promise = std::make_shared<std::promise<CancelPublicationResponse>>();
-  auto cancel_token =
-      CancelPublication(client, publication_id, billing_tag,
-                        [promise](CancelPublicationResponse response) {
-                          promise->set_value(std::move(response));
-                        });
-  return CancellableFuture<CancelPublicationResponse>(cancel_token, promise);
 }
 
 CancellationToken PublishApi::CancelPublication(

--- a/olp-cpp-sdk-dataservice-write/src/generated/PublishApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/PublishApi.h
@@ -80,29 +80,6 @@ class PublishApi {
    * @param billing_tag Optional. An optional free-form tag which is used for
    * grouping billing records together. If supplied, it must be between 4 - 16
    * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
-   * @return A CancellableFuture containing the InitPublicationResponse.
-   */
-  static client::CancellableFuture<InitPublicationResponse> InitPublication(
-      const client::OlpClient& client, const model::Publication& publication,
-      const boost::optional<std::string>& billing_tag = boost::none);
-
-  /**
-   * @brief Initialize a new publication
-   * Initializes a new publication for publishing metadata. Determines the
-   * publication type based on the provided layer IDs. A publication can only
-   * consist of layer IDs that have the same layer type. For example, you can
-   * have a publication for multiple layers of type `versioned`, but you cannot
-   * have a single publication that publishes to both `versioned` and `stream`
-   * layers. In addition, you may only have one `versioned` or `volatile`
-   * publication in process at a time. You cannot have multiple active
-   * publications to the same catalog for `versioned` and `volatile` layer
-   * types. The body field `versionDependencies` is optional and is used for
-   * `versioned` layers to declare version dependencies.
-   * @param client Instance of OlpClient used to make REST request.
-   * @param publication Fields to initialize a publication.
-   * @param billing_tag Optional. An optional free-form tag which is used for
-   * grouping billing records together. If supplied, it must be between 4 - 16
-   * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
    * @param callback InitPublicationCallback which will be called with the
    * InitPublicationResponse when the operation completes.
    * @return A CancellationToken which can be used to cancel the ongoing
@@ -112,31 +89,6 @@ class PublishApi {
       const client::OlpClient& client, const model::Publication& publication,
       const boost::optional<std::string>& billing_tag,
       InitPublicationCallback callback);
-
-  /**
-   * @brief Upload partitions
-   * Upload partitions to the given layer. Dependending on the publication type,
-   * post processing may be required before the partitions are published. For
-   * better performance batch your partitions (e.g. 1000 per request), rather
-   * than uploading them individually.
-   * @param client Instance of OlpClient used to make REST request.
-   * @param publish_partitions Publication partitions. Data and DataHandle
-   * fields cannot be populated at the same time. See Partition object for more
-   * details on body fields
-   * @param publication_id The ID of publication to publish to.
-   * @param layer_id The ID of the layer to publish to.
-   * @param billing_tag Billing Tag is an optional free-form tag which is used
-   * for grouping billing records together. If supplied, it must be between 4 -
-   * 16 characters and contain only alphanumeric ASCII characters [A-Za-z0-9].
-   * Grouping billing records by billing tag will be available in future
-   * releases.
-   * @return A CancellableFuture containing the UploadPartitionsResponse.
-   */
-  static client::CancellableFuture<UploadPartitionsResponse> UploadPartitions(
-      const client::OlpClient& client,
-      const model::PublishPartitions& publish_partitions,
-      const std::string& publication_id, const std::string& layer_id,
-      const boost::optional<std::string>& billing_tag = boost::none);
 
   /**
    * @brief Upload partitions
@@ -180,26 +132,6 @@ class PublishApi {
    * 16 characters and contain only alphanumeric ASCII characters [A-Za-z0-9].
    * Grouping billing records by billing tag will be available in future
    * releases.
-   *
-   * @return A CancellableFuture containing the SubmitPublicationResponse.
-   */
-  static client::CancellableFuture<SubmitPublicationResponse> SubmitPublication(
-      const client::OlpClient& client, const std::string& publication_id,
-      const boost::optional<std::string>& billing_tag = boost::none);
-
-  /**
-   * @brief Submits a publication
-   * Submits the publication and initiates post processing if necessary.
-   * Publication state becomes `Submitted` directly after submission and
-   * `Succeeded` after successful processing. See Data API Developer’s Guide in
-   * the Documentation section for complete publication states diagram.
-   * @param client Instance of OlpClient used to make REST request.
-   * @param publication_id ID of publication to submit.
-   * @param billing_tag Billing Tag is an optional free-form tag which is used
-   * for grouping billing records together. If supplied, it must be between 4 -
-   * 16 characters and contain only alphanumeric ASCII characters [A-Za-z0-9].
-   * Grouping billing records by billing tag will be available in future
-   * releases.
    * @param client Instance of OlpClient used to make REST request.
    * @param callback SubmitPublicationCallback which will be called with the
    * SubmitPublicationResponse when the operation completes.
@@ -224,26 +156,6 @@ class PublishApi {
    * 16 characters and contain only alphanumeric ASCII characters [A-Za-z0-9].
    * Grouping billing records by billing tag will be available in future
    * releases.
-   *
-   * @return A CancellableFuture containing the GetPublicationResponse.
-   */
-  static client::CancellableFuture<GetPublicationResponse> GetPublication(
-      const client::OlpClient& client, const std::string& publication_id,
-      const boost::optional<std::string>& billing_tag = boost::none);
-
-  /**
-   * @brief Gets a publication
-   * Returns the details of the specified publication. Publication can be in one
-   * of these states: Initialized, Submitted, Cancelled, Failed, Succeeded,
-   * Expired. See Data API Developer’s Guide in the Documentation section for
-   * the publication state diagram.
-   * @param client Instance of OlpClient used to make REST request.
-   * @param publication_id The ID of the publication to retrieve.
-   * @param billing_tag Billing Tag is an optional free-form tag which is used
-   * for grouping billing records together. If supplied, it must be between 4 -
-   * 16 characters and contain only alphanumeric ASCII characters [A-Za-z0-9].
-   * Grouping billing records by billing tag will be available in future
-   * releases.
    * @param callback GetPublicationCallback which will be called with the
    * GetPublicationResponse when the operation completes.
    * @return A CancellationToken which can be used to cancel the ongoing
@@ -253,24 +165,6 @@ class PublishApi {
       const client::OlpClient& client, const std::string& publication_id,
       const boost::optional<std::string>& billing_tag,
       GetPublicationCallback callback);
-
-  /**
-   * @brief Cancels a publication
-   * Cancels the publication.
-   * Publication state becomes `Cancelled`.
-   * @param client Instance of OlpClient used to make REST request.
-   * @param publication_id ID of publication to submit.
-   * @param billing_tag Billing Tag is an optional free-form tag which is used
-   * for grouping billing records together. If supplied, it must be between 4 -
-   * 16 characters and contain only alphanumeric ASCII characters [A-Za-z0-9].
-   * Grouping billing records by billing tag will be available in future
-   * releases.
-   *
-   * @return A CancellableFuture containing the CancelPublicationResponse.
-   */
-  static client::CancellableFuture<CancelPublicationResponse> CancelPublication(
-      const client::OlpClient& client, const std::string& publication_id,
-      const boost::optional<std::string>& billing_tag = boost::none);
 
   /**
    * @brief Cancels a publication


### PR DESCRIPTION
Remove non-used CancellableFuture APIs.

Relates-To: OLPEDGE-1010
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>