### PR TITLE
Add MoveResult function for ApiResponse.

### DIFF
--- a/examples/dataservice-read/example.cpp
+++ b/examples/dataservice-read/example.cpp
@@ -50,7 +50,7 @@ std::string HandleCatalogResponse(
     OLP_SDK_LOG_INFO_F(kLogTag, "Catalog description: %s",
                        response_result.GetDescription().c_str());
 
-    auto layers = response_result.GetLayers();
+    const auto& layers = response_result.GetLayers();
     if (!layers.empty()) {
       first_layer_id = layers.front().GetId();
     }
@@ -78,7 +78,7 @@ std::string HandlePartitionsResponse(
   std::string first_partition_id;
   if (partitions_response.IsSuccessful()) {
     const auto& response_result = partitions_response.GetResult();
-    auto partitions = response_result.GetPartitions();
+    const auto& partitions = response_result.GetPartitions();
     OLP_SDK_LOG_INFO_F(kLogTag, "Layer contains %ld partitions.",
                        partitions.size());
 

--- a/olp-cpp-sdk-authentication/src/AutoRefreshingToken.cpp
+++ b/olp-cpp-sdk-authentication/src/AutoRefreshingToken.cpp
@@ -96,7 +96,7 @@ struct AutoRefreshingToken::Impl {
           static_cast<int>(current_token_.GetError().GetErrorCode()),
           current_token_.GetError().GetMessage().c_str());
     } else if (current_token_.GetResult().GetErrorResponse().code != 0) {
-      const auto result = current_token_.GetResult();
+      const auto& result = current_token_.GetResult();
       OLP_SDK_LOG_INFO_F(kLogTag, "Token NOK, status=%d, code=%d, error=%s",
                          static_cast<int>(result.GetHttpStatus()),
                          static_cast<int>(result.GetErrorResponse().code),
@@ -131,7 +131,7 @@ struct AutoRefreshingToken::Impl {
                 static_cast<int>(current_token.GetError().GetErrorCode()),
                 current_token.GetError().GetMessage().c_str());
           } else if (current_token.GetResult().GetErrorResponse().code != 0) {
-            const auto result = current_token.GetResult();
+            const auto& result = current_token.GetResult();
             OLP_SDK_LOG_INFO_F(kLogTag,
                                "Token NOK, status=%d code=%d, error=%s",
                                static_cast<int>(result.GetHttpStatus()),

--- a/olp-cpp-sdk-core/include/olp/core/client/ApiResponse.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/ApiResponse.h
@@ -72,6 +72,12 @@ class ApiResponse {
    * otherwise.
    */
   inline const ResultType& GetResult() const { return result_; }
+  /**
+   * @brief MoveResult Moves the result for a succcessfully executed request
+   * @return A valid Result if IsSuccessful() returns true. Undefined,
+   * otherwise.
+   */
+  inline ResultType&& MoveResult() { return std::move(result_); }
 
   /**
    * @brief GetError Gets the error for an unsucccessful request attempt.

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
@@ -109,10 +109,9 @@ PartitionsResponse PartitionsRepository::GetVolatilePartitions(
     return expiry_response.GetError();
   }
 
-  auto expiry = expiry_response.GetResult();
   return GetPartitions(std::move(catalog), std::move(layer),
                        cancellation_context, std::move(request),
-                       std::move(settings), std::move(expiry));
+                       std::move(settings), expiry_response.MoveResult());
 }
 
 PartitionsResponse PartitionsRepository::GetPartitions(

--- a/olp-cpp-sdk-dataservice-write/src/ApiClientLookup.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/ApiClientLookup.cpp
@@ -215,7 +215,7 @@ ApiClientLookup::ApiClientResponse ApiClientLookup::LookupApiClient(
     return api_response.GetError();
   }
 
-  auto client = api_response.GetResult();
+  auto client = api_response.MoveResult();
   if (client.GetBaseUrl().empty()) {
     OLP_SDK_LOG_WARNING_F(kLogTag, "LookupApi(%s/%s): %s - empty base URL",
                           service.c_str(), service_version.c_str(),

--- a/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.cpp
@@ -160,7 +160,7 @@ CancellationToken IndexLayerClientImpl::InitCatalogModel(
           return;
         }
 
-        self->catalog_model_ = catalog_response.GetResult();
+        self->catalog_model_ = catalog_response.MoveResult();
 
         callback(boost::none);
       });

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
@@ -211,7 +211,7 @@ CancellationToken StreamLayerClientImpl::InitCatalogModel(
           return;
         }
 
-        self->catalog_model_ = catalog_response.GetResult();
+        self->catalog_model_ = catalog_response.MoveResult();
 
         callback(boost::none);
       });
@@ -814,7 +814,7 @@ PublishSdiiResponse StreamLayerClientImpl::IngestSdii(
     return api_response.GetError();
   }
 
-  auto client = api_response.GetResult();
+  auto client = api_response.MoveResult();
   return IngestApi::IngestSdii(client, request.GetLayerId(),
                                request.GetSdiiMessageList(),
                                request.GetTraceId(), request.GetBillingTag(),

--- a/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.cpp
@@ -189,7 +189,7 @@ client::CancellationToken VersionedLayerClientImpl::StartBatch(
             !init_pub_response.GetResult().GetId()) {
           callback(std::move(init_pub_response.GetError()));
         } else {
-          callback(std::move(init_pub_response.GetResult()));
+          callback(init_pub_response.MoveResult());
         }
       };
 
@@ -265,7 +265,7 @@ olp::client::CancellationToken VersionedLayerClientImpl::GetBaseVersion(
             callback(std::move(response.GetError()));
           }
         } else {
-          callback(std::move(response.GetResult()));
+          callback(response.MoveResult());
         }
       };
 
@@ -331,7 +331,7 @@ olp::client::CancellationToken VersionedLayerClientImpl::GetBatch(
         if (!getPublicationResponse.IsSuccessful()) {
           callback(std::move(getPublicationResponse.GetError()));
         } else {
-          callback(std::move(getPublicationResponse.GetResult()));
+          callback(getPublicationResponse.MoveResult());
         }
       };
 
@@ -396,7 +396,7 @@ olp::client::CancellationToken VersionedLayerClientImpl::CompleteBatch(
         if (!submitPublicationResponse.IsSuccessful()) {
           callback(std::move(submitPublicationResponse.GetError()));
         } else {
-          callback(std::move(submitPublicationResponse.GetResult()));
+          callback(submitPublicationResponse.MoveResult());
         }
       };
 
@@ -462,7 +462,7 @@ olp::client::CancellationToken VersionedLayerClientImpl::CancelBatch(
         if (!cancelPublicationResponse.IsSuccessful()) {
           callback(std::move(cancelPublicationResponse.GetError()));
         } else {
-          callback(std::move(cancelPublicationResponse.GetResult()));
+          callback(cancelPublicationResponse.GetResult());
         }
       };
 
@@ -594,7 +594,7 @@ void VersionedLayerClientImpl::InitCatalogModel(
     if (!response.IsSuccessful()) {
       callback(std::move(response.GetError()));
     } else {
-      catalog_model_ = response.GetResult();
+      catalog_model_ = response.MoveResult();
       callback(boost::none);
     }
   };
@@ -643,7 +643,7 @@ void VersionedLayerClientImpl::UploadPartition(
     if (!response.IsSuccessful()) {
       callback(std::move(response.GetError()));
     } else {
-      callback(std::move(response.GetResult()));
+      callback(response.MoveResult());
     }
   };
 
@@ -701,7 +701,7 @@ void VersionedLayerClientImpl::UploadBlob(
     if (!response.IsSuccessful()) {
       callback(std::move(response.GetError()));
     } else {
-      callback(std::move(response.GetResult()));
+      callback(response.MoveResult());
     }
   };
 
@@ -773,7 +773,7 @@ client::CancellationToken VersionedLayerClientImpl::CheckDataExists(
         if (!check_data_exists_response.IsSuccessful()) {
           callback(std::move(check_data_exists_response.GetError()));
         } else {
-          callback(std::move(check_data_exists_response.GetResult()));
+          callback(check_data_exists_response.MoveResult());
         }
       };
 

--- a/olp-cpp-sdk-dataservice-write/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/VolatileLayerClientImpl.cpp
@@ -192,7 +192,7 @@ CancellationToken VolatileLayerClientImpl::InitCatalogModel(
           return;
         }
 
-        self->catalog_model_ = catalog_response.GetResult();
+        self->catalog_model_ = catalog_response.MoveResult();
 
         callback(boost::none);
       });
@@ -247,7 +247,7 @@ olp::client::CancellationToken VolatileLayerClientImpl::GetBaseVersion(
             callback(std::move(response.GetError()));
           }
         } else {
-          callback(std::move(response.GetResult()));
+          callback(response.MoveResult());
         }
       };
 
@@ -301,7 +301,7 @@ client::CancellationToken VolatileLayerClientImpl::StartBatch(
             !init_pub_response.GetResult().GetId()) {
           callback(std::move(init_pub_response.GetError()));
         } else {
-          callback(std::move(init_pub_response.GetResult()));
+          callback(init_pub_response.MoveResult());
         }
       };
 
@@ -516,7 +516,7 @@ olp::client::CancellationToken VolatileLayerClientImpl::GetBatch(
         if (!getPublicationResponse.IsSuccessful()) {
           callback(std::move(getPublicationResponse.GetError()));
         } else {
-          callback(std::move(getPublicationResponse.GetResult()));
+          callback(getPublicationResponse.MoveResult());
         }
       };
 
@@ -578,9 +578,9 @@ olp::client::CancellationToken VolatileLayerClientImpl::GetDataHandleMap(
           if (!response.IsSuccessful()) {
             callback(std::move(response.GetError()));
           } else {
-            auto partitions = response.GetResult().GetPartitions();
+            const auto& partitions = response.GetResult().GetPartitions();
             std::map<std::string, std::string> dataHandleMap;
-            for (model::Partition& p : partitions) {
+            for (const model::Partition& p : partitions) {
               if (std::find(partitionIds.begin(), partitionIds.end(),
                             p.GetPartition()) != partitionIds.end()) {
                 dataHandleMap[p.GetPartition()] = p.GetDataHandle();
@@ -698,7 +698,7 @@ olp::client::CancellationToken VolatileLayerClientImpl::PublishToBatch(
         if (!upload_partitions_response.IsSuccessful()) {
           callback(std::move(upload_partitions_response.GetError()));
         } else {
-          callback(std::move(upload_partitions_response.GetResult()));
+          callback(upload_partitions_response.MoveResult());
         }
       };
 
@@ -782,7 +782,7 @@ olp::client::CancellationToken VolatileLayerClientImpl::CompleteBatch(
         if (!submitPublicationResponse.IsSuccessful()) {
           callback(std::move(submitPublicationResponse.GetError()));
         } else {
-          callback(std::move(submitPublicationResponse.GetResult()));
+          callback(submitPublicationResponse.MoveResult());
         }
       };
 

--- a/tests/functional/olp-cpp-sdk-dataservice-read/ApiTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/ApiTest.cpp
@@ -99,7 +99,7 @@ TEST_F(ApiTest, GetCatalog) {
 
   ASSERT_TRUE(client_response.IsSuccessful())
       << ApiErrorToString(client_response.GetError());
-  auto config_client = client_response.GetResult();
+  auto config_client = client_response.MoveResult();
 
   std::promise<olp::dataservice::read::ConfigApi::CatalogResponse>
       catalog_promise;
@@ -131,7 +131,7 @@ TEST_F(ApiTest, GetPartitions) {
 
   ASSERT_TRUE(client_response.IsSuccessful())
       << ApiErrorToString(client_response.GetError());
-  auto metadata_client = client_response.GetResult();
+  auto metadata_client = client_response.MoveResult();
   olp::client::CancellationContext context;
 
   auto start_time = std::chrono::high_resolution_clock::now();
@@ -157,7 +157,7 @@ TEST_F(ApiTest, GetPartitionById) {
 
   ASSERT_TRUE(client_response.IsSuccessful())
       << ApiErrorToString(client_response.GetError());
-  auto query_client = client_response.GetResult();
+  auto query_client = client_response.MoveResult();
 
   {
     SCOPED_TRACE("Test with 2 partitions");
@@ -223,7 +223,7 @@ TEST_F(ApiTest, GetCatalogVersion) {
 
   ASSERT_TRUE(client_response.IsSuccessful())
       << ApiErrorToString(client_response.GetError());
-  auto metadata_client = client_response.GetResult();
+  auto metadata_client = client_response.MoveResult();
   olp::client::CancellationContext context;
 
   auto start_time = std::chrono::high_resolution_clock::now();
@@ -247,7 +247,7 @@ TEST_F(ApiTest, GetLayerVersions) {
 
   ASSERT_TRUE(client_response.IsSuccessful())
       << ApiErrorToString(client_response.GetError());
-  auto metadata_client = client_response.GetResult();
+  auto metadata_client = client_response.MoveResult();
   olp::client::CancellationContext context;
 
   auto start_time = std::chrono::high_resolution_clock::now();
@@ -272,7 +272,7 @@ TEST_F(ApiTest, GetBlob) {
 
   ASSERT_TRUE(client_response.IsSuccessful())
       << ApiErrorToString(client_response.GetError());
-  auto blob_client = client_response.GetResult();
+  auto blob_client = client_response.MoveResult();
 
   olp::client::CancellationContext context;
 
@@ -301,7 +301,7 @@ TEST_F(ApiTest, DISABLED_GetVolatileBlob) {
 
   ASSERT_TRUE(client_response.IsSuccessful())
       << ApiErrorToString(client_response.GetError());
-  auto volatile_blob_client = client_response.GetResult();
+  auto volatile_blob_client = client_response.MoveResult();
   auto start_time = std::chrono::high_resolution_clock::now();
   auto data_response = olp::dataservice::read::VolatileBlobApi::GetVolatileBlob(
       volatile_blob_client, "testlayer", "d5d73b64-7365-41c3-8faf-aa6ad5bab135",
@@ -327,7 +327,7 @@ TEST_F(ApiTest, QuadTreeIndex) {
 
   ASSERT_TRUE(client_response.IsSuccessful())
       << ApiErrorToString(client_response.GetError());
-  auto query_client = client_response.GetResult();
+  auto query_client = client_response.MoveResult();
 
   std::string layer_id("hype-test-prefetch");
   int64_t version = 3;

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVersionedLayerClientTest.cpp
@@ -209,7 +209,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, GetBaseVersion) {
   auto response = versioned_client->GetBaseVersion().GetFuture().get();
 
   EXPECT_SUCCESS(response);
-  auto version_response = response.GetResult();
+  auto version_response = response.MoveResult();
   ASSERT_GE(version_response.GetVersion(), 0);
 }
 

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVolatileLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVolatileLayerClientTest.cpp
@@ -131,7 +131,7 @@ TEST_F(DataserviceWriteVolatileLayerClientTest, GetBaseVersion) {
   auto response = volatile_client->GetBaseVersion().GetFuture().get();
 
   EXPECT_SUCCESS(response);
-  auto version_response = response.GetResult();
+  auto version_response = response.MoveResult();
   ASSERT_GE(version_response.GetVersion(), 0);
 }
 

--- a/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -590,9 +590,9 @@ TEST_F(AuthenticationClientTest, SignOutUser) {
 
   AuthenticationClient::SignOutUserResponse response = request_future.get();
   EXPECT_TRUE(response.IsSuccessful());
-  SignOutResult s = response.GetResult();
+  SignOutResult s = response.MoveResult();
   EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT, s.GetStatus());
-  EXPECT_EQ(kErrorNoContent, response.GetResult().GetErrorResponse().message);
+  EXPECT_EQ(kErrorNoContent, s.GetErrorResponse().message);
 }
 
 TEST_F(AuthenticationClientTest, SignInFacebookData) {

--- a/tests/integration/olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
@@ -165,7 +165,7 @@ TEST_F(HereAccountOauth2Test, AutoRefreshingTokenCancelSync) {
                          const std::chrono::seconds minimumValidity) {
         return GetTokenFromSyncRequest(cancellationToken, autoToken,
                                        minimumValidity)
-            .GetResult();
+            .MoveResult();
       });
 }
 
@@ -243,6 +243,6 @@ TEST_F(HereAccountOauth2Test, AutoRefreshingTokenCancelAsync) {
                          const std::chrono::seconds minimumValidity) {
         return GetTokenFromAsyncRequest(cancellationToken, autoToken,
                                         minimumValidity)
-            .GetResult();
+            .MoveResult();
       });
 }


### PR DESCRIPTION
Internal code was addapted to use MoveResult function instead GetResult.
Reduced unnesesary object copying, where it is possible.

Relates-To: OLPEDGE-1110

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>