### PR TITLE
Added DefaultCacheTest.BadPathMutable to black list.

### DIFF
--- a/scripts/linux/fv/gitlab-olp-cpp-sdk-core-test.sh
+++ b/scripts/linux/fv/gitlab-olp-cpp-sdk-core-test.sh
@@ -22,4 +22,4 @@ echo ">>> Core Test ... >>>"
 source $FV_HOME/olp-cpp-sdk-core-test.variables
 $REPO_HOME/build/olp-cpp-sdk-core/tests/olp-cpp-sdk-core-tests \
     --gtest_output="xml:$REPO_HOME/reports/olp-core-test-report.xml" \
-    --gtest_filter=-"DefaultCacheTest.BadPath"
+    --gtest_filter=-"DefaultCacheTest.BadPathMutable"

--- a/scripts/linux/nv/gitlab_test_valgrind.sh
+++ b/scripts/linux/nv/gitlab_test_valgrind.sh
@@ -126,7 +126,7 @@ for test_name in "${TEST_TARGET_NAMES[@]}"
 do
 {
     if [[ ${test_name} == "olp-cpp-sdk-core-test" ]] ; then
-        EXCEPTION="--gtest_filter="-DefaultCacheTest.BadPath""
+        EXCEPTION="--gtest_filter="-DefaultCacheTest.BadPathMutable""
     else
         EXCEPTION=""
     fi


### PR DESCRIPTION
DefaultCacheTest.BadPathMutable(initially DefaultCacheTest.BadPath) was already in black list
but this has been lost after its renaming. Restoring.

Resolves: OLPEDGE-1266

Signed-off-by: Dmytro Poberezhnyi <ext-dmytro.poberezhnyi@here.com>