### PR TITLE
Models for Stream Layer added

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/generated/model/ConsumeDataResponse.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/model/ConsumeDataResponse.h
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <boost/optional.hpp>
+#include <olp/dataservice/read/model/Data.h>
+#include "StreamOffset.h"
+
+namespace olp {
+namespace dataservice {
+namespace read {
+namespace model {
+
+class Metadata {
+ public:
+  Metadata() = default;
+  virtual ~Metadata() = default;
+
+  const std::string& GetPartition() const { return partition_; }
+  void SetPartition(const std::string& value) { partition_ = value; }
+
+  const boost::optional<std::string>& GetChecksum() const { return checksum_; }
+  void SetChecksum(const std::string& value) { checksum_ = value; }
+
+  const boost::optional<int64_t>& GetCompressedDataSize() const {
+    return compressed_data_size_;
+  }
+  void SetCompressedDataSize(int64_t value) { compressed_data_size_ = value; }
+
+  const boost::optional<int64_t>& GetDataSize() const { return data_size_; }
+  void SetDataSize(int64_t value) { data_size_ = value; }
+
+  const Data& GetData() const { return data_; }
+  void SetData(const Data& value) { data_ = value; }
+
+  const boost::optional<std::string>& GetDataHandle() const {
+    return data_handle_;
+  }
+  void SetDataHandle(const std::string& value) { data_handle_ = value; }
+
+  const boost::optional<int64_t>& GetTimestamp() const { return timestamp_; }
+  void SetTimestamp(int64_t value) { timestamp_ = value; }
+
+ private:
+  /**
+   * @brief A key that specifies which
+   * [Partition](https://developer.here.com/olp/documentation/data-user-guide/shared_content/topics/olp/concepts/partitions.html)
+   * the content is related to. This is provided by the user while producing to
+   * the stream layer. The maximum length of the partition key is 500
+   * characters.
+   */
+  std::string partition_;
+
+  /**
+   * @brief The checksum of the content. The algorithm used to calculate the
+   * checksum is user specific. Algorithms that can be used are, for example,
+   * MD5 or SHA1. This is not a secure hash, it's used only to detect changes in
+   * content.
+   */
+  boost::optional<std::string> checksum_;
+
+  /**
+   * @brief The compressed size of the content in bytes. Applicable also when
+   * `Content-Encoding` is set to gzip when uploading and downloading data.
+   * Note: This will be present only if ‘_dataHandle_’ field is present.
+   */
+  boost::optional<int64_t> compressed_data_size_;
+
+  /**
+   * @brief The nominal size in bytes of the content. When compression is
+   * enabled, this is the size of the uncompressed content. Note: This will be
+   * present only if the ‘dataHandle’ field is present.
+   */
+  boost::optional<int64_t> data_size_;
+
+  /**
+   * @brief The content published directly in the metadata and encoded in
+   * base64. The size of the content is limited. Either `data` or `dataHandle`
+   * must be present. Data Handle Example: 1b2ca68f-d4a0-4379-8120-cd025640510c.
+   * Note: This will be present only if the message size is less than or equal
+   * to 1 MB.
+   */
+  Data data_;
+
+  /**
+   * @brief The handle created when uploading the content. It is used to
+   * retrieve the content at a later stage. Either `data` or `dataHandle` must
+   * be present. Note: This will be present only if the message size is greater
+   * than 1 MB.
+   */
+  boost::optional<std::string> data_handle_;
+
+  /**
+   * @brief The timestamp of the content, in milliseconds since the Unix epoch.
+   * This can be provided by the user while producing to the stream layer. Refer
+   * to [NewPartition
+   * Object](https://developer.here.com/olp/documentation/data-client-library/api_reference_scala/index.html#com.here.platform.data.client.scaladsl.NewPartition).
+   * If not provided by the user, this is the timestamp when the message was
+   * produced to the stream layer.
+   */
+  boost::optional<int64_t> timestamp_;
+};
+
+class Message {
+ public:
+  Message() = default;
+  virtual ~Message() = default;
+
+  const Metadata& GetMetaData() const { return meta_data_; };
+  void SetMetaData(const Metadata& value) { meta_data_ = value; };
+
+  const StreamOffset& GetOffset() const { return offset_; };
+  void SetOffset(const StreamOffset& value) { offset_ = value; };
+
+ private:
+  Metadata meta_data_;
+  StreamOffset offset_;
+};
+
+class ConsumeDataResponse {
+ public:
+  ConsumeDataResponse() = default;
+  virtual ~ConsumeDataResponse() = default;
+
+  const std::vector<Message>& GetMessages() const { return messages_; };
+  void SetMessages(const std::vector<Message>& value) { messages_ = value; };
+
+ private:
+  std::vector<Message> messages_;
+};
+
+}  // namespace model
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/generated/model/ConsumerSubscribeResponse.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/model/ConsumerSubscribeResponse.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+
+#include <boost/optional.hpp>
+
+namespace olp {
+namespace dataservice {
+namespace read {
+namespace model {
+
+class ConsumerSubscribeResponse {
+ public:
+  ConsumerSubscribeResponse() = default;
+  virtual ~ConsumerSubscribeResponse() = default;
+
+  const boost::optional<std::string>& GetNodeBaseURL() const {
+    return node_base_url_;
+  }
+  void SetNodeBaseURL(const std::string& value) { node_base_url_ = value; }
+
+  const boost::optional<std::string>& GetSubscriptionId() const {
+    return subscription_id_;
+  }
+  void SetSubscriptionId(const std::string& value) { subscription_id_ = value; }
+
+ private:
+  /**
+   * @brief A subscription/Kafka Consumer is created in a specific server
+   * instance. This base URL represents the specific server node on which this
+   * subscription/Kafka Consumer was created. This base URL should be used
+   * instead of the base URL returned by the `lookup` service when making
+   * requests to these endpoints: /partitions, /offsets, /seek and /subscribe
+   * (DELETE).
+   */
+  boost::optional<std::string> node_base_url_;
+
+  /**
+   * @brief A unique identifier of the subscription. It is used to make requests
+   * to these endpoints: /partitions, /offsets, /seek and /subscribe (DELETE).
+   */
+  boost::optional<std::string> subscription_id_;
+};
+
+}  // namespace model
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/generated/model/OffsetsRequest.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/model/OffsetsRequest.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "StreamOffset.h"
+
+namespace olp {
+namespace dataservice {
+namespace read {
+namespace model {
+
+class OffsetsRequest {
+ public:
+  OffsetsRequest() = default;
+  virtual ~OffsetsRequest() = default;
+
+  const std::vector<StreamOffset>& GetOffsets() const { return offsets_; }
+  OffsetsRequest& WithOffsets(const std::vector<StreamOffset>& value) {
+    offsets_ = value;
+    return *this;
+  }
+
+ private:
+  std::vector<StreamOffset> offsets_;
+};
+
+}  // namespace model
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/generated/model/StreamLayerEndpointResponse.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/model/StreamLayerEndpointResponse.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace olp {
+namespace dataservice {
+namespace read {
+namespace model {
+
+class BootstrapServer {
+ public:
+  BootstrapServer() = default;
+  virtual ~BootstrapServer() = default;
+
+  const std::string& GetHostname() const { return m_Hostname; }
+  void SetHostname(const std::string& value) { m_Hostname = value; }
+
+  int32_t GetPort() const { return m_Port; }
+  void SetPort(int32_t value) { m_Port = value; }
+
+ private:
+  std::string m_Hostname;
+  int32_t m_Port;
+};
+
+/**
+ * @brief Information to use to connect to the stream layer.
+ */
+class StreamLayerEndpointResponse {
+ public:
+  StreamLayerEndpointResponse() = default;
+  virtual ~StreamLayerEndpointResponse() = default;
+
+  const std::vector<std::string>& GetKafkaProtocolVersion() {
+    return kafka_protocol_version_;
+  }
+  void SetKafkaProtocolVersion(const std::vector<std::string>& value) {
+    kafka_protocol_version_ = value;
+  }
+
+  const std::string& GetTopic() const { return topic_; }
+  void SetTopic(const std::string& value) { topic_ = value; }
+
+  const std::string& GetClientId() const { return client_id_; }
+  void SetClientId(const std::string& value) { client_id_ = value; }
+
+  const std::string& GetConsumerGroupPrefix() const {
+    return consumer_group_prefix_;
+  }
+  void SetConsumerGroupPrefix(const std::string& value) {
+    consumer_group_prefix_ = value;
+  }
+
+  const std::vector<BootstrapServer>& GetBootstrapServers() const {
+    return bootstrap_servers_;
+  }
+  void SetBootstrapServers(const std::vector<BootstrapServer>& value) {
+    bootstrap_servers_ = value;
+  }
+
+  const std::vector<BootstrapServer>& GetBootstrapServersInternal() const {
+    return bootstrap_servers_internal_;
+  }
+  void SetBootstrapServersInternal(const std::vector<BootstrapServer>& value) {
+    bootstrap_servers_internal_ = value;
+  }
+
+ private:
+  std::vector<std::string> kafka_protocol_version_;
+
+  std::string topic_;
+
+  std::string client_id_;
+
+  /**
+   * @brief If present, this should be used as the prefix of `group.id` [Kafka
+   * Consumer
+   * properties](https://kafka.apache.org/11/documentation.html#newconsumerconfigs).
+   */
+  std::string consumer_group_prefix_;
+
+  std::vector<BootstrapServer> bootstrap_servers_;
+
+  std::vector<BootstrapServer> bootstrap_servers_internal_;
+};
+
+}  // namespace model
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/generated/model/StreamOffset.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/model/StreamOffset.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+namespace olp {
+namespace dataservice {
+namespace read {
+namespace model {
+
+/**
+ * @brief An offset in a specific partition of the stream layer.
+ */
+class StreamOffset {
+ public:
+  StreamOffset() = default;
+  virtual ~StreamOffset() = default;
+
+  int32_t GetPartition() const { return partition_; }
+  void SetPartition(int32_t value) { partition_ = value; }
+
+  int64_t GetOffset() const { return offset_; };
+  void SetOffset(int64_t value) { offset_ = value; }
+
+ private:
+  /**
+   * @brief The partition of the stream layer for which this offset applies. It
+   * is not the same as [Partitions
+   * object](https://developer.here.com/olp/documentation/data-user-guide/shared_content/topics/olp/concepts/partitions.html).
+   */
+  int32_t partition_;
+
+  /**
+   * @brief The offset in the partition of the stream layer.
+   */
+  int64_t offset_;
+};
+
+}  // namespace model
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/generated/model/SubscriptionProperties.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/model/SubscriptionProperties.h
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+
+#include <boost/optional.hpp>
+
+namespace olp {
+namespace dataservice {
+namespace read {
+namespace model {
+
+/**
+ * @brief This is the same as [Kafka Consumer
+ * properties](https://kafka.apache.org/11/documentation.html#newconsumerconfigs)
+ * with some default values changed.
+ */
+class KafkaConsumerProperties {
+ public:
+  KafkaConsumerProperties() = default;
+  virtual ~KafkaConsumerProperties() = default;
+
+  const boost::optional<int32_t>& GetAutoCommitIntervalMs() const {
+    return auto_commit_interval_ms_;
+  }
+  KafkaConsumerProperties& SetAutoCommitIntervalMs(int32_t value) {
+    auto_commit_interval_ms_ = value;
+    return *this;
+  }
+
+  const boost::optional<std::string>& GetAutoOffsetReset() const {
+    return auto_offset_reset_;
+  }
+  KafkaConsumerProperties& SetAutoOffsetReset(const std::string& value) {
+    auto_offset_reset_ = value;
+    return *this;
+  }
+
+  const boost::optional<bool>& isEnableAutoCommit() const {
+    return enable_auto_commit_;
+  }
+  KafkaConsumerProperties& SetEnableAutoCommit(bool value) {
+    enable_auto_commit_ = value;
+    return *this;
+  }
+
+  const boost::optional<int32_t>& GetFetchMaxBytes() const {
+    return fetch_max_bytes_;
+  }
+  KafkaConsumerProperties& SetFetchMaxBytes(int32_t value) {
+    fetch_max_bytes_ = value;
+    return *this;
+  }
+
+  const boost::optional<int32_t>& GetFetchMaxWaitMs() const {
+    return fetch_max_wait_ms_;
+  }
+  KafkaConsumerProperties& SetFetchMaxWaitMs(int32_t value) {
+    fetch_max_wait_ms_ = value;
+    return *this;
+  }
+
+  const boost::optional<int32_t>& GetFetchMinBytes() const {
+    return fetch_min_bytes_;
+  }
+  KafkaConsumerProperties& SetFetchMinBytes(int32_t value) {
+    fetch_min_bytes_ = value;
+    return *this;
+  }
+
+  const boost::optional<std::string> GetGroupId() const { return group_id_; }
+  KafkaConsumerProperties& SetGroupId(const std::string& value) {
+    group_id_ = value;
+    return *this;
+  }
+
+  const boost::optional<int32_t>& GetMaxPartitionFetchBytes() const {
+    return max_partition_fetch_bytes_;
+  }
+  KafkaConsumerProperties& SetMaxPartitionFetchBytes(int32_t value) {
+    max_partition_fetch_bytes_ = value;
+    return *this;
+  }
+
+  const boost::optional<int32_t>& GetMaxPollRecords() const {
+    return max_poll_records_;
+  }
+  KafkaConsumerProperties& SetMaxPollRecords(int32_t value) {
+    max_poll_records_ = value;
+    return *this;
+  }
+
+ private:
+  /**
+   * @brief Refer to [Kafka Consumer
+   * properties](https://kafka.apache.org/11/documentation.html#newconsumerconfigs)
+   */
+  boost::optional<int32_t> auto_commit_interval_ms_;
+
+  /**
+   * @brief Refer to [Kafka Consumer
+   * properties](https://kafka.apache.org/11/documentation.html#newconsumerconfigs)
+   */
+  boost::optional<std::string> auto_offset_reset_;
+
+  /**
+   * @brief Refer to [Kafka Consumer
+   * properties](https://kafka.apache.org/11/documentation.html#newconsumerconfigs)
+   */
+  boost::optional<bool> enable_auto_commit_;
+
+  /**
+   * @brief Refer to [Kafka Consumer
+   * properties](https://kafka.apache.org/11/documentation.html#newconsumerconfigs)
+   */
+  boost::optional<int32_t> fetch_max_bytes_;
+
+  /**
+   * @brief Refer to [Kafka Consumer
+   * properties](https://kafka.apache.org/11/documentation.html#newconsumerconfigs)
+   */
+  boost::optional<int32_t> fetch_max_wait_ms_;
+
+  /**
+   * @brief Refer to [Kafka Consumer
+   * properties](https://kafka.apache.org/11/documentation.html#newconsumerconfigs)
+   */
+  boost::optional<int32_t> fetch_min_bytes_;
+
+  /**
+   * @brief For applications intending to read in parallel mode belonging to
+   * same 'group.id' the values for 'catalogId, layerId, aid' should also be
+   * same.
+   */
+  boost::optional<std::string> group_id_;
+
+  /**
+   * @brief Refer to [Kafka Consumer
+   * properties](https://kafka.apache.org/11/documentation.html#newconsumerconfigs)
+   */
+  boost::optional<int32_t> max_partition_fetch_bytes_;
+
+  /**
+   * @brief Refer to [Kafka Consumer
+   * properties](https://kafka.apache.org/11/documentation.html#newconsumerconfigs)
+   */
+  boost::optional<int32_t> max_poll_records_;
+};
+
+class SubscriptionProperties {
+ public:
+  SubscriptionProperties() = default;
+  virtual ~SubscriptionProperties() = default;
+
+  const KafkaConsumerProperties& GetKafkaConsumerProperties() const {
+    return kafka_consumer_properties_;
+  }
+  SubscriptionProperties& WithKafkaConsumerProperties(
+      const KafkaConsumerProperties& value) {
+    kafka_consumer_properties_ = value;
+    return *this;
+  }
+
+ private:
+  KafkaConsumerProperties kafka_consumer_properties_;
+};
+
+}  // namespace model
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp


### PR DESCRIPTION
Models were generated using Swagger from OLP Stream API v2 and adapted
to be consistent with existing models for other layers.

All Doxygen documentation corresponds to OLP Stream API v2 descriptions.

Original OLP Stream API v2 models CommitOffsetsRequest and
SeekOffsetsRequest are represented in the code by single OffsetsRequest
model to reduce code duplication because they are completely the same.

Relates-To: OLPEDGE-1196

Signed-off-by: Mykola Malik <ext-mykola.malik@here.com>