### PR TITLE
Added protected cache usage in DefaultCache::Get method

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
@@ -54,8 +54,8 @@ class CORE_API DefaultCache : public KeyValueCache {
   /**
    * @brief Open the cache to start read/write operations.
    *
-   * @return StorageOpenResult if there were problems opening the path on the
-   * disk.
+   * @return StorageOpenResult if there were problems opening any of the
+   * provided pathes on the disk.
    */
   StorageOpenResult Open();
 
@@ -129,11 +129,11 @@ class CORE_API DefaultCache : public KeyValueCache {
 
  private:
   CacheSettings settings_;
-  bool is_open_{false};
+  bool is_open_;
   std::unique_ptr<InMemoryCache> memory_cache_;
-  std::unique_ptr<DiskCache> disk_cache_;
+  std::unique_ptr<DiskCache> mutable_cache_;
+  std::unique_ptr<DiskCache> protected_cache_;
   std::mutex cache_lock_;
-  // TODO: leveldb cache
 };
 
 }  // namespace cache

--- a/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
@@ -34,6 +34,8 @@ namespace {
 
 constexpr auto kLogTag = "DefaultCache";
 
+using DataPtr = std::shared_ptr<std::vector<unsigned char>>;
+
 std::string CreateExpiryKey(const std::string& key) { return key + "::expiry"; }
 
 time_t GetRemainingExpiryTime(const std::string& key,
@@ -47,6 +49,21 @@ time_t GetRemainingExpiryTime(const std::string& key,
   }
 
   return expiry;
+}
+
+/// Return success flag, cache data and remaing expiry time
+std::tuple<bool, DataPtr, time_t> GetFromCache(
+    const std::string& key, olp::cache::DiskCache& disk_cache) {
+  auto expiry = GetRemainingExpiryTime(key, disk_cache);
+  if (expiry > 0) {
+    auto value = disk_cache.Get(key);
+    if (value) {
+      auto data = std::make_shared<std::vector<unsigned char>>(
+          value.get().begin(), value.get().end());
+      return std::make_tuple(true, data, expiry);
+    }
+  }
+  return std::make_tuple(false, nullptr, expiry);
 }
 
 void PurgeDiskItem(const std::string& key, olp::cache::DiskCache& disk_cache) {
@@ -84,7 +101,8 @@ DefaultCache::DefaultCache(const CacheSettings& settings)
     : settings_(settings),
       is_open_(false),
       memory_cache_(nullptr),
-      disk_cache_(nullptr) {}
+      mutable_cache_(nullptr),
+      protected_cache_(nullptr) {}
 
 DefaultCache::~DefaultCache() {}
 
@@ -99,8 +117,10 @@ void DefaultCache::Close() {
   if (!is_open_) {
     return;
   }
-  if (memory_cache_) memory_cache_.reset();
-  if (disk_cache_) disk_cache_.reset();
+  memory_cache_.reset();
+  mutable_cache_.reset();
+  protected_cache_.reset();
+
   is_open_ = false;
 }
 
@@ -114,17 +134,13 @@ bool DefaultCache::Clear() {
     memory_cache_->Clear();
   }
 
-  if (disk_cache_) {
-    if (!disk_cache_->Clear()) {
+  if (mutable_cache_) {
+    if (!mutable_cache_->Clear()) {
       return false;
     }
   }
-  if (SetupStorage() != DefaultCache::StorageOpenResult::Success) {
-    OLP_SDK_LOG_DEBUG_F(kLogTag, "Failed to reopen the diskcache %s",
-                        settings_.disk_path_mutable.get().c_str());
-    return false;
-  }
-  return true;
+
+  return SetupStorage() == DefaultCache::StorageOpenResult::Success;
 }
 
 bool DefaultCache::Put(const std::string& key, const boost::any& value,
@@ -139,14 +155,14 @@ bool DefaultCache::Put(const std::string& key, const boost::any& value,
       return false;
   }
 
-  if (disk_cache_) {
+  if (mutable_cache_) {
     if (expiry < (std::numeric_limits<time_t>::max)()) {
-      if (!StoreExpiry(key, *disk_cache_, expiry)) {
+      if (!StoreExpiry(key, *mutable_cache_, expiry)) {
         return false;
       }
     }
 
-    if (!disk_cache_->Put(key, encodedItem)) {
+    if (!mutable_cache_->Put(key, encodedItem)) {
       return false;
     }
   }
@@ -154,7 +170,7 @@ bool DefaultCache::Put(const std::string& key, const boost::any& value,
 }
 
 bool DefaultCache::Put(const std::string& key,
-                       const std::shared_ptr<std::vector<unsigned char>> value,
+                       const DataPtr value,
                        time_t expiry) {
   std::lock_guard<std::mutex> lk(cache_lock_);
   if (!is_open_) {
@@ -167,15 +183,15 @@ bool DefaultCache::Put(const std::string& key,
     }
   }
 
-  if (disk_cache_) {
+  if (mutable_cache_) {
     if (expiry < (std::numeric_limits<time_t>::max)()) {
-      if (!StoreExpiry(key, *disk_cache_, expiry)) {
+      if (!StoreExpiry(key, *mutable_cache_, expiry)) {
         return false;
       }
     }
 
     std::string val(value->begin(), value->end());
-    if (!disk_cache_->Put(key, val)) {
+    if (!mutable_cache_->Put(key, val)) {
       return false;
     }
   }
@@ -196,58 +212,41 @@ boost::any DefaultCache::Get(const std::string& key, const Decoder& decoder) {
     }
   }
 
-  if (disk_cache_) {
-    auto expiry = GetRemainingExpiryTime(key, *disk_cache_);
-    if (expiry <= 0) {
-      PurgeDiskItem(key, *disk_cache_);
-      return boost::any();
-    }
+  bool valid = false;
+  DataPtr result;
+  time_t expiry = 0;
 
-    auto value = disk_cache_->Get(key);
-    if (value) {
-      auto decoded_item = decoder(value.get());
-      if (memory_cache_) {
-        memory_cache_->Put(key, decoded_item, expiry, value->size());
-      }
-      return decoded_item;
+  if (protected_cache_) {
+    std::tie(valid, result, expiry) = GetFromCache(key, *protected_cache_);
+  }
+
+  if (mutable_cache_ && !valid) {
+    std::tie(valid, result, expiry) = GetFromCache(key, *mutable_cache_);
+
+    if (expiry <= 0) {
+      PurgeDiskItem(key, *mutable_cache_);
     }
+  }
+
+  if (valid) {
+    auto decoded_item = decoder({result->begin(), result->end()});
+    if (memory_cache_) {
+      memory_cache_->Put(key, decoded_item, expiry, result->size());
+    }
+    return decoded_item;
   }
 
   return boost::any();
 }
 
-std::shared_ptr<std::vector<unsigned char>> DefaultCache::Get(
+DataPtr DefaultCache::Get(
     const std::string& key) {
-  std::lock_guard<std::mutex> lk(cache_lock_);
-  if (!is_open_) {
-    return nullptr;
-  }
+  auto data =
+      Get(key, [](const std::string& str) -> boost::any { return str; });
 
-  if (memory_cache_) {
-    auto value = memory_cache_->Get(key);
-
-    if (!value.empty()) {
-      return boost::any_cast<std::shared_ptr<std::vector<unsigned char>>>(
-          value);
-    }
-  }
-
-  if (disk_cache_) {
-    auto expiry = GetRemainingExpiryTime(key, *disk_cache_);
-    if (expiry <= 0) {
-      PurgeDiskItem(key, *disk_cache_);
-      return nullptr;
-    }
-
-    auto value = disk_cache_->Get(key);
-    if (value) {
-      auto data = std::make_shared<std::vector<unsigned char>>(
-          value.get().begin(), value.get().end());
-      if (memory_cache_) {
-        memory_cache_->Put(key, data, expiry, value->size());
-      }
-      return data;
-    }
+  if (!data.empty()) {
+    auto buffer = boost::any_cast<DataPtr>(&data);
+    return buffer ? *buffer : nullptr;
   }
 
   return nullptr;
@@ -263,8 +262,8 @@ bool DefaultCache::Remove(const std::string& key) {
     memory_cache_->Remove(key);
   }
 
-  if (disk_cache_) {
-    if (!disk_cache_->Remove(key)) return false;
+  if (mutable_cache_) {
+    if (!mutable_cache_->Remove(key)) return false;
   }
 
   return true;
@@ -280,21 +279,19 @@ bool DefaultCache::RemoveKeysWithPrefix(const std::string& key) {
     memory_cache_->RemoveKeysWithPrefix(key);
   }
 
-  if (disk_cache_) {
-    return disk_cache_->RemoveKeysWithPrefix(key);
+  if (mutable_cache_) {
+    return mutable_cache_->RemoveKeysWithPrefix(key);
   }
   return true;
 }  // namespace cache
 
 DefaultCache::StorageOpenResult DefaultCache::SetupStorage() {
   auto result = Success;
-  if (memory_cache_) {
-    memory_cache_.reset();
-  }
 
-  if (disk_cache_) {
-    disk_cache_.reset();
-  }
+  memory_cache_.reset();
+  mutable_cache_.reset();
+  protected_cache_.reset();
+
   if (settings_.max_memory_cache_size > 0) {
     memory_cache_.reset(new InMemoryCache(settings_.max_memory_cache_size));
   }
@@ -310,20 +307,37 @@ DefaultCache::StorageOpenResult DefaultCache::SetupStorage() {
         settings_.enforce_immediate_flush;
     storage_settings.max_file_size = settings_.max_file_size;
 
-    disk_cache_ = std::make_unique<DiskCache>();
-    auto status = disk_cache_->Open(settings_.disk_path_mutable.get(),
-                                    settings_.disk_path_mutable.get(),
-                                    storage_settings, OpenOptions::Default);
+    mutable_cache_ = std::make_unique<DiskCache>();
+    auto status = mutable_cache_->Open(settings_.disk_path_mutable.get(),
+                                       settings_.disk_path_mutable.get(),
+                                       storage_settings, OpenOptions::Default);
     if (status == OpenResult::Fail) {
-      disk_cache_.reset();
+      OLP_SDK_LOG_ERROR_F(kLogTag, "Failed to open the mutable cache %s",
+                          settings_.disk_path_mutable.get().c_str());
+
+      mutable_cache_.reset();
       settings_.disk_path_mutable = boost::none;
+      result = OpenDiskPathFailure;
+    }
+  }
+
+  if (settings_.disk_path_protected) {
+    protected_cache_ = std::make_unique<DiskCache>();
+    auto status =
+        protected_cache_->Open(settings_.disk_path_protected.get(),
+                               settings_.disk_path_protected.get(),
+                               StorageSettings{}, OpenOptions::ReadOnly);
+    if (status == OpenResult::Fail) {
+      OLP_SDK_LOG_ERROR_F(kLogTag, "Failed to reopen protected cache %s",
+                          settings_.disk_path_protected.get().c_str());
+
+      protected_cache_.reset();
+      settings_.disk_path_protected = boost::none;
       result = OpenDiskPathFailure;
     }
   }
 
   return result;
 }
-
 }  // namespace cache
-
 }  // namespace olp

--- a/tests/performance/MemoryTest.cpp
+++ b/tests/performance/MemoryTest.cpp
@@ -407,7 +407,7 @@ TestConfiguration ShortRunningTestWithMemoryCache() {
  * Short 5 minutes test to collect SDK allocations with both in memory cache
  * and disk cache.
  */
-TestConfiguration ShortRunningTestWithDiskCache() {
+TestConfiguration ShortRunningTestWithMutableCache() {
   using namespace olp;
 
   cache::CacheSettings settings;
@@ -429,7 +429,7 @@ std::vector<TestConfiguration> Configurations() {
   std::vector<TestConfiguration> configurations;
   configurations.emplace_back(ShortRunningTestWithNullCache());
   configurations.emplace_back(ShortRunningTestWithMemoryCache());
-  configurations.emplace_back(ShortRunningTestWithDiskCache());
+  configurations.emplace_back(ShortRunningTestWithMutableCache());
   configurations.emplace_back(LongRunningTest());
   return configurations;
 }


### PR DESCRIPTION
Protected cache should be checked before mutable cache.
Added test to cover that.

Resolves: OLPEDGE-1040

Signed-off-by: Dmytro Poberezhnyi <ext-dmytro.poberezhnyi@here.com>