### PR TITLE
Fixed the data race in the Condition class

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/Condition.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/Condition.h
@@ -43,8 +43,12 @@ class Condition final {
     {
       std::unique_lock<std::mutex> lock(mutex_);
       signaled_ = true;
+
+      // Condition should be under the lock in order to not run into the data
+      // race, which might occur when spurious wakeup happens in the other
+      // thread while waiting for the condition's signal.
+      condition_.notify_one();
     }
-    condition_.notify_one();
   }
 
   /**


### PR DESCRIPTION
Fixed the data race in the Condition class, which occurred while running the dataservice-read unit tests.
Looks like the issue was that the waiting thread was spuriously woke up right before the condition is about to be signaled, but after the `Condition::signaled_` var is set to `true`.
This happened because the `std::conditional_variable::notify_one` on the condition wasn't under the `std::lock_guard`. After the execution was returned to the signaling thread, the `condition_` might be dead, as in the example with OlpClient::SendRequest. So, we have to make sure that access to condition_ and signaled_ are always protected with same mutex.

Alternatively, we could rewrite the `Condition` class usage via std::make_shared<> instead using the local variable - see OlpClient::SendRequest and ApiClientLookup::LookupApiClient.

Relates-to: OLPEDGE-1293

Signed-off-by: Kuchma, Mykhailo <ext-mykhailo.kuchma@here.com>
Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>