### PR TITLE
Fix incorrect exit code in functional test FV script

### DIFF
--- a/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test.sh
+++ b/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test.sh
@@ -45,3 +45,4 @@ export result=$?
 kill -15 ${SERVER_PID}
 # Waiter for server process to be exited correctly
 wait ${SERVER_PID}
+exit ${result}


### PR DESCRIPTION
Functional tests were exited with error code from last command which is `wait`
Add exit with correct exit code for futher handling in retry mechanism.

Resolves: OLPEDGE-1144

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>