### PR TITLE
Added a protected disk cache instance to DefaultCache

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
@@ -54,8 +54,8 @@ class CORE_API DefaultCache : public KeyValueCache {
   /**
    * @brief Open the cache to start read/write operations.
    *
-   * @return StorageOpenResult if there were problems opening the path on the
-   * disk.
+   * @return StorageOpenResult if there were problems opening any of the
+   * provided pathes on the disk.
    */
   StorageOpenResult Open();
 
@@ -129,11 +129,11 @@ class CORE_API DefaultCache : public KeyValueCache {
 
  private:
   CacheSettings settings_;
-  bool is_open_{false};
+  bool is_open_;
   std::unique_ptr<InMemoryCache> memory_cache_;
-  std::unique_ptr<DiskCache> disk_cache_;
+  std::unique_ptr<DiskCache> mutable_cache_;
+  std::unique_ptr<DiskCache> protected_cache_;
   std::mutex cache_lock_;
-  // TODO: leveldb cache
 };
 
 }  // namespace cache

--- a/olp-cpp-sdk-core/tests/cache/DefaultCacheTest.cpp
+++ b/olp-cpp-sdk-core/tests/cache/DefaultCacheTest.cpp
@@ -20,6 +20,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <fstream>
 #include <string>
 #include <thread>
 
@@ -194,9 +195,9 @@ TEST(DefaultCacheTest, ExpiredMemTest) {
   ASSERT_TRUE(cache.Clear());
 }
 
-TEST(DefaultCacheTest, BadPath) {
+TEST(DefaultCacheTest, BadPathMutable) {
   olp::cache::CacheSettings settings;
-  settings.disk_path_mutable = std::string("/////this/is/a/bad/path");
+  settings.disk_path_mutable = std::string("/////this/is/a/bad/mutable/path");
   olp::cache::DefaultCache cache(settings);
   ASSERT_EQ(olp::cache::DefaultCache::OpenDiskPathFailure, cache.Open());
 
@@ -208,6 +209,23 @@ TEST(DefaultCacheTest, BadPath) {
       cache.Get("key1", [](const std::string& data) { return data; });
   ASSERT_FALSE(key1DataRead.empty());
   ASSERT_EQ(key1DataString, boost::any_cast<std::string>(key1DataRead));
+}
+
+TEST(DefaultCacheTest, BadPathProtected) {
+  olp::cache::CacheSettings settings;
+  settings.disk_path_protected =
+      std::string("/////this/is/a/bad/protected/path");
+  olp::cache::DefaultCache cache(settings);
+  ASSERT_EQ(olp::cache::DefaultCache::OpenDiskPathFailure, cache.Open());
+
+  // Verify that in-memory still works after bad path was set for memcache
+  std::string key1_data_string{"this is key1's data"};
+  cache.Put("key1", key1_data_string, [=]() { return key1_data_string; },
+            std::numeric_limits<time_t>::max());
+  auto key1_data_read =
+      cache.Get("key1", [](const std::string& data) { return data; });
+  ASSERT_FALSE(key1_data_read.empty());
+  ASSERT_EQ(key1_data_string, boost::any_cast<std::string>(key1_data_read));
 }
 
 TEST(DefaultCacheTest, AlreadyInUsePath) {

--- a/tests/performance/MemoryTest.cpp
+++ b/tests/performance/MemoryTest.cpp
@@ -407,7 +407,7 @@ TestConfiguration ShortRunningTestWithMemoryCache() {
  * Short 5 minutes test to collect SDK allocations with both in memory cache
  * and disk cache.
  */
-TestConfiguration ShortRunningTestWithDiskCache() {
+TestConfiguration ShortRunningTestWithMutableCache() {
   using namespace olp;
 
   cache::CacheSettings settings;
@@ -429,7 +429,7 @@ std::vector<TestConfiguration> Configurations() {
   std::vector<TestConfiguration> configurations;
   configurations.emplace_back(ShortRunningTestWithNullCache());
   configurations.emplace_back(ShortRunningTestWithMemoryCache());
-  configurations.emplace_back(ShortRunningTestWithDiskCache());
+  configurations.emplace_back(ShortRunningTestWithMutableCache());
   configurations.emplace_back(LongRunningTest());
   return configurations;
 }


### PR DESCRIPTION
Attempt to initiate the protected cache if CacheSettings::disk_path_protected
is provided. Returns OpenDiskPathFailure if the provided path is incorrect.
Added tests to cover the protected cache initializing.

Resolves: OLPEDGE-1041

Signed-off-by: Dmytro Poberezhnyi <ext-dmytro.poberezhnyi@here.com>