### PR TITLE
Add condition to run retry in functional NV scripts

### DIFF
--- a/scripts/linux/fv/gitlab_test_fv.sh
+++ b/scripts/linux/fv/gitlab_test_fv.sh
@@ -77,6 +77,7 @@ set -e
 ${FV_HOME}/gitlab-olp-cpp-sdk-integration-test.sh 2>> errors.txt || TEST_FAILURE=1
 
 # Lines below are added for pretty data sum-up and finalize results of this script is case of FAILURE
+set +x  # to avoid dirty output at the end on logs
 if [[ ${TEST_FAILURE} == 1 ]]; then
     export REPORT_COUNT=$(ls ${REPO_HOME}/reports | wc -l)
     if [[ ${REPORT_COUNT} -ne ${EXPECTED_REPORT_COUNT} || ${REPORT_COUNT} == 0 ]]; then

--- a/scripts/linux/nv/gitlab_test_valgrind.sh
+++ b/scripts/linux/nv/gitlab_test_valgrind.sh
@@ -98,23 +98,26 @@ do
             RETRY_COUNT=$((RETRY_COUNT+1))
             echo "This is ${RETRY_COUNT} time retry ..."
 
-            # Run functional tests
-            echo "-----> Calling \"${test_command}\" for ${test_group_name} : "
-            eval "${test_command}"
-            result=$?
-            echo "-----> Finished ${test_group_name} - Result=${result}"
             if [[ ${result} -eq 1 ]]; then
+                # Run functional tests if it failed above
+                echo "-----> Calling \"${test_command}\" for ${test_group_name} : "
+                eval "${test_command}"
+                result=$?
+                echo "-----> Finished ${test_group_name} - Result=${result}"
+            fi
+            if [[ ${result} -eq 1 ]]; then
+                # Return to next loop and do retry
                 TEST_FAILURE=1
                 continue
             else
-                # Return to success
+                # Return to success and exit from loop
                 TEST_FAILURE=0
                 break
             fi
         fi
         break
     done
-    # End of retry part. This part can be removed anytime.
+    # End of retry part. This part can be removed anytime when online tests are stable.
 }
 done
 
@@ -152,6 +155,7 @@ cd ..
 ls -la reports/
 ls -la reports/valgrind
 
+set +x  # to avoid dirty output at the end on logs
 for failreport in $(ls ${REPO_HOME}/reports/*.xml)
 do
     echo "Parsing ${failreport} ..."


### PR DESCRIPTION
Currently functional tests run twice every time on NV because condition absent.
Added more comments, added set +x to avoid dirty output at the end on logs.

Relates-To: OLPEDGE-1144

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>