### PR TITLE
Added http status logging to curl request complete messages

### DIFF
--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
@@ -939,16 +939,16 @@ void NetworkCurl::CompleteMessage(CURL* handle, CURLcode result) {
           (handles_[index].retry_count++ < handles_[index].max_retries)) {
         OLP_SDK_LOG_DEBUG(kLogTag, "Retrying request with id="
                                        << handles_[index].id << ", url=" << url
-                                       << " err=" << error);
+                                       << " err=(" << status << ") " << error);
         handles_[index].count = 0;
         lock.lock();
         events_.emplace_back(EventInfo::Type::SEND_EVENT, &handles_[index]);
         return;
       }
     }
-    OLP_SDK_LOG_DEBUG(kLogTag, "Completed message id=" << handles_[index].id
-                                                       << ", url=" << url
-                                                       << ", status=" << error);
+    OLP_SDK_LOG_DEBUG(kLogTag, "Completed message id="
+                                   << handles_[index].id << ", url=" << url
+                                   << ", status=(" << status << ") " << error);
 
     auto response = NetworkResponse()
                         .WithRequestId(handles_[index].id)


### PR DESCRIPTION
Due to some errors were returned by curl/network that were not
covered in text and sometimes returned by server. This change
will print actual status code to log to improve further debugging
of unexpected messages that may be returned by server.

Relates-to: OLPEDGE-1215

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>