### PR TITLE
Added sync version of dataservice-write ConfigApi::GetCatalog

### DIFF
--- a/olp-cpp-sdk-dataservice-write/src/generated/ConfigApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/ConfigApi.cpp
@@ -65,6 +65,27 @@ CancellationToken ConfigApi::GetCatalog(
                          formParams, nullptr, "", callback);
 }
 
+CatalogResponse ConfigApi::GetCatalog(const OlpClient& client,
+                                      const std::string& catalog_hrn,
+                                      boost::optional<std::string> billing_tag,
+                                      client::CancellationContext context) {
+  std::multimap<std::string, std::string> header_params;
+  header_params.insert(std::make_pair("Accept", "application/json"));
+  std::multimap<std::string, std::string> query_params;
+  if (billing_tag) {
+    query_params.insert(std::make_pair("billingTag", *billing_tag));
+  }
+  std::string catalog_uri = "/catalogs/" + catalog_hrn;
+
+  client::HttpResponse response = client.CallApi(
+      std::move(catalog_uri), "GET", std::move(query_params),
+      std::move(header_params), {}, nullptr, std::string{}, std::move(context));
+  if (response.status != olp::http::HttpStatusCode::OK) {
+    return client::ApiError(response.status, response.response.str());
+  }
+  return olp::parser::parse<model::Catalog>(response.response);
+}
+
 }  // namespace write
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/ConfigApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/ConfigApi.h
@@ -26,6 +26,7 @@
 
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>
+#include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/OlpClient.h>
 
 #include "model/Catalog.h"
@@ -59,6 +60,23 @@ class ConfigApi {
       std::shared_ptr<client::OlpClient> client, const std::string& catalog_hrn,
       boost::optional<std::string> billing_tag,
       const CatalogCallback& callback);
+
+  /**
+   * @brief Call to synchronously retrieve the configuration of a catalog.
+   * @param client Instance of OlpClient used to make REST request.
+   * @param catalog_hrn Full catalog name.
+   * @param billing_tag An optional free-form tag which is used for grouping
+   * billing records together. If supplied, it must be between 4 - 16
+   * characters,
+   * contain only alpha/numeric ASCII characters  [A-Za-z0-9].
+   * @param context A CancellationContext instance which can be used to cancel
+   * this method.
+   * @return The result of operation as a client::ApiResponse object.
+   */
+  static CatalogResponse GetCatalog(const client::OlpClient& client,
+                                    const std::string& catalog_hrn,
+                                    boost::optional<std::string> billing_tag,
+                                    client::CancellationContext context);
 };
 
 }  // namespace write


### PR DESCRIPTION
Added the sync version of dataservice-write ConfigApi::GetCatlog method.
Tested only with custom functional tests. Unit tests will be provided once we will find a common ground with unit testing of generated API.

Relates to: OLPEDGE-1267

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>