### PR TITLE
Replaced async version of dataservice-read QueryApi with sync

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.h
@@ -24,9 +24,10 @@
 
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>
+#include <olp/core/client/CancellationContext.h>
 #include <boost/optional.hpp>
-#include "olp/dataservice/read/model/Partitions.h"
 #include "generated/model/Index.h"
+#include "olp/dataservice/read/model/Partitions.h"
 
 namespace olp {
 namespace client {
@@ -42,72 +43,75 @@ class QueryApi {
  public:
   using PartitionsResponse =
       client::ApiResponse<model::Partitions, client::ApiError>;
-  using PartitionsCallback = std::function<void(PartitionsResponse)>;
+  using QuadTreeIndexResponse =
+      client::ApiResponse<model::Index, client::ApiError>;
 
   /**
-   * @brief Call to asynchronously retrieve metadata for specified partitions in
+   * @brief Call to synchronously retrieve metadata for specified partitions in
    * a specified layer.
    * @param client Instance of OlpClient used to make REST request.
-   * @param layerId Layer id.
+   * @param layer_id Layer id.
    * @param partition Partition ids to use for filtering. You can specify
    * multiple partitions by using this parameter multiple times. Maximum allowed
    * partitions ids per call is 100.
    * @param version Specify the version for a versioned layer. Doesn't apply for
    * other layer types.
-   * @param additionalFields Additional fields - dataSize, checksum,
+   * @param additional_fields Additional fields - dataSize, checksum,
    * compressedDataSize.
-   * @param billingTag An optional free-form tag which is used for grouping
+   * @param billing_tag An optional free-form tag which is used for grouping
    * billing records together. If supplied, it must be between 4 - 16
    * characters, contain only alpha/numeric ASCII characters  [A-Za-z0-9].
    * @param callback A callback function to invoke with the partitions
    * response.
-   *
-   * @return The cancellation token.
+   * @param context A CancellationContext instance which can be used to cancel
+   * call of this method.
+   * @param The result of this operation as a client::ApiResponse object with \c
+   * model::Partitions as a result.
    */
-  static client::CancellationToken GetPartitionsbyId(
-      const client::OlpClient& client, const std::string& layerId,
+  static PartitionsResponse GetPartitionsbyId(
+      const client::OlpClient& client, const std::string& layer_id,
       const std::vector<std::string>& partition,
       boost::optional<int64_t> version,
-      boost::optional<std::vector<std::string>> additionalFields,
-      boost::optional<std::string> billingTag,
-      const PartitionsCallback& callback);
-
-  using QuadTreeIndexResponse =
-      client::ApiResponse<model::Index, client::ApiError>;
-  using QuadTreeIndexCallback = std::function<void(QuadTreeIndexResponse)>;
+      boost::optional<std::vector<std::string>> additional_fields,
+      boost::optional<std::string> billing_tag,
+      client::CancellationContext context);
 
   /**
    * @brief Gets index metadata
-   * Gets metadata for the requested index. Only available for layers where the
-   * partitioning scheme is &#x60;heretile&#x60;.
+   * Gets metadata synchronously for the requested index. Only available for
+   * layers where the partitioning scheme is &#x60;heretile&#x60;.
    *
-   * @param layerId The ID of the layer specified in the request.
+   * @param layer_id The ID of the layer specified in the request.
    * Content of this parameter must refer to a valid layer already configured
    * in the catalog configuration. Exactly one layer ID must be
    * provided.
    * @param version The version of the catalog against
    * which to run the query. Must be a valid catalog version.
-   * @param quadKey The geometric area specified by an index in the request,
+   * @param quad_key The geometric area specified by an index in the request,
    * represented as a HERE tile
    * @param depth The recursion depth
    * of the response. If set to 0, the response includes only data for the
-   * quadKey specified in the request. In this way, depth describes the maximum
+   * quad_key specified in the request. In this way, depth describes the maximum
    * length of the subQuadKeys in the response. The maximum allowed value for
    * the depth parameter is 4.
-   * @param additionalFields Additional fields - &#x60;dataSize&#x60;,
+   * @param additional_fields Additional fields - &#x60;dataSize&#x60;,
    * &#x60;checksum&#x60;, &#x60;compressedDataSize&#x60;
-   * @param billingTag Billing Tag is an optional free-form tag used to
+   * @param billing_tag Billing Tag is an optional free-form tag used to
    * group billing records together. If supplied, it must be between 4 - 16
    * characters and  contain only alphanumeric ASCII characters  [A-Za-z0-9].
    * Grouping billing records by billing tag will be available in a future
    * release.
+   * @param context A CancellationContext instance which can be used to cancel
+   * call of this method.
+   * @param The result of this operation as a client::ApiResponse object with \c
+   * model::Index as a result
    **/
-  static client::CancellationToken QuadTreeIndex(
-      const client::OlpClient& client, const std::string& layerId,
-      int64_t version, const std::string& quadKey, int32_t depth,
-      boost::optional<std::vector<std::string>> additionalFields,
-      boost::optional<std::string> billingTag,
-      const QuadTreeIndexCallback& callback);
+  static QuadTreeIndexResponse QuadTreeIndex(
+      const client::OlpClient& client, const std::string& layer_id,
+      int64_t version, const std::string& quad_key, int32_t depth,
+      boost::optional<std::vector<std::string>> additional_fields,
+      boost::optional<std::string> billing_tag,
+      client::CancellationContext context);
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
@@ -251,50 +251,9 @@ PartitionsResponse PartitionsRepository::GetPartitionById(
 
   const client::OlpClient& client = query_api.GetResult();
 
-  Condition condition{};
-
-  // when the network operation took too much time we cancel it and exit
-  // execution, to make sure that network callback will not access dangling
-  // references we protect them with atomic bool flag.
-  auto flag = std::make_shared<std::atomic_bool>(true);
-
-  PartitionsResponse query_response;
-  auto query_client_callback = [&, flag](PartitionsResponse response) {
-    if (flag->exchange(false)) {
-      query_response = std::move(response);
-      condition.Notify();
-    }
-  };
-
-  cancellation_context.ExecuteOrCancelled(
-      [&, flag]() {
-        auto token = QueryApi::GetPartitionsbyId(
-            client, layer, partitions, version, boost::none,
-            data_request.GetBillingTag(), std::move(query_client_callback));
-        return client::CancellationToken([&, token, flag]() {
-          if (flag->exchange(false)) {
-            token.Cancel();
-            condition.Notify();
-          }
-        });
-      },
-      [&]() { condition.Notify(); });
-
-  if (!condition.Wait(timeout)) {
-    cancellation_context.CancelOperation();
-    OLP_SDK_LOG_INFO_F(kLogTag, "timeout");
-    return client::ApiError(client::ErrorCode::RequestTimeout,
-                            "Network request timed out.");
-  }
-
-  flag->store(false);
-
-  if (cancellation_context.IsCancelled()) {
-    // We can't use api response here because it could potentially be
-    // uninitialized.
-    return client::ApiError(client::ErrorCode::Cancelled,
-                            "Operation cancelled.");
-  }
+  PartitionsResponse query_response = QueryApi::GetPartitionsbyId(
+      client, layer, partitions, version, boost::none,
+      data_request.GetBillingTag(), cancellation_context);
 
   if (query_response.IsSuccessful()) {
     OLP_SDK_LOG_INFO_F(kLogTag, "put '%s' to cache",

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -218,33 +218,12 @@ SubQuadsResponse PrefetchTilesRepository::GetSubQuads(
   auto tile_key = tile.ToHereTile();
   auto version = request.GetVersion().get();
 
-  context.ExecuteOrCancelled(
-      [&] {
-        OLP_SDK_LOG_INFO_F(kLogTag,
-                           "GetSubQuads execute(%s, %" PRId64 ", %" PRId32 ")",
-                           tile_key.c_str(), version, depth);
-
-        return QueryApi::QuadTreeIndex(
-            query_api.GetResult(), layer_id, version, tile_key, depth,
-            boost::none, request.GetBillingTag(),
-            [=](QuadTreeIndexResponse response) {
-              promise->set_value(std::move(response));
-            });
-      },
-      [=]() {
-        OLP_SDK_LOG_INFO_F(
-            kLogTag, "GetSubQuads cancelled(%s, %" PRId64 ", %" PRId32 ")",
-            tile_key.c_str(), version, depth);
-        promise->set_value({{ErrorCode::Cancelled, "Cancelled", true}});
-      });
-
-  // Wait for response
-  auto future = promise->get_future();
-  auto quad_tree = future.get();
-
-  if (context.IsCancelled()) {
-    return client::ApiError{ErrorCode::Cancelled, "Cancelled", true};
-  }
+  OLP_SDK_LOG_INFO_F(kLogTag,
+                     "GetSubQuads execute(%s, %" PRId64 ", %" PRId32 ")",
+                     tile_key.c_str(), version, depth);
+  auto quad_tree = QueryApi::QuadTreeIndex(
+      query_api.GetResult(), layer_id, version, tile_key, depth, boost::none,
+      request.GetBillingTag(), context);
 
   if (!quad_tree.IsSuccessful()) {
     OLP_SDK_LOG_INFO_F(kLogTag,

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -41,7 +41,8 @@ using namespace client;
 using namespace dataservice::read;
 using namespace olp::tests::common;
 
-const std::string kCatalog = "hrn:here:data::olp-here-test:hereos-internal-test-v2";
+const std::string kCatalog =
+    "hrn:here:data::olp-here-test:hereos-internal-test-v2";
 const std::string kLayerId = "test_layer";
 const std::string kPartitionId = "1111";
 constexpr int kVersion = 4;
@@ -403,6 +404,7 @@ TEST(PartitionsRepositoryTest, GetPartitionById) {
               olp::client::ErrorCode::RequestTimeout);
     Mock::VerifyAndClearExpectations(network.get());
   }
+
   {
     SCOPED_TRACE("Network request timed out at partition state");
     setup_online_only_mocks();

--- a/tests/functional/olp-cpp-sdk-dataservice-read/ApiTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/ApiTest.cpp
@@ -169,21 +169,13 @@ TEST_F(ApiTest, GetPartitionById) {
 
   {
     SCOPED_TRACE("Test with 2 partitions");
-    std::promise<olp::dataservice::read::MetadataApi::PartitionsResponse>
-        partitions_promise;
-    auto partitions_callback =
-        [&partitions_promise](
-            olp::dataservice::read::MetadataApi::PartitionsResponse
-                partitions_response) {
-          partitions_promise.set_value(partitions_response);
-        };
 
     auto start_time = std::chrono::high_resolution_clock::now();
     std::vector<std::string> partitions = {"269", "270"};
-    olp::dataservice::read::QueryApi::GetPartitionsbyId(
-        query_client, "testlayer", partitions, 1, boost::none, boost::none,
-        partitions_callback);
-    auto partitions_response = partitions_promise.get_future().get();
+    auto partitions_response =
+        olp::dataservice::read::QueryApi::GetPartitionsbyId(
+            query_client, "testlayer", partitions, 1, boost::none, boost::none,
+            olp::client::CancellationContext{});
     auto end = std::chrono::high_resolution_clock::now();
 
     std::chrono::duration<double> time = end - start_time;
@@ -201,22 +193,14 @@ TEST_F(ApiTest, GetPartitionById) {
 
   {
     SCOPED_TRACE("Test with single partition");
-    std::promise<olp::dataservice::read::MetadataApi::PartitionsResponse>
-        partitions_promise;
-    auto partitions_callback =
-        [&partitions_promise](
-            olp::dataservice::read::MetadataApi::PartitionsResponse
-                partitions_response) {
-          partitions_promise.set_value(partitions_response);
-        };
 
     auto start_time = std::chrono::high_resolution_clock::now();
     std::vector<std::string> partitions = {"270"};
     std::vector<std::string> additional_fields = {"checksum", "dataSize"};
-    olp::dataservice::read::QueryApi::GetPartitionsbyId(
-        query_client, "testlayer", partitions, 1, additional_fields,
-        boost::none, partitions_callback);
-    auto partitions_response = partitions_promise.get_future().get();
+    auto partitions_response =
+        olp::dataservice::read::QueryApi::GetPartitionsbyId(
+            query_client, "testlayer", partitions, 1, additional_fields,
+            boost::none, olp::client::CancellationContext{});
     auto end = std::chrono::high_resolution_clock::now();
 
     std::chrono::duration<double> time = end - start_time;
@@ -391,19 +375,10 @@ TEST_F(ApiTest, QuadTreeIndex) {
   std::string quad_key("5904591");
   int32_t depth = 2;
 
-  std::promise<olp::dataservice::read::QueryApi::QuadTreeIndexResponse>
-      index_promise;
-  auto quad_tree_index_callback =
-      [&index_promise](
-          olp::dataservice::read::QueryApi::QuadTreeIndexResponse response) {
-        index_promise.set_value(response);
-      };
-
   auto start_time = std::chrono::high_resolution_clock::now();
-  auto cancel_fn = olp::dataservice::read::QueryApi::QuadTreeIndex(
+  auto index_response = olp::dataservice::read::QueryApi::QuadTreeIndex(
       query_client, layer_id, version, quad_key, depth, boost::none,
-      boost::none, quad_tree_index_callback);
-  auto index_response = index_promise.get_future().get();
+      boost::none, olp::client::CancellationContext{});
   auto end = std::chrono::high_resolution_clock::now();
 
   std::chrono::duration<double> time = end - start_time;


### PR DESCRIPTION
Replaced the async QueryApi::GetPartitionsbyId and QueryApi::QuadTreeIndex methods with synchronous version.

Relates-to: OLPEDGE-1191

Signed-off-by: Kuchma, Mykhailo <ext-mykhailo.kuchma@here.com>
Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>