### PR TITLE
Implemented the sync version of PublishDataGreaterThanTwentyMib

### DIFF
--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.h
@@ -86,6 +86,12 @@ class StreamLayerClientImpl
       const model::PublishDataRequest& request,
       client::CancellationContext context);
 
+  virtual PublishDataResponse PublishDataGreaterThanTwentyMibSync(
+      const model::PublishDataRequest& request,
+      client::CancellationContext context);
+
+  virtual std::string GenerateUuid() const;
+
  private:
   client::CancellationToken InitApiClients(
       const std::shared_ptr<client::CancellationContext>& cancel_context,


### PR DESCRIPTION
- Implemented the sync version of PublishDataGreaterThanTwentyMib in StreamLayerClientImpl. Added tests for success and failure cases, which would cover the sync PublishApi and BlobApi
- Moved GeneratedUuid method from anonymous namespace to the virtual protected method, so it can be mocked;
- improved logging;

Relates-to: OLPEDGE-1182

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>