### PR TITLE
Adapt Blob API to sync CallApi of OlpClient

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/generated/api/BlobApi.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/BlobApi.h
@@ -29,7 +29,8 @@
 namespace olp {
 namespace client {
 class OlpClient;
-}
+class CancellationContext;
+}  // namespace client
 
 namespace dataservice {
 namespace read {
@@ -39,14 +40,13 @@ namespace read {
 class BlobApi {
  public:
   using DataResponse = client::ApiResponse<model::Data, client::ApiError>;
-  using DataResponseCallback = std::function<void(DataResponse)>;
 
   /**
-   * @brief Call to asynchronously retrieve a data blob for specified handle.
+   * @brief Retrieves a data blob for specified handle.
    * @param client Instance of OlpClient used to make REST request.
-   * @param layerId Layer id.
-   * @param dataHandle Indentifies a specific blob.
-   * @param billingTag An optional free-form tag which is used for grouping
+   * @param layer_id Layer id.
+   * @param data_handle Indentifies a specific blob.
+   * @param billing_tag An optional free-form tag which is used for grouping
    * billing records together. If supplied, it must be between 4 - 16
    * characters, contain only alpha/numeric ASCII characters  [A-Za-z0-9].
    * @param range Use this parameter to resume download of a large response for
@@ -56,15 +56,16 @@ class BlobApi {
    * only supports a single byte range. The range parameter can also be
    * specified as a query parameter, i.e. range=bytes=10-. For volatile layers
    * use the pagination links returned in the response body.
-   * @param callback A callback function to invoke with the data response.
+   * @param context A CancellationContext, which can be used to cancel the pending request.
    *
-   * @return The cancellation token.
+   * @return Data response.
    */
-
-  static client::CancellationToken GetBlob(
-      const client::OlpClient& client, const std::string& layerId,
-      const std::string& dataHandle, boost::optional<std::string> billingTag,
-      boost::optional<std::string> range, const DataResponseCallback& callback);
+  static DataResponse GetBlob(const client::OlpClient& client,
+                              const std::string& layer_id,
+                              const std::string& data_handle,
+                              boost::optional<std::string> billing_tag,
+                              boost::optional<std::string> range,
+                              const client::CancellationContext& context);
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/VolatileBlobApi.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/VolatileBlobApi.h
@@ -29,6 +29,7 @@
 namespace olp {
 namespace client {
 class OlpClient;
+class CancellationContext;
 }
 
 namespace dataservice {
@@ -39,26 +40,24 @@ namespace read {
 class VolatileBlobApi {
  public:
   using DataResponse = client::ApiResponse<model::Data, client::ApiError>;
-  using DataResponseCallback = std::function<void(DataResponse)>;
 
   /**
-   * @brief Call to asynchronously retrieve a volatile data blob for specified
-   * handle.
+   * @brief Retrieves a volatile data blob for specified handle.
    * @param client Instance of OlpClient used to make REST request.
-   * @param layerId Layer id.
-   * @param dataHandle Indentifies a specific blob.
-   * @param billingTag An optional free-form tag which is used for grouping
+   * @param layer_id Layer id.
+   * @param data_handle Identifies a specific blob.
+   * @param billing_tag An optional free-form tag which is used for grouping
    * billing records together. If supplied, it must be between 4 - 16
    * characters, contain only alpha/numeric ASCII characters  [A-Za-z0-9].
-   * @param callback A callback function to invoke with the data response.
+   * @param context A CancellationContext, which can be used to cancel request.
    *
-   * @return The cancellation token.
+   * @return Data response.
    */
-
-  static client::CancellationToken GetVolatileBlob(
-      const client::OlpClient& client, const std::string& layerId,
-      const std::string& dataHandle, boost::optional<std::string> billingTag,
-      const DataResponseCallback& callback);
+  static DataResponse GetVolatileBlob(const client::OlpClient& client,
+                                      const std::string& layer_id,
+                                      const std::string& data_handle,
+                                      boost::optional<std::string> billing_tag,
+                                      const client::CancellationContext& context);
 };
 
 }  // namespace read

--- a/tests/functional/olp-cpp-sdk-dataservice-read/ApiTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/ApiTest.cpp
@@ -274,18 +274,12 @@ TEST_F(ApiTest, GetBlob) {
       << ApiErrorToString(client_response.GetError());
   auto blob_client = client_response.GetResult();
 
-  std::promise<olp::dataservice::read::BlobApi::DataResponse> data_promise;
-  auto data_callback =
-      [&data_promise](
-          olp::dataservice::read::BlobApi::DataResponse data_response) {
-        data_promise.set_value(data_response);
-      };
+  olp::client::CancellationContext context;
 
   auto start_time = std::chrono::high_resolution_clock::now();
-  olp::dataservice::read::BlobApi::GetBlob(
+  auto data_response = olp::dataservice::read::BlobApi::GetBlob(
       blob_client, "testlayer", "d5d73b64-7365-41c3-8faf-aa6ad5bab135",
-      boost::none, boost::none, data_callback);
-  auto data_response = data_promise.get_future().get();
+      boost::none, boost::none, context);
   auto end = std::chrono::high_resolution_clock::now();
 
   std::chrono::duration<double> time = end - start_time;
@@ -308,19 +302,10 @@ TEST_F(ApiTest, DISABLED_GetVolatileBlob) {
   ASSERT_TRUE(client_response.IsSuccessful())
       << ApiErrorToString(client_response.GetError());
   auto volatile_blob_client = client_response.GetResult();
-
-  std::promise<olp::dataservice::read::BlobApi::DataResponse> data_promise;
-  auto data_callback =
-      [&data_promise](
-          olp::dataservice::read::BlobApi::DataResponse data_response) {
-        data_promise.set_value(data_response);
-      };
-
   auto start_time = std::chrono::high_resolution_clock::now();
-  olp::dataservice::read::VolatileBlobApi::GetVolatileBlob(
+  auto data_response = olp::dataservice::read::VolatileBlobApi::GetVolatileBlob(
       volatile_blob_client, "testlayer", "d5d73b64-7365-41c3-8faf-aa6ad5bab135",
-      boost::none, data_callback);
-  auto data_response = data_promise.get_future().get();
+      boost::none, {});
   auto end = std::chrono::high_resolution_clock::now();
 
   std::chrono::duration<double> time = end - start_time;


### PR DESCRIPTION
Adapt implementation to use sync CallApi of OlpClient. Fix tests to use
fixed Blob api. Fix code style.

Relates-To: OLPEDGE-1168
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>