### PR TITLE
Change default abi for andorid build

### DIFF
--- a/scripts/android/build.sh
+++ b/scripts/android/build.sh
@@ -21,7 +21,7 @@
 mkdir -p build && cd build
 cmake .. -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake" \
 	-DANDROID_PLATFORM=android-28 \
-	-DANDROID_ABI=arm64-v8a \
+	-DANDROID_ABI=armeabi-v7a \
 	-DOLP_SDK_ENABLE_TESTING=NO \
 	-DOLP_SDK_BUILD_EXAMPLES=ON
 


### PR DESCRIPTION
Change to build script to reproduce build error for 32 bit andorid

Relates-To: OLPSUP-8752
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>