### PR TITLE
Add small fix to retry mechanism for exit on success

### DIFF
--- a/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test.sh
+++ b/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test.sh
@@ -45,4 +45,5 @@ export result=$?
 kill -15 ${SERVER_PID}
 # Waiter for server process to be exited correctly
 wait ${SERVER_PID}
+echo "Functional test finished with status: ${result}"
 exit ${result}

--- a/scripts/linux/fv/gitlab_test_fv.sh
+++ b/scripts/linux/fv/gitlab_test_fv.sh
@@ -55,12 +55,16 @@ do
         break
     fi
 
-    RETRY_COUNT=$((RETRY_COUNT+1))
-    echo "This is ${RETRY_COUNT} time retry ..."
+    if [[ ${RETRY_COUNT} -eq 0 ]]; then
+        echo "This is ${RETRY_COUNT} time run ..."
+    else
+        RETRY_COUNT=$((RETRY_COUNT+1))
+        echo "This is ${RETRY_COUNT} time retry ..."
+    fi
 
     # Run functional tests
     ${FV_HOME}/gitlab-olp-cpp-sdk-functional-test.sh 2>> errors.txt
-    if [[ $? -eq 1 || ${result} -eq 1 ]]; then
+    if [[ $? -eq 1 ]]; then
         TEST_FAILURE=1
         continue
     else


### PR DESCRIPTION
Result variable was storing last failure so not needed for next retry in case we got 0.
Fix minor echo messages for first run of test.

Relates-To: OLPEDGE-1144

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>