### PR TITLE
Added sync version of IngestApi::IngestData in dataservice-write

### DIFF
--- a/olp-cpp-sdk-dataservice-write/src/generated/IngestApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/IngestApi.h
@@ -76,6 +76,8 @@ class IngestApi {
    *
    * @return A CancellationToken which can be used to cancel the ongoing
    * request.
+   * @deprecated Will be removed once \c StreamLayerClientImpl will be switched
+   * to sync API.
    */
   static client::CancellationToken IngestData(
       const client::OlpClient& client, const std::string& layer_id,
@@ -85,6 +87,39 @@ class IngestApi {
       const boost::optional<std::string>& billing_tag,
       const boost::optional<std::string>& checksum,
       IngestDataCallback callback);
+
+  /**
+   * @brief Synchronous call to ingest data into an OLP Stream Layer.
+   * @param client Instance of OlpClient used to make REST request.
+   * @param layer_id Layer of the catalog where you want to store the data. The
+   * layer type must be Stream.
+   * @param content_type The content type configured for the target layer.
+   * @param data Content to be uploaded to OLP.
+   * @param trace_id Optional. A unique message ID, such as a UUID. This can be
+   * included in the request if you want to use an ID that you define. If you do
+   * not include an ID, one will be generated during ingestion and included in
+   * the response. You can use this ID to track your request and identify the
+   * message in the catalog.
+   * @param billing_tag Optional. An optional free-form tag which is used for
+   * grouping billing records together. If supplied, it must be between 4 - 16
+   * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
+   * @param checksum A SHA-256 hash you can provide for
+   * validation against the calculated value on the request body hash. This
+   * verifies the integrity of your request and prevents modification by a third
+   * party.It will be created by the service if not provided. A SHA-256 hash
+   * consists of 256 bits or 64 chars.
+   * @param context A CancellationContext, which can be used to cancel request.
+   *
+   * @return A result of operation as IngestDataResponse.
+   */
+  static IngestDataResponse IngestData(
+      const client::OlpClient& client, const std::string& layer_id,
+      const std::string& content_type,
+      const std::shared_ptr<std::vector<unsigned char>>& data,
+      const boost::optional<std::string>& trace_id,
+      const boost::optional<std::string>& billing_tag,
+      const boost::optional<std::string>& checksum,
+      client::CancellationContext context);
 
   /**
    * @brief Send list of SDII messages to a stream layer.


### PR DESCRIPTION
Implemented sync version of IngestApi::IngestData in dataservice-write component. No tests for now. Note, that after we finish with switching the StreamLayerClientImpl to SyncApi, the async version of IngestApi::IngetData should be removed.

Relates-to: OLPEDGE-1268

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>