### PR TITLE
Add StreamOffset and StreamOffsets models for Stream Api

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/generated/parser/ParserWrapper.h
+++ b/olp-cpp-sdk-core/include/olp/core/generated/parser/ParserWrapper.h
@@ -21,15 +21,21 @@
 
 #include <map>
 #include <memory>
+#include <string>
 #include <vector>
 
-#include <rapidjson/rapidjson.h>
 #include <boost/optional.hpp>
+#include <rapidjson/rapidjson.h>
 
 namespace olp {
 namespace parser {
+
 inline void from_json(const rapidjson::Value& value, std::string& x) {
   x = value.GetString();
+}
+
+inline void from_json(const rapidjson::Value& value, int32_t& x) {
+  x = value.GetInt();
 }
 
 inline void from_json(const rapidjson::Value& value, int64_t& x) {
@@ -89,5 +95,4 @@ inline T parse(const rapidjson::Value& value, const std::string& name) {
 }
 
 }  // namespace parser
-
 }  // namespace olp

--- a/olp-cpp-sdk-core/include/olp/core/generated/serializer/SerializerWrapper.h
+++ b/olp-cpp-sdk-core/include/olp/core/generated/serializer/SerializerWrapper.h
@@ -21,32 +21,35 @@
 
 #include <map>
 #include <memory>
+#include <string>
 #include <vector>
 
-#include <rapidjson/rapidjson.h>
 #include <boost/optional.hpp>
+#include <rapidjson/document.h>
 
 namespace olp {
 namespace serializer {
-inline void to_json(const std::string& x,
-                    rapidjson::Value& value,
+
+inline void to_json(const std::string& x, rapidjson::Value& value,
                     rapidjson::Document::AllocatorType& allocator) {
   value.SetString(rapidjson::StringRef(x.c_str()), allocator);
 }
 
-inline void to_json(int64_t x,
-                    rapidjson::Value& value,
+inline void to_json(int32_t x, rapidjson::Value& value,
+                    rapidjson::Document::AllocatorType& allocator) {
+  value.SetInt(x);
+}
+
+inline void to_json(int64_t x, rapidjson::Value& value,
                     rapidjson::Document::AllocatorType& allocator) {
   value.SetInt64(x);
 }
 
-inline void to_json(double x,
-                    rapidjson::Value& value,
+inline void to_json(double x, rapidjson::Value& value,
                     rapidjson::Document::AllocatorType& allocator) {
   value.SetDouble(x);
 }
-inline void to_json(bool x,
-                    rapidjson::Value& value,
+inline void to_json(bool x, rapidjson::Value& value,
                     rapidjson::Document::AllocatorType& allocator) {
   value.SetBool(x);
 }
@@ -59,8 +62,7 @@ inline void to_json(const std::shared_ptr<std::vector<unsigned char>>& x,
 }
 
 template <typename T>
-inline void to_json(const boost::optional<T>& x,
-                    rapidjson::Value& value,
+inline void to_json(const boost::optional<T>& x, rapidjson::Value& value,
                     rapidjson::Document::AllocatorType& allocator) {
   if (x) {
     to_json(x.get(), value, allocator);
@@ -70,8 +72,7 @@ inline void to_json(const boost::optional<T>& x,
 }
 
 template <typename T>
-inline void to_json(const std::map<std::string, T>& x,
-                    rapidjson::Value& value,
+inline void to_json(const std::map<std::string, T>& x, rapidjson::Value& value,
                     rapidjson::Document::AllocatorType& allocator) {
   value.SetObject();
   for (auto itr = x.begin(); itr != x.end(); ++itr) {
@@ -83,12 +84,11 @@ inline void to_json(const std::map<std::string, T>& x,
 }
 
 template <typename T>
-inline void to_json(const std::vector<T>& x,
-                    rapidjson::Value& value,
+inline void to_json(const std::vector<T>& x, rapidjson::Value& value,
                     rapidjson::Document::AllocatorType& allocator) {
   value.SetArray();
-  for (typename std::vector<T>::const_iterator itr = x.begin();
-       itr != x.end(); ++itr) {
+  for (typename std::vector<T>::const_iterator itr = x.begin(); itr != x.end();
+       ++itr) {
     rapidjson::Value item_value;
     to_json(*itr, item_value, allocator);
     value.PushBack(item_value, allocator);
@@ -96,8 +96,7 @@ inline void to_json(const std::vector<T>& x,
 }
 
 template <typename T>
-inline void serialize(const std::string& key,
-                      const T& x,
+inline void serialize(const std::string& key, const T& x,
                       rapidjson::Value& value,
                       rapidjson::Document::AllocatorType& allocator) {
   rapidjson::Value item_value;
@@ -110,5 +109,4 @@ inline void serialize(const std::string& key,
 }
 
 }  // namespace serializer
-
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/model/StreamOffsets.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/model/StreamOffsets.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <vector>
+
+#include <olp/dataservice/read/DataServiceReadApi.h>
+
+namespace olp {
+namespace dataservice {
+namespace read {
+namespace model {
+
+/**
+ * @brief An offset in a specific partition of the stream layer.
+ */
+class DATASERVICE_READ_API StreamOffset final {
+ public:
+  StreamOffset() = default;
+
+  int32_t GetPartition() const { return partition_; }
+  void SetPartition(int32_t value) { partition_ = value; }
+
+  int64_t GetOffset() const { return offset_; };
+  void SetOffset(int64_t value) { offset_ = value; }
+
+ private:
+  /// The partition of the stream layer for which this offset applies. It is not
+  /// the same as [Partitions
+  /// object](https://developer.here.com/olp/documentation/data-api/data_dev_guide/rest/layers/partitions.html).
+  int32_t partition_;
+
+  /// The offset in the partition of the stream layer.
+  int64_t offset_;
+};
+
+/**
+ * @brief Represent a list of offsets.
+ */
+class DATASERVICE_READ_API StreamOffsets final {
+ public:
+  StreamOffsets() = default;
+
+  const std::vector<StreamOffset>& GetOffsets() const { return offsets_; };
+  void SetOffsets(std::vector<StreamOffset> value) {
+    offsets_ = std::move(value);
+  };
+
+ private:
+  std::vector<StreamOffset> offsets_;
+};
+
+}  // namespace model
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/generated/parser/StreamOffsetParser.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/parser/StreamOffsetParser.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "StreamOffsetParser.h"
+
+#include <olp/core/generated/parser/ParserWrapper.h>
+
+namespace olp {
+namespace parser {
+using namespace olp::dataservice::read;
+
+void from_json(const rapidjson::Value& value, model::StreamOffset& x) {
+  x.SetPartition(parse<int32_t>(value, "partition"));
+  x.SetOffset(parse<int64_t>(value, "offset"));
+}
+
+}  // namespace parser
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/generated/parser/StreamOffsetParser.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/parser/StreamOffsetParser.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <rapidjson/document.h>
+#include <olp/dataservice/read/model/StreamOffsets.h>
+
+namespace olp {
+namespace parser {
+
+void from_json(const rapidjson::Value& value,
+               olp::dataservice::read::model::StreamOffset& x);
+
+}  // namespace parser
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/generated/serializer/StreamOffsetsSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/serializer/StreamOffsetsSerializer.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "StreamOffsetsSerializer.h"
+
+#include <olp/core/generated/serializer/SerializerWrapper.h>
+
+namespace olp {
+namespace serializer {
+
+void to_json(const dataservice::read::model::StreamOffset& x,
+             rapidjson::Value& value,
+             rapidjson::Document::AllocatorType& allocator) {
+  value.SetObject();
+  serialize("partition", x.GetPartition(), value, allocator);
+  serialize("offset", x.GetOffset(), value, allocator);
+}
+
+void to_json(const dataservice::read::model::StreamOffsets& x,
+             rapidjson::Value& value,
+             rapidjson::Document::AllocatorType& allocator) {
+  value.SetObject();
+  serialize("offsets", x.GetOffsets(), value, allocator);
+}
+
+}  // namespace serializer
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/generated/serializer/StreamOffsetsSerializer.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/serializer/StreamOffsetsSerializer.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <rapidjson/document.h>
+#include <olp/dataservice/read/model/StreamOffsets.h>
+
+namespace olp {
+namespace serializer {
+
+void to_json(const dataservice::read::model::StreamOffset& x,
+             rapidjson::Value& value,
+             rapidjson::Document::AllocatorType& allocator);
+
+void to_json(const dataservice::read::model::StreamOffsets& x,
+             rapidjson::Value& value,
+             rapidjson::Document::AllocatorType& allocator);
+
+}  // namespace serializer
+}  // namespace olp


### PR DESCRIPTION
Models were generated using Swagger from OLP Stream API v2 and adapted
to be consistent with existing models for other layers and with Stream
Layer Client Detailed Design proposal.

Relates-To: OLPEDGE-1196

Signed-off-by: Mykola Malik <ext-mykola.malik@here.com>