### PR TITLE
Added parsing of Client Id from Access Token

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/SignInResult.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/SignInResult.h
@@ -77,6 +77,14 @@ class AUTHENTICATION_API SignInResult {
   const std::string& GetAccessToken() const;
 
   /**
+   * @brief Gets client ID
+   * @return The string that contains the client ID that is associated with the
+   * access token. In case of parsing errors this method will return empty
+   * string. Proper message will be printed to log.
+   */
+  const std::string& GetClientId() const;
+
+  /**
    * @brief Gets the access token type.
    *
    * @return The string containing the access token type (always a bearer

--- a/olp-cpp-sdk-authentication/src/SignInResult.cpp
+++ b/olp-cpp-sdk-authentication/src/SignInResult.cpp
@@ -44,6 +44,10 @@ const std::string& SignInResult::GetAccessToken() const {
   return impl_->GetAccessToken();
 }
 
+const std::string& SignInResult::GetClientId() const {
+  return impl_->GetClientId();
+}
+
 const std::string& SignInResult::GetTokenType() const {
   return impl_->GetTokenType();
 }

--- a/olp-cpp-sdk-authentication/src/SignInResultImpl.cpp
+++ b/olp-cpp-sdk-authentication/src/SignInResultImpl.cpp
@@ -19,17 +19,33 @@
 
 #include "SignInResultImpl.h"
 
+#include <vector>
+
 #include "Constants.h"
 #include "olp/core/http/HttpStatusCode.h"
+#include "olp/core/logging/Log.h"
+#include "olp/core/utils/Base64.h"
 
 namespace {
 constexpr auto kTokenType = "tokenType";
 constexpr auto kUserId = "userId";
 constexpr auto kScope = "scope";
+constexpr auto kLogTag = "SignIn";
+
 }  // namespace
 
 namespace olp {
 namespace authentication {
+
+namespace {
+bool IsJwtToken(const std::string& token) {
+  return token.front() == 'e';
+}
+
+bool IsHnToken(const std::string& token) {
+    return token.front() == 'h';
+}
+}  // namespace
 
 SignInResultImpl::SignInResultImpl() noexcept
     : SignInResultImpl(http::HttpStatusCode::SERVICE_UNAVAILABLE,
@@ -50,8 +66,10 @@ SignInResultImpl::SignInResultImpl(
       status_ = http::HttpStatusCode::SERVICE_UNAVAILABLE;
       error_.message = Constants::ERROR_HTTP_SERVICE_UNAVAILABLE;
     } else {
-      if (json_document->HasMember(Constants::ACCESS_TOKEN))
+      if (json_document->HasMember(Constants::ACCESS_TOKEN)) {
         access_token_ = (*json_document)[Constants::ACCESS_TOKEN].GetString();
+        client_id_ = ParseClientIdFromToken(access_token_.c_str());
+      }
       if (json_document->HasMember(kTokenType))
         token_type_ = (*json_document)[kTokenType].GetString();
       if (json_document->HasMember(Constants::REFRESH_TOKEN))
@@ -73,6 +91,8 @@ const std::string& SignInResultImpl::GetAccessToken() const {
   return access_token_;
 }
 
+const std::string& SignInResultImpl::GetClientId() const { return client_id_; }
+
 const std::string& SignInResultImpl::GetTokenType() const {
   return token_type_;
 }
@@ -90,6 +110,70 @@ const std::string& SignInResultImpl::GetUserIdentifier() const {
 const std::string& SignInResultImpl::GetScope() const { return scope_; }
 
 bool SignInResultImpl::IsValid() const { return is_valid_; }
+
+std::string SignInResultImpl::ParseJwtToken(const std::string& token) {
+  const std::string::size_type first_dot = token.find_first_of('.');
+  if (first_dot == std::string::npos) {
+    OLP_SDK_LOG_ERROR(kLogTag, "Cannot parse ClientId. Wrong token format.");
+    return std::string();
+  }
+
+  const std::string jws_header_encoded = token.substr(0, first_dot);
+
+  std::vector<std::uint8_t> decoded_bytes;
+  if (!utils::Base64Decode(jws_header_encoded, decoded_bytes)) {
+    OLP_SDK_LOG_ERROR(kLogTag,
+                      "Cannot parse ClientId. Non-decodable token format");
+    return std::string();
+  }
+
+  std::string jws_header_decoded;
+  std::copy(decoded_bytes.begin(), decoded_bytes.end(),
+            std::back_inserter(jws_header_decoded));
+
+  rapidjson::Document doc;
+  doc.Parse(jws_header_decoded.c_str());
+
+  if (doc.HasParseError() || !doc.IsObject()) {
+    OLP_SDK_LOG_ERROR(kLogTag, "Cannot parse ClientId. Defective token format");
+    return std::string();
+  }
+
+  auto client_id_field = doc.FindMember("aid");
+  if (client_id_field == doc.MemberEnd() ||
+      !client_id_field->value.IsString()) {
+    OLP_SDK_LOG_ERROR(kLogTag,
+                      "Cannot parse ClientId. Field does not exist or is not "
+                      "a string json value");
+    return std::string();
+  }
+
+  const std::string result = client_id_field->value.GetString();
+
+  if (result.empty()) {
+    OLP_SDK_LOG_ERROR(kLogTag,
+                      "Cannot parse ClientId. Incomplete token format");
+  }
+
+  return result;
+}
+
+std::string SignInResultImpl::ParseClientIdFromToken(const std::string& token) {
+  if (token.empty()) {
+    OLP_SDK_LOG_ERROR(kLogTag, "Token is empty");
+    return std::string();
+  }
+
+  if (IsJwtToken(token)) {
+    return ParseJwtToken(token);
+  } else if (IsHnToken(token)) {
+    OLP_SDK_LOG_ERROR(kLogTag, "hN Tokens are not supported!");
+    return std::string();
+  } else {
+    OLP_SDK_LOG_ERROR(kLogTag, "Unknown token format");
+    return std::string();
+  }
+}
 
 }  // namespace authentication
 }  // namespace olp

--- a/olp-cpp-sdk-authentication/src/SignInResultImpl.h
+++ b/olp-cpp-sdk-authentication/src/SignInResultImpl.h
@@ -51,6 +51,13 @@ class SignInResultImpl : public BaseResult {
   const std::string& GetTokenType() const;
 
   /**
+   * @brief The client ID getter method
+   * @return string containing the client id that is associated with the access
+   * token
+   */
+  const std::string& GetClientId() const;
+
+  /**
    * @brief Refresh token getter method
    * @return string containing a token which is used to obtain a new access
    * token using the refresh API. Refresh token is always issued unless
@@ -79,11 +86,15 @@ class SignInResultImpl : public BaseResult {
   const std::string& GetScope() const;
 
  private:
+  static std::string ParseJwtToken(const std::string&);
+  static std::string ParseClientIdFromToken(const std::string& token);
+
   bool is_valid_;
 
  protected:
   std::string access_token_;
   std::string token_type_;
+  std::string client_id_;
   time_t expiry_time_;
   std::string refresh_token_;
   std::string user_identifier_;

--- a/olp-cpp-sdk-authentication/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-authentication/tests/CMakeLists.txt
@@ -17,6 +17,7 @@
 
 set(OLP_AUTHENTICATION_TEST_SOURCES
     AuthenticationCredentialsTest.cpp
+    SignInResultImplTest.cpp
 )
 
 if (ANDROID OR IOS)

--- a/olp-cpp-sdk-authentication/tests/SignInResultImplTest.cpp
+++ b/olp-cpp-sdk-authentication/tests/SignInResultImplTest.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gtest/gtest.h>
+#include <olp/core/http/HttpStatusCode.h>
+#include "../src/SignInResultImpl.h"
+
+namespace {
+constexpr auto kClientId = "4GaUh8X9CpOax4CCC3of";
+constexpr auto kTokenResponse =
+    "{\"accessToken\":"
+    "\"eyJhbGciOiJSUzUxMiIsImN0eSI6IkpXVCIsImlzcyI6IkhFUkUiLCJhaWQiOiI0R2FVaDhY"
+    "OUNwT2F4NENDQzNvZiIsImlhdCI6MTU3ODMxMDExNCwiZXhwIjoxNTc4MzEzNzE0LCJraWQiOi"
+    "JqMSJ9."
+    "ZXlKaGJHY2lPaUprYVhJaUxDSmxibU1pT2lKQk1qVTJRMEpETFVoVE5URXlJbjAuLnFMb0Jmd0"
+    "1rSVktRHhuRFA1Ym9kYlEubmdZZkJIUFBsNXVBazZvY0w5djVTa3R4QU4xalE4RENjTzBiYnJO"
+    "Y2FuUkdKWFRvaU8tRXRuNGFNZE44OTBXaDR5QUlKaWI4LTUzY3lVMWVDZF9iX0ZCRmYxWEFsVU"
+    "ZkU1lFdUtFWHpoVUVVVnB0ZE1QdlY2VnVEVWktbTJoYWQ3ZEd4YUtXdVNoVVJNVFpOa1NHZy13"
+    "Lm9wdHJQUzRYQi1CNnBxdTZxa1Y4a09WQlNLbXFLUVhBODRMUV9IS0RZTms."
+    "UGyfwSjA8g6gDfLY4sCEu4fkrgp8WNm-uq5F2KLJ-zcDJIwoPKNrJjd2FEZdllG8-"
+    "tbbVWx5fwxn9qV6vLbm5BOMdvX3eMw_FQgsEPQAX3cOyv3he-"
+    "3xIlw0WjEAEfI6hOZnx89FdkKGXuUp7cOPaM-b133mFsE-"
+    "S5uuuQ3vYnztKcfmEwc8SSzgCiyRTuUYUE_ESZdpwQi1jx1rbag7fBFqIIGNSVN_"
+    "d6Scpg2s6ybHftoXajMVydnvmG4Iyls8eOeCcLDYMUPcgy05Uqc5CMvGSsL8WUOJAoLWw3eF_"
+    "ik1Xyv4iHRz3-67EAzzdwtL6nPbN8c0S16leVshnfdUZA\",\"tokenType\":\"bearer\","
+    "\"expiresIn\":3599}";
+constexpr auto kInvalidTokenResponse =
+    "{\"accessToken\":"
+    "\"eyJhbGciOiJSUzUxbx5sImN0eSI6IkpXVCIsImlzcyI6IkhFUkUiLCJhaWQiOiI0R2FVaDhY"
+    "OUNwT2F4NENDQzNvZiIsImlhdCI6MTU3ODMxMDExNCwiZXhwIjoxNTc4MzEzNzE0LCJraWQiOi"
+    "JqMSJ9."
+    "ZXlKaGJHY2lPaUprYVhJaUxDSmxibU1pT2lKQk1qVTJRMEpETFVoVE5URXlJbjAuLnFMb0Jmd0"
+    "1rSVktRHhuRFA1Ym9kYlEubmdZZkJIUFBsNXVBazZvY0w5djVTa3R4QU4xalE4RENjTzBiYnJO"
+    "Y2FuUkdKWFRvaU8tRXRuNGFNZE44OTBXaDR5QUlKaWI4LTUzY3lVMWVDZF9iX0ZCRmYxWEFsVU"
+    "ZkU1lFdUtFWHpoVUVVVnB0ZE1QdlY2VnVEVWktbTJoYWQ3ZEd4YUtXdVNoVVJNVFpOa1NHZy13"
+    "Lm9wdHJQUzRYQi1CNnBxdTZxa1Y4a09WQlNLbXFLUVhBODRMUV9IS0RZTms."
+    "UGyfwSjA8g6gDfLY4sCEu4fkrgp8WNm-uq5F2KLJ-zcDJIwoPKNrJjd2FEZdllG8-"
+    "tbbVWx5fwxn9qV6vLbm5BOMdvX3eMw_FQgsEPQAX3cOyv3he-"
+    "3xIlw0WjEAEfI6hOZnx89FdkKGXuUp7cOPaM-b133mFsE-"
+    "S5uuuQ3vYnztKcfmEwc8SSzgCiyRTuUYUE_ESZdpwQi1jx1rbag7fBFqIIGNSVN_"
+    "d6Scpg2s6ybHftoXajMVydnvmG4Iyls8eOeCcLDYMUPcgy05Uqc5CMvGSsL8WUOJAoLWw3eF_"
+    "ik1Xyv4iHRz3-67EAzzdwtL6nPbN8c0S16leVshnfdUZA\",\"tokenType\":\"bearer\","
+    "\"expiresIn\":3599}";
+constexpr auto kNoIdFieldInToken =
+    "{\"accessToken\":"
+    "\"eyJhbGciOiJSUzUxMiIsImN0eSI6IkpXVCIsImlzcyI6IkhFUkUiLCJhaWQiOjMsImlhdCI6"
+    "MTU3ODMxMDExNCwiZXhwIjoxNTc4MzEzNzE0LCJraWQiOiJqMSJ9."
+    "ZXlKaGJHY2lPaUprYVhJaUxDSmxibU1pT2lKQk1qVTJRMEpETFVoVE5URXlJbjAuLnFMb0Jmd0"
+    "1rSVktRHhuRFA1Ym9kYlEubmdZZkJIUFBsNXVBazZvY0w5djVTa3R4QU4xalE4RENjTzBiYnJO"
+    "Y2FuUkdKWFRvaU8tRXRuNGFNZE44OTBXaDR5QUlKaWI4LTUzY3lVMWVDZF9iX0ZCRmYxWEFsVU"
+    "ZkU1lFdUtFWHpoVUVVVnB0ZE1QdlY2VnVEVWktbTJoYWQ3ZEd4YUtXdVNoVVJNVFpOa1NHZy13"
+    "Lm9wdHJQUzRYQi1CNnBxdTZxa1Y4a09WQlNLbXFLUVhBODRMUV9IS0RZTms."
+    "UGyfwSjA8g6gDfLY4sCEu4fkrgp8WNm-uq5F2KLJ-zcDJIwoPKNrJjd2FEZdllG8-"
+    "tbbVWx5fwxn9qV6vLbm5BOMdvX3eMw_FQgsEPQAX3cOyv3he-"
+    "3xIlw0WjEAEfI6hOZnx89FdkKGXuUp7cOPaM-b133mFsE-"
+    "S5uuuQ3vYnztKcfmEwc8SSzgCiyRTuUYUE_ESZdpwQi1jx1rbag7fBFqIIGNSVN_"
+    "d6Scpg2s6ybHftoXajMVydnvmG4Iyls8eOeCcLDYMUPcgy05Uqc5CMvGSsL8WUOJAoLWw3eF_"
+    "ik1Xyv4iHRz3-67EAzzdwtL6nPbN8c0S16leVshnfdUZA\",\"tokenType\":\"bearer\","
+    "\"expiresIn\":3599}";
+constexpr auto kWrongIdFieldInToken =
+    "{\"accessToken\":"
+    "\"eyJhbGciOiJSUzUxMiIsImN0eSI6IkpXVCIsImlzcyI6IkhFUkUiLCJhaWQiOjMsImlhdCI6"
+    "MTU3ODMxMDExNCwiZXhwIjoxNTc4MzEzNzE0LCJraWQiOiJqMSJ9."
+    "ZXlKaGJHY2lPaUprYVhJaUxDSmxibU1pT2lKQk1qVTJRMEpETFVoVE5URXlJbjAuLnFMb0Jmd0"
+    "1rSVktRHhuRFA1Ym9kYlEubmdZZkJIUFBsNXVBazZvY0w5djVTa3R4QU4xalE4RENjTzBiYnJO"
+    "Y2FuUkdKWFRvaU8tRXRuNGFNZE44OTBXaDR5QUlKaWI4LTUzY3lVMWVDZF9iX0ZCRmYxWEFsVU"
+    "ZkU1lFdUtFWHpoVUVVVnB0ZE1QdlY2VnVEVWktbTJoYWQ3ZEd4YUtXdVNoVVJNVFpOa1NHZy13"
+    "Lm9wdHJQUzRYQi1CNnBxdTZxa1Y4a09WQlNLbXFLUVhBODRMUV9IS0RZTms."
+    "UGyfwSjA8g6gDfLY4sCEu4fkrgp8WNm-uq5F2KLJ-zcDJIwoPKNrJjd2FEZdllG8-"
+    "tbbVWx5fwxn9qV6vLbm5BOMdvX3eMw_FQgsEPQAX3cOyv3he-"
+    "3xIlw0WjEAEfI6hOZnx89FdkKGXuUp7cOPaM-b133mFsE-"
+    "S5uuuQ3vYnztKcfmEwc8SSzgCiyRTuUYUE_ESZdpwQi1jx1rbag7fBFqIIGNSVN_"
+    "d6Scpg2s6ybHftoXajMVydnvmG4Iyls8eOeCcLDYMUPcgy05Uqc5CMvGSsL8WUOJAoLWw3eF_"
+    "ik1Xyv4iHRz3-67EAzzdwtL6nPbN8c0S16leVshnfdUZA\",\"tokenType\":\"bearer\","
+    "\"expiresIn\":3599}";
+constexpr auto kWrongFormatToken =
+    "{\"accessToken\":"
+    "\"eyJhbGciOiJSUzUxMiIsImN0eSI6IkpXVCIsImlzcyI6IkhFUkUiLCJhaWQiOiI0R2FVaDhY"
+    "OUNwT2F4NENDQzNvZiIsImlhdCI6MTU3ODMxMDExNCwiZXhwIjoxNTc4MzEzNzE0LCJraWQiOi"
+    "JqMSJ9\",\"tokenType\":\"bearer\",\"expiresIn\":3599}";
+
+TEST(SignInResultImplTest, ValidToken) {
+  auto doc = std::make_shared<rapidjson::Document>();
+  doc->Parse(kTokenResponse);
+  olp::authentication::SignInResultImpl result(olp::http::HttpStatusCode::OK,
+                                               std::string(), doc);
+  EXPECT_EQ(result.GetClientId(), kClientId);
+}
+
+TEST(SignInResultImplTest, WrongIdField) {
+  auto doc = std::make_shared<rapidjson::Document>();
+  doc->Parse(kWrongIdFieldInToken);
+  olp::authentication::SignInResultImpl result(olp::http::HttpStatusCode::OK,
+                                               std::string(), doc);
+  EXPECT_TRUE(result.GetClientId().empty());
+}
+
+TEST(SignInResultImplTest, NoIdField) {
+  auto doc = std::make_shared<rapidjson::Document>();
+  doc->Parse(kNoIdFieldInToken);
+  olp::authentication::SignInResultImpl result(olp::http::HttpStatusCode::OK,
+                                               std::string(), doc);
+  EXPECT_TRUE(result.GetClientId().empty());
+}
+
+TEST(SignInResultImplTest, NotSupportedFormat) {
+  auto doc = std::make_shared<rapidjson::Document>();
+  doc->Parse(kWrongFormatToken);
+  olp::authentication::SignInResultImpl result(olp::http::HttpStatusCode::OK,
+                                               std::string(), doc);
+  EXPECT_TRUE(result.GetClientId().empty());
+}
+
+TEST(SignInResultImplTest, InvalidToken) {
+  auto doc = std::make_shared<rapidjson::Document>();
+  doc->Parse(kInvalidTokenResponse);
+  olp::authentication::SignInResultImpl result(olp::http::HttpStatusCode::OK,
+                                               std::string(), doc);
+  EXPECT_TRUE(result.GetClientId().empty());
+}
+}  // namespace

--- a/scripts/linux/fv/olp-common.variables
+++ b/scripts/linux/fv/olp-common.variables
@@ -10,6 +10,7 @@ export index_layer="olp-cpp-sdk-ingestion-test-index-layer"
 ###
 export service_id="${appid}"
 export service_secret="${secret}"
+export service_client_id="${client_id}"
 export production_service_id="${production_service_id}"
 export production_service_secret="${production_service_secret}"
 export facebook_access_token="${facebook_access_token}"


### PR DESCRIPTION
Now ClientId that is associated with access token can be
retrieved using SignInResult::GetClientId() method

Resolves: OLPEDGE-1287

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>