### PR TITLE
Adapt Lookup API to sync CallApi of OlpClient

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/generated/api/PlatformApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/PlatformApi.cpp
@@ -34,15 +34,9 @@ namespace olp {
 namespace dataservice {
 namespace read {
 
-client::CancellationToken PlatformApi::GetApis(
-    std::shared_ptr<client::OlpClient> client, const std::string& service,
-    const std::string& serviceVersion, const ApisCallback& callback) {
-  return GetApis(*client, service, serviceVersion, callback);
-}
-
-client::CancellationToken PlatformApi::GetApis(
+PlatformApi::ApisResponse PlatformApi::GetApis(
     const client::OlpClient& client, const std::string& service,
-    const std::string& service_version, const ApisCallback& callback) {
+    const std::string& service_version, const client::CancellationContext& context) {
   std::multimap<std::string, std::string> header_params;
   header_params.insert(std::make_pair("Accept", "application/json"));
   std::multimap<std::string, std::string> query_params;
@@ -51,24 +45,16 @@ client::CancellationToken PlatformApi::GetApis(
   std::string platform_url =
       "/platform/apis/" + service + "/" + service_version;
 
-  client::NetworkAsyncCallback network_callback =
-      [callback](client::HttpResponse response) {
-        if (response.status != 200) {
-          callback(ApisResponse(
-              client::ApiError(response.status, response.response.str())));
-        } else {
-          // parse the services
-          // TODO catch any exception and return as Error
-          callback(
-              ApisResponse(parser::parse<olp::dataservice::read::model::Apis>(
-                  response.response)));
-        }
-      };
-
-  return client.CallApi(platform_url, "GET", query_params, header_params,
-                        form_params, nullptr, "", network_callback);
+  auto response =
+      client.CallApi(platform_url, "GET", query_params, header_params,
+                     form_params, nullptr, "", context);
+  if (response.status != http::HttpStatusCode::OK) {
+    return ApisResponse(
+        client::ApiError(response.status, response.response.str()));
+  }
+  return ApisResponse(
+      parser::parse<olp::dataservice::read::model::Apis>(response.response));
 }
-
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/PlatformApi.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/PlatformApi.h
@@ -29,7 +29,8 @@
 namespace olp {
 namespace client {
 class OlpClient;
-}
+class CancellationContext;
+}  // namespace client
 
 namespace dataservice {
 namespace read {
@@ -39,37 +40,20 @@ namespace read {
 class PlatformApi {
  public:
   using ApisResponse = client::ApiResponse<model::Apis, client::ApiError>;
-  using ApisCallback = std::function<void(ApisResponse)>;
-
-  /**
-   * @deprecated
-   * @brief Call to lookup platform base urls.
-   * @param client Instance of OlpClient used to make REST request.
-   * @param service Name of the service.
-   * @param serviceVersion Version of the service.
-   * @param A callback function to invoke with the collection of Api services
-   * that match the parameters.
-   *
-   * @return The cancellation token.
-   */
-  static client::CancellationToken GetApis(
-      std::shared_ptr<client::OlpClient> client, const std::string& service,
-      const std::string& serviceVersion, const ApisCallback& callback);
 
   /**
    * @brief Call to lookup platform base urls.
    * @param client Instance of OlpClient used to make REST request.
    * @param service Name of the service.
    * @param service_version Version of the service.
-   * @param A callback function to invoke with the collection of Api services
-   * that match the parameters.
+   * @param context A CancellationContext, which can be used to cancel any pending request.
    *
-   * @return The cancellation token.
+   * @return The Apis response.
    */
-  static client::CancellationToken GetApis(const client::OlpClient& client,
-                                           const std::string& service,
-                                           const std::string& service_version,
-                                           const ApisCallback& callback);
+  static ApisResponse GetApis(const client::OlpClient& client,
+                              const std::string& service,
+                              const std::string& service_version,
+                              const client::CancellationContext& context);
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/ResourcesApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/ResourcesApi.cpp
@@ -33,41 +33,27 @@ namespace olp {
 namespace dataservice {
 namespace read {
 
-client::CancellationToken ResourcesApi::GetApis(
-    std::shared_ptr<client::OlpClient> client, const std::string& hrn,
-    const std::string& service, const std::string& service_version,
-    const ApisCallback& callback) {
-  return GetApis(*client, hrn, service, service_version, callback);
-}
-
-client::CancellationToken ResourcesApi::GetApis(
+ResourcesApi::ApisResponse ResourcesApi::GetApis(
     const client::OlpClient& client, const std::string& hrn,
     const std::string& service, const std::string& service_version,
-    const ApisCallback& callback) {
+    const client::CancellationContext& context) {
   std::multimap<std::string, std::string> header_params;
-  header_params.insert(std::make_pair("Accept", "application/json"));
+  header_params.emplace("Accept", "application/json");
   std::multimap<std::string, std::string> query_params;
   std::multimap<std::string, std::string> form_params;
-
   // scan apis at resource endpoint
   std::string resource_url =
       "/resources/" + hrn + "/apis/" + service + "/" + service_version;
+  auto response =
+      client.CallApi(resource_url, "GET", query_params, header_params,
+                     form_params, nullptr, "", context);
 
-  client::NetworkAsyncCallback network_callback =
-      [callback](client::HttpResponse response) {
-        if (response.status != 200) {
-          callback(ApisResponse(
-              client::ApiError(response.status, response.response.str())));
-        } else {
-          // parse the services
-          // TODO catch any exception and return as Error
-          callback(
-              ApisResponse(parser::parse<olp::dataservice::read::model::Apis>(
-                  response.response)));
-        }
-      };
-  return client.CallApi(resource_url, "GET", query_params, header_params,
-                        form_params, nullptr, "", network_callback);
+  if (response.status != http::HttpStatusCode::OK) {
+    return ApisResponse(
+        client::ApiError(response.status, response.response.str()));
+  }
+  return ApisResponse(
+      parser::parse<olp::dataservice::read::model::Apis>(response.response));
 }
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/ResourcesApi.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/ResourcesApi.h
@@ -29,7 +29,8 @@
 namespace olp {
 namespace client {
 class OlpClient;
-}
+class CancellationContext;
+}  // namespace client
 
 namespace dataservice {
 namespace read {
@@ -39,24 +40,6 @@ namespace read {
 class ResourcesApi {
  public:
   using ApisResponse = client::ApiResponse<model::Apis, client::ApiError>;
-  using ApisCallback = std::function<void(ApisResponse)>;
-
-  /**
-   * @deprecated
-   * @brief Call to resources service base urls.
-   * @param client Instance of OlpClient used to make REST request.
-   * @param service Name of the service.
-   * @param service_version Version of the service.
-   * @param hrn Full catalog name.
-   * @param A callback function to invoke with the collection of Api services
-   * that match the parameters.
-   *
-   * @return The cancellation token.
-   */
-  static client::CancellationToken GetApis(
-      std::shared_ptr<client::OlpClient> client, const std::string& hrn,
-      const std::string& service, const std::string& service_version,
-      const ApisCallback& callback);
 
   /**
    * @brief Call to resources service base urls.
@@ -64,16 +47,15 @@ class ResourcesApi {
    * @param service Name of the service.
    * @param service_version Version of the service.
    * @param hrn Full catalog name.
-   * @param A callback function to invoke with the collection of Api services
-   * that match the parameters.
+   * @param context A CancellationContext, which can be used to cancel any pending request.
    *
-   * @return The cancellation token.
+   * @return The Apis response.
    */
-  static client::CancellationToken GetApis(const client::OlpClient& client,
-                                           const std::string& hrn,
-                                           const std::string& service,
-                                           const std::string& service_version,
-                                           const ApisCallback& callback);
+  static ApisResponse GetApis(const client::OlpClient& client,
+                              const std::string& hrn,
+                              const std::string& service,
+                              const std::string& service_version,
+                              const client::CancellationContext& context);
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/VolatileBlobApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/VolatileBlobApi.cpp
@@ -50,7 +50,7 @@ CancellationToken VolatileBlobApi::GetVolatileBlob(
   NetworkAsyncCallback callback =
       [dataResponseCallback](client::HttpResponse response) {
         auto str_response = response.response.str();
-        if (response.status != 200) {
+        if (response.status != http::HttpStatusCode::OK) {
           dataResponseCallback(ApiError(response.status, str_response));
         } else {
           dataResponseCallback(


### PR DESCRIPTION
Adapt implementation to use sync CallApi of OlpClient. Fix code style.

Relates-To: OLPEDGE-1168
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>