### PR TITLE
Add unit tests for olp::logging::Configuration class

### DIFF
--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -37,7 +37,9 @@ set(OLP_CPP_SDK_CORE_TESTS_SOURCES
     ./geo/tiling/TileKeyTest.cpp
     ./geo/tiling/TileKeyUtilsTest.cpp
 
+    ./logging/ConfigurationTest.cpp
     ./logging/MessageFormatterTest.cpp
+    ./logging/MockAppender.cpp
 
     ./olpclient/OlpClientTest.cpp
 

--- a/olp-cpp-sdk-core/tests/logging/ConfigurationTest.cpp
+++ b/olp-cpp-sdk-core/tests/logging/ConfigurationTest.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gtest/gtest.h>
+#include <olp/core/logging/Configuration.h>
+#include <olp/core/logging/Log.h>
+#include <memory>
+#include "MockAppender.h"
+
+namespace {
+
+using namespace olp::logging;
+using namespace testing;
+
+TEST(ConfigurationTest, InvalidConfiguration) {
+  Configuration configuration;
+  EXPECT_FALSE(configuration.isValid());
+  EXPECT_FALSE(Log::configure(configuration));
+  OLP_SDK_LOG_TRACE("My tag", "My message");
+}
+
+TEST(ConfigurationTest, DefaultConfiguration) {
+  Configuration configuration = Configuration::createDefault();
+  EXPECT_TRUE(configuration.isValid());
+  EXPECT_TRUE(Log::configure(configuration));
+  OLP_SDK_LOG_TRACE("My tag", "My message");
+}
+
+TEST(ConfigurationTest, MockAppender) {
+  Configuration configuration;
+  configuration.addAppender(std::make_shared<MockAppender>());
+  EXPECT_TRUE(configuration.isValid());
+  EXPECT_TRUE(Log::configure(configuration));
+  OLP_SDK_LOG_TRACE("My tag", "My message");
+}
+
+}  // namespace

--- a/olp-cpp-sdk-core/tests/logging/MockAppender.cpp
+++ b/olp-cpp-sdk-core/tests/logging/MockAppender.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "MockAppender.h"
+
+namespace testing {
+
+using namespace olp::logging;
+
+IAppender& MockAppender::append(const LogMessage& message) {
+  MockAppender::MessageData message_data;
+  message_data.level_ = message.level;
+  message_data.tag_ = message.tag;
+  message_data.message_ = message.message;
+  message_data.file_ = message.file;
+  message_data.line_ = message.line;
+  message_data.function_ = message.function;
+  messages_.emplace_back(message_data);
+
+  return *this;
+}
+
+}  // namespace testing

--- a/olp-cpp-sdk-core/tests/logging/MockAppender.h
+++ b/olp-cpp-sdk-core/tests/logging/MockAppender.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <olp/core/logging/Appender.h>
+#include <string>
+#include <vector>
+
+namespace testing {
+
+using namespace olp::logging;
+
+class MockAppender : public IAppender {
+ public:
+  struct MessageData {
+    Level level_;
+    std::string tag_;
+    std::string message_;
+    std::string file_;
+    unsigned int line_;
+    std::string function_;
+  };
+
+  IAppender& append(const LogMessage& message) override;
+
+  std::vector<MessageData> messages_;
+};
+
+}  // namespace testing


### PR DESCRIPTION
# Add unit tests for olp::logging::Configuration class

Introducing MockAppender that will be used for testing
this and other logging classes.

Relates-To: OLPEDGE-1237

Signed-off-by: Kirill Zhuchkov <643378+r0busta@users.noreply.github.com>