### PR TITLE
Mark methods in Authentication client as deprecated.

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
@@ -244,6 +244,7 @@ class AUTHENTICATION_API AuthenticationClient {
    * "https://account.api.here.com")
    * @param token_cache_limit Maximum number of tokens that will be cached.
    */
+  OLP_SDK_DEPRECATED("Deprecated. Will be removed in 04.2020")
   AuthenticationClient(
       const std::string& authentication_server_url = kHereAccountProductionUrl,
       size_t token_cache_limit = 100u);
@@ -487,6 +488,7 @@ class AUTHENTICATION_API AuthenticationClient {
    * @param proxy_settings proxy settings to be used by the network layer when
    * making requests.
    */
+  OLP_SDK_DEPRECATED("Deprecated. Will be removed in 04.2020")
   void SetNetworkProxySettings(
       const http::NetworkProxySettings& proxy_settings);
 
@@ -496,6 +498,7 @@ class AUTHENTICATION_API AuthenticationClient {
    * Should not be nullptr, otherwise any access to class' method calls would
    * render http::ErrorCode::IO_ERROR
    */
+  OLP_SDK_DEPRECATED("Deprecated. Will be removed in 04.2020")
   void SetNetwork(std::shared_ptr<http::Network> network);
 
   /**
@@ -503,6 +506,7 @@ class AUTHENTICATION_API AuthenticationClient {
    * @param task_scheduler Shared TaskScheduler instance to be used for requests
    * outcomes. If set to nullptr, callbacks will be sent synchronously.
    */
+  OLP_SDK_DEPRECATED("Deprecated. Will be removed in 04.2020")
   void SetTaskScheduler(std::shared_ptr<thread::TaskScheduler> task_scheduler);
 
  private:

--- a/olp-cpp-sdk-authentication/src/TokenEndpoint.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenEndpoint.cpp
@@ -28,6 +28,7 @@
 #include "olp/authentication/SignInResult.h"
 #include "olp/authentication/TokenRequest.h"
 #include "olp/core/logging/Log.h"
+#include "olp/core/porting/warning_disable.h"
 
 namespace {
 const std::string kOauth2TokenEndpoint = "/oauth2/token";
@@ -40,12 +41,15 @@ struct TokenEndpoint::Impl {
   explicit Impl(Settings settings)
       : auth_client_(std::move(settings.token_endpoint_url)),
         auth_credentials_(std::move(settings.credentials)) {
+    PORTING_PUSH_WARNINGS()
+    PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
     if (settings.network_proxy_settings) {
       auth_client_.SetNetworkProxySettings(
           settings.network_proxy_settings.get());
     }
     auth_client_.SetNetwork(std::move(settings.network_request_handler));
     auth_client_.SetTaskScheduler(std::move(settings.task_scheduler));
+    PORTING_POP_WARNINGS()
   }
 
   client::CancellationToken RequestToken(const TokenRequest& token_request,


### PR DESCRIPTION
Disable warnings for all current usages.
Deprecated methods:
    Constructor
    SetNetworkProxySettings
    SetNetwork
    SetTaskScheduler

Relates-To: OLPEDGE-1259

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>