### PR TITLE
Mark TokenRequest class as deprecated. 

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AutoRefreshingToken.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AutoRefreshingToken.h
@@ -29,6 +29,7 @@
 #include "TokenResult.h"
 
 #include "olp/core/client/CancellationToken.h"
+#include "olp/core/porting/warning_disable.h"
 
 namespace olp {
 namespace authentication {
@@ -114,7 +115,10 @@ class AUTHENTICATION_API AutoRefreshingToken {
    * @param token_endpoint the token endpoint to refresh against
    * @param token_request the token request to send to the token endpoint
    */
+  PORTING_PUSH_WARNINGS()
+  PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
   AutoRefreshingToken(TokenEndpoint token_endpoint, TokenRequest token_request);
+  PORTING_POP_WARNINGS()
 
  private:
   struct Impl;

--- a/olp-cpp-sdk-authentication/include/olp/authentication/TokenEndpoint.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/TokenEndpoint.h
@@ -31,10 +31,13 @@
 
 #include "olp/core/client/ApiResponse.h"
 #include "olp/core/client/CancellationToken.h"
+#include "olp/core/porting/warning_disable.h"
 
 namespace olp {
 namespace authentication {
 class AutoRefreshingToken;
+PORTING_PUSH_WARNINGS()
+PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
 
 /**
  * @brief The TokenEndpoint class directly corresponds to the token endpoint as
@@ -107,6 +110,7 @@ class AUTHENTICATION_API TokenEndpoint {
   struct Impl;
   std::shared_ptr<Impl> impl_;
 };
+PORTING_POP_WARNINGS()
 
 }  // namespace authentication
 }  // namespace olp

--- a/olp-cpp-sdk-authentication/include/olp/authentication/TokenRequest.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/TokenRequest.h
@@ -23,6 +23,7 @@
 #include <cstdint>
 
 #include "AuthenticationApi.h"
+#include <olp/core/porting/deprecated.h>
 
 namespace olp {
 namespace authentication {
@@ -30,7 +31,8 @@ namespace authentication {
  * @brief The TokenRequest class holds parameters of an OAuth2.0 Authorization
  * Grant Request.
  */
-class AUTHENTICATION_API TokenRequest {
+class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed in 04.2020")
+    TokenRequest {
  public:
   /**
    * @brief Constructor.

--- a/olp-cpp-sdk-authentication/src/AutoRefreshingToken.cpp
+++ b/olp-cpp-sdk-authentication/src/AutoRefreshingToken.cpp
@@ -25,6 +25,7 @@
 #include "olp/authentication/TokenEndpoint.h"
 #include "olp/core/client/CancellationToken.h"
 #include "olp/core/logging/Log.h"
+#include "olp/core/porting/warning_disable.h"
 
 namespace {
 constexpr auto kLogTag = "authentication::AutoRefreshingToken";
@@ -40,6 +41,8 @@ std::chrono::system_clock::time_point ComputeRefreshTime(
 
 namespace olp {
 namespace authentication {
+PORTING_PUSH_WARNINGS()
+PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
 
 struct AutoRefreshingToken::Impl {
   Impl(TokenEndpoint token_endpoint, TokenRequest token_request)
@@ -176,6 +179,7 @@ client::CancellationToken AutoRefreshingToken::GetToken(
     const std::chrono::seconds& minimum_validity) const {
   return impl_->GetToken(callback, minimum_validity);
 }
+PORTING_POP_WARNINGS()
 
 }  // namespace authentication
 }  // namespace olp

--- a/olp-cpp-sdk-authentication/src/TokenEndpoint.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenEndpoint.cpp
@@ -48,6 +48,8 @@ struct TokenEndpoint::Impl {
     auth_client_.SetTaskScheduler(std::move(settings.task_scheduler));
   }
 
+  PORTING_PUSH_WARNINGS()
+  PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
   client::CancellationToken RequestToken(const TokenRequest& token_request,
                                          const RequestTokenCallback& callback) {
     return auth_client_.SignInClient(
@@ -126,6 +128,7 @@ AutoRefreshingToken TokenEndpoint::RequestAutoRefreshingToken(
     const TokenRequest& token_request) {
   return AutoRefreshingToken(*this, token_request);
 }
+PORTING_POP_WARNINGS()
 
 }  // namespace authentication
 }  // namespace olp


### PR DESCRIPTION
 Disable warnings for all current usages of TokenRequest.

Relates-To: OLPEDGE-1263

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>