### PR TITLE
Fix bash retry mechanism bug when loop becomes infinite

### DIFF
--- a/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test.sh
+++ b/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test.sh
@@ -19,7 +19,7 @@
 
 
 # Start local server
-node $REPO_HOME/tests/utils/mock_server/server.js & export SERVER_PID=$!
+node $REPO_HOME/tests/utils/mock_server/server.js & SERVER_PID=$!
 
 # Node can start server in 1 second, but not faster.
 # Add waiter for server to be started. No other way to solve that.
@@ -30,7 +30,7 @@ do
         set +e
         curl -s http://localhost:3000
         RC=$?
-        sleep 0.15
+        sleep 0.2
         set -e
 done
 
@@ -39,11 +39,12 @@ source $FV_HOME/olp-cpp-sdk-functional-test.variables
 $REPO_HOME/build/tests/functional/olp-cpp-sdk-functional-tests \
     --gtest_output="xml:$REPO_HOME/reports/olp-functional-test-report.xml" \
     --gtest_filter="-ArcGisAuthenticationTest.SignInArcGis":"FacebookAuthenticationTest.SignInFacebook"
-export result=$?
+result=$?
+echo "Functional test finished with status: ${result}"
 
 # Kill local server
-kill -15 ${SERVER_PID}
+# Some workarounds applied below due to unstable nodejs mock_server shutdown
+kill -15 ${SERVER_PID} || wait
 # Waiter for server process to be exited correctly
-wait ${SERVER_PID}
-echo "Functional test finished with status: ${result}"
+wait ${SERVER_PID} || wait
 exit ${result}

--- a/scripts/linux/fv/gitlab_test_fv.sh
+++ b/scripts/linux/fv/gitlab_test_fv.sh
@@ -49,22 +49,24 @@ ${FV_HOME}/gitlab-olp-cpp-sdk-dataservice-write-test.sh 2>> errors.txt || TEST_F
 set +e
 while true
 do
-    # Stop after 3 retry
-    if [[ ${RETRY_COUNT} -eq 3 ]]; then
+    # Stop after 2rd retry
+    if [[ ${RETRY_COUNT} -eq 2 ]]; then
         echo "Reach limit (${RETRY_COUNT}) of retries ..."
         break
     fi
 
     if [[ ${RETRY_COUNT} -eq 0 ]]; then
-        echo "This is ${RETRY_COUNT} time run ..."
+        echo "This is (${RETRY_COUNT}) time run ..."
     else
         RETRY_COUNT=$((RETRY_COUNT+1))
-        echo "This is ${RETRY_COUNT} time retry ..."
+        sleep 10
+        echo "This is (${RETRY_COUNT}) time retry ..."
     fi
 
     # Run functional tests
-    ${FV_HOME}/gitlab-olp-cpp-sdk-functional-test.sh 2>> errors.txt
+    ${FV_HOME}/gitlab-olp-cpp-sdk-functional-test.sh
     if [[ $? -eq 1 ]]; then
+        # Functional test failed with exit code 1 means some tests failed
         TEST_FAILURE=1
         continue
     else
@@ -74,7 +76,7 @@ do
     fi
 done
 set -e
-# End of retry part. This part can be removed anytime.
+# End of retry part. This part can be removed any time later or after all online tests are stable.
 
 
 # Run integration tests


### PR DESCRIPTION
Bug reproduced only on CI when sometimes functional tests run in infinite loop in FV pipelines.
Removed export as it's not needed and causing issue when retry happens.
Decreased retry count limit to 2.

Resolves: OLPEDGE-1245

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>