### PR TITLE
Fix 32-bit build, by using same types inside ::max

### DIFF
--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
@@ -222,7 +222,8 @@ static curl_code SslctxFunction(CURL* curl, void* sslctx, void*) {
 
 NetworkCurl::NetworkCurl(size_t max_requests_count)
     : handles_(max_requests_count),
-      static_handle_count_(std::max(1lu, max_requests_count / 4)) {
+      static_handle_count_(
+          std::max(static_cast<size_t>(1u), max_requests_count / 4)) {
   OLP_SDK_LOG_TRACE(kLogTag, "Created NetworkCurl with address="
                                  << this
                                  << ", handles_count=" << max_requests_count);


### PR DESCRIPTION
Add static cast to size_t of unsigned constant inside ::max. Currently
cpp doesn't have built-in literal fir size_t type.

Relates-To: OLPSUP-8752
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>