### PR TITLE
Implemented the sync version of BlobApi::PutBlob

### DIFF
--- a/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.cpp
@@ -67,6 +67,39 @@ CancellationToken BlobApi::PutBlob(
   return cancel_token;
 }
 
+PutBlobResponse BlobApi::PutBlob(
+    const OlpClient& client, const std::string& layer_id,
+    const std::string& content_type, const std::string& data_handle,
+    const std::shared_ptr<std::vector<unsigned char>>& data,
+    const boost::optional<std::string>& billing_tag,
+    client::CancellationContext cancel_context) {
+  std::multimap<std::string, std::string> header_params;
+  std::multimap<std::string, std::string> query_params;
+  std::multimap<std::string, std::string> form_params;
+
+  header_params.insert(std::make_pair("Accept", "application/json"));
+
+  if (billing_tag) {
+    query_params.insert(
+        std::make_pair(kQueryParamBillingTag, billing_tag.get()));
+  }
+
+  std::string put_blob_uri = "/layers/" + layer_id + "/data/" + data_handle;
+
+  auto http_response =
+      client.CallApi(std::move(put_blob_uri), "PUT", std::move(query_params),
+                     std::move(header_params), std::move(form_params),
+                     std::move(data), std::move(content_type), cancel_context);
+
+  if (http_response.status != olp::http::HttpStatusCode::OK &&
+      http_response.status != olp::http::HttpStatusCode::NO_CONTENT) {
+    return PutBlobResponse(
+        ApiError(http_response.status, http_response.response.str()));
+  }
+
+  return PutBlobResponse(ApiNoResult());
+}
+
 CancellationToken BlobApi::deleteBlob(
     const client::OlpClient& client, const std::string& layer_id,
     const std::string& data_handle,

--- a/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.h
@@ -25,6 +25,7 @@
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiNoResult.h>
 #include <olp/core/client/ApiResponse.h>
+#include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/OlpClient.h>
 
 namespace olp {
@@ -75,6 +76,8 @@ class BlobApi {
    *
    * @return A CancellationToken which can be used to cancel the ongoing
    * request.
+   * @deprecated Should be removed once all the clients will be migrated to the
+   * sync API.
    */
   static client::CancellationToken PutBlob(
       const client::OlpClient& client, const std::string& layer_id,
@@ -82,6 +85,16 @@ class BlobApi {
       const std::shared_ptr<std::vector<unsigned char>>& data,
       const boost::optional<std::string>& billing_tag,
       PutBlobCallback callback);
+
+  /**
+   * @brief Synchronous version of \c PutBlob method.
+   */
+  static PutBlobResponse PutBlob(
+      const client::OlpClient& client, const std::string& layer_id,
+      const std::string& content_type, const std::string& data_handle,
+      const std::shared_ptr<std::vector<unsigned char>>& data,
+      const boost::optional<std::string>& billing_tag,
+      client::CancellationContext cancel_contex);
 
   /**
    * @brief Delete a data blob


### PR DESCRIPTION
Implemented the synchronous version of BlobApi::PutBlob method, which is required for the sync version of StreamLayerClientImpl::InitPublishDataGreaterThanTwentyMib.

No tests for now (in future will be added).

Relates-to: OLPEDGE-1182

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>