### PR TITLE
Add a public CancelPendingRequests method to a StreamLayerClient

### DIFF
--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClient.h
@@ -80,6 +80,17 @@ class DATASERVICE_WRITE_API StreamLayerClient {
                     client::OlpClientSettings settings);
 
   /**
+   * @brief Cancels all the ongoing publish operations that this client started.
+   *
+   * Returns instantly and does not wait for the callbacks.
+   * Use this operation to cancel all the submitted publish requests without
+   * destroying the actual client instance.
+   * @note This operation does not cancel publish requests queued by the \ref
+   * Queue method.
+   */
+  void CancelPendingRequests();
+
+  /**
    * @brief Publishes data to an OLP stream layer.
    * @note Content-Type for this request is implicitly based on the
    * layer metadata for the target layer on OLP.

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClient.cpp
@@ -45,6 +45,10 @@ StreamLayerClient::StreamLayerClient(client::HRN catalog,
       std::move(catalog), std::move(client_settings), std::move(settings));
 }
 
+void StreamLayerClient::CancelPendingRequests() {
+  impl_->CancelPendingRequests();
+}
+
 olp::client::CancellableFuture<PublishDataResponse>
 StreamLayerClient::PublishData(model::PublishDataRequest request) {
   return impl_->PublishData(request);


### PR DESCRIPTION
Implemented CancelPendingRequests method to a StreamLayerClient with corresponding tests.
This will help users to cancel all the on-going requests without destroying instance of the client.

Resolves: OLPEDGE-975

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>
Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>