### PR TITLE
Adapt dataservice-read request classes to coding style.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,12 @@
 
 #pragma once
 
-#include "FetchOptions.h"
-
 #include <sstream>
 #include <string>
 
+#include <olp/dataservice/read/DataServiceReadApi.h>
+#include <olp/dataservice/read/FetchOptions.h>
 #include <boost/optional.hpp>
-
-#include "DataServiceReadApi.h"
 
 namespace olp {
 namespace dataservice {
@@ -56,12 +54,11 @@ class DATASERVICE_READ_API CatalogRequest final {
    *
    * @see `GetBillingTag()` for usage and format.
    *
-   * @param billingTag The `BillingTag` string or `boost::none`.
+   * @param tag The `BillingTag` string or `boost::none`.
    * @return A reference to the updated `CatalogRequest` instance.
    */
-  inline CatalogRequest& WithBillingTag(
-      boost::optional<std::string> billingTag) {
-    billing_tag_ = billingTag;
+  inline CatalogRequest& WithBillingTag(boost::optional<std::string> tag) {
+    billing_tag_ = std::move(tag);
     return *this;
   }
 
@@ -70,12 +67,12 @@ class DATASERVICE_READ_API CatalogRequest final {
    *
    * @see `GetBillingTag()` for usage and format.
    *
-   * @param billingTag The rvalue reference to the `BillingTag` string or
+   * @param tag The rvalue reference to the `BillingTag` string or
    * `boost::none`.
    * @return A reference to the updated `CatalogRequest` instance.
    */
-  inline CatalogRequest& WithBillingTag(std::string&& billingTag) {
-    billing_tag_ = std::move(billingTag);
+  inline CatalogRequest& WithBillingTag(std::string&& tag) {
+    billing_tag_ = std::move(tag);
     return *this;
   }
 
@@ -90,16 +87,16 @@ class DATASERVICE_READ_API CatalogRequest final {
   inline FetchOptions GetFetchOption() const { return fetch_option_; }
 
   /**
-   * * @brief Sets the fetch option that you can use to set the source from
+   * @brief Sets the fetch option that you can use to set the source from
    * which data should be fetched.
    *
    * @see `GetFetchOption()` for usage and format.
    *
-   * @param fetchoption The `FetchOption` enum.
+   * @param fetch_option The `FetchOption` enum.
    * @return A reference to the updated `CatalogVersionRequest` instance.
    */
-  inline CatalogRequest& WithFetchOption(FetchOptions fetchoption) {
-    fetch_option_ = fetchoption;
+  inline CatalogRequest& WithFetchOption(FetchOptions fetch_option) {
+    fetch_option_ = fetch_option;
     return *this;
   }
 
@@ -110,19 +107,16 @@ class DATASERVICE_READ_API CatalogRequest final {
    */
   inline std::string CreateKey() const {
     std::stringstream out;
-
     if (GetBillingTag()) {
       out << "$" << GetBillingTag().get();
     }
-
     out << "^" << GetFetchOption();
-
     return out.str();
   }
 
  private:
   boost::optional<std::string> billing_tag_;
-  FetchOptions fetch_option_ = OnlineIfNotFound;
+  FetchOptions fetch_option_{OnlineIfNotFound};
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/DataRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/DataRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,10 +22,9 @@
 #include <sstream>
 #include <string>
 
-#include <olp/core/porting/deprecated.h>
+#include <olp/dataservice/read/DataServiceReadApi.h>
+#include <olp/dataservice/read/FetchOptions.h>
 #include <boost/optional.hpp>
-#include "DataServiceReadApi.h"
-#include "FetchOptions.h"
 
 namespace olp {
 namespace dataservice {
@@ -42,6 +41,25 @@ namespace read {
 class DATASERVICE_READ_API DataRequest final {
  public:
   /**
+   * @brief WithVersion sets the catalog metadata version of the request.
+   * @param catalog_version The catalog metadta version of the requested
+   * partions. If no version is specified, the latest will be retrieved.
+   * @return a reference to the updated PartitionsRequest.
+   */
+  inline DataRequest& WithVersion(boost::optional<int64_t> catalog_version) {
+    catalog_version_ = catalog_version;
+    return *this;
+  }
+
+  /**
+   * @brief Get the catalog metadata version requested for the partitions.
+   * @return the billing tag, or boost::none if not set.
+   */
+  inline const boost::optional<std::int64_t>& GetVersion() const {
+    return catalog_version_;
+  }
+
+  /**
    * @brief GetPartitionId gets the request's Partition Id.
    * @return the partition id.
    */
@@ -53,12 +71,12 @@ class DATASERVICE_READ_API DataRequest final {
    * @brief WithPartitionId sets the request's Partition Id. If the partition
    * cannot be found in the layer, the callback will come back with an empty
    * response (null for data and error)
-   * @param partitionId the Partition Id.
+   * @param partition_id the Partition Id.
    * @return a reference to the updated DataRequest.
    */
   inline DataRequest& WithPartitionId(
-      boost::optional<std::string> partitionId) {
-    partition_id_ = partitionId;
+      boost::optional<std::string> partition_id) {
+    partition_id_ = std::move(partition_id);
     return *this;
   }
 
@@ -66,32 +84,12 @@ class DATASERVICE_READ_API DataRequest final {
    * @brief WithPartitionId sets the request's Partition Id. If the partition
    * cannot be found in the layer, the callback will come back with an empty
    * response (null for data and error).
-   * @param partitionId the Partition Id.
+   * @param partition_id the Partition Id.
    * @return a reference to the updated DataRequest.
    */
-  inline DataRequest& WithPartitionId(std::string&& partitionId) {
-    partition_id_ = std::move(partitionId);
+  inline DataRequest& WithPartitionId(std::string&& partition_id) {
+    partition_id_ = std::move(partition_id);
     return *this;
-  }
-
-  /**
-   * @brief WithVersion sets the catalog metadata version of the request.
-   * @param catalogMetadataVersion The catalog metadta version of the requested
-   * partions. If no version is specified, the latest will be retrieved.
-   * @return a reference to the updated PartitionsRequest.
-   */
-  inline DataRequest& WithVersion(
-      boost::optional<int64_t> catalogMetadataVersion) {
-    catalog_metadata_version_ = catalogMetadataVersion;
-    return *this;
-  }
-
-  /**
-   * @brief Get the catalog metadata version requested for the partitions.
-   * @return the billing tag, or boost::none if not set.
-   */
-  inline const boost::optional<std::int64_t>& GetVersion() const {
-    return catalog_metadata_version_;
   }
 
   /**
@@ -106,11 +104,11 @@ class DATASERVICE_READ_API DataRequest final {
    * @brief WithDataHandle sets the request's Data Handle. If the data handle
    * cannot be found in the layer, the callback will come back with an empty
    * response (null for data and error).
-   * @param dataHandle the Data Handle.
+   * @param data_handle the Data Handle.
    * @return a reference to the updated DataRequest.
    */
-  inline DataRequest& WithDataHandle(boost::optional<std::string> dataHandle) {
-    data_handle_ = dataHandle;
+  inline DataRequest& WithDataHandle(boost::optional<std::string> data_handle) {
+    data_handle_ = std::move(data_handle);
     return *this;
   }
 
@@ -118,11 +116,11 @@ class DATASERVICE_READ_API DataRequest final {
    * @brief WithDataHandle sets the request's Data Handle. If the data handle
    * cannot be found in the layer, the callback will come back with an empty
    * response (null for data and error).
-   * @param dataHandle the Data Handle.
+   * @param data_handle the Data Handle.
    * @return a reference to the updated DataRequest.
    */
-  inline DataRequest& WithDataHandle(std::string&& dataHandle) {
-    data_handle_ = std::move(dataHandle);
+  inline DataRequest& WithDataHandle(std::string&& data_handle) {
+    data_handle_ = std::move(data_handle);
     return *this;
   }
 
@@ -139,23 +137,22 @@ class DATASERVICE_READ_API DataRequest final {
   /**
    * @brief WithBillingTag sets the billing tag. See ::GetBillingTag() for usage
    * and format.
-   * @param billingTag a string or boost::none
+   * @param tag a string or boost::none
    * @return a reference to the updated DataRequest
    */
-  inline DataRequest& WithBillingTag(
-      const boost::optional<std::string>& billingTag) {
-    billing_tag_ = billingTag;
+  inline DataRequest& WithBillingTag(const boost::optional<std::string>& tag) {
+    billing_tag_ = tag;
     return *this;
   }
 
   /**
    * @brief WithBillingTag sets the billing tag. See ::GetBillingTag() for usage
    * and format.
-   * @param billingTag a string or boost::none
+   * @param tag a string or boost::none
    * @return a reference to the updated DataRequest
    */
-  inline DataRequest& WithBillingTag(std::string&& billingTag) {
-    billing_tag_ = std::move(billingTag);
+  inline DataRequest& WithBillingTag(std::string&& tag) {
+    billing_tag_ = std::move(tag);
     return *this;
   }
 
@@ -170,11 +167,11 @@ class DATASERVICE_READ_API DataRequest final {
   /**
    * @brief WithFetchOption sets the fetch option. See ::GetFetchOption() for
    * usage and format.
-   * @param fetchoption enums
+   * @param fetch_option enums
    * @return a reference to the updated DataRequest
    */
-  inline DataRequest& WithFetchOption(FetchOptions fetchoption) {
-    fetch_option_ = fetchoption;
+  inline DataRequest& WithFetchOption(FetchOptions fetch_option) {
+    fetch_option_ = fetch_option;
     return *this;
   }
 
@@ -185,36 +182,29 @@ class DATASERVICE_READ_API DataRequest final {
    */
   inline std::string CreateKey(const std::string& layer_id) const {
     std::stringstream out;
-    out << layer_id;
-
-    out << "[";
-
+    out << layer_id << "[";
     if (GetPartitionId()) {
       out << GetPartitionId().get();
     } else if (GetDataHandle()) {
       out << GetDataHandle().get();
     }
     out << "]";
-
     if (GetVersion()) {
       out << "@" << GetVersion().get();
     }
-
     if (GetBillingTag()) {
       out << "$" << GetBillingTag().get();
     }
-
     out << "^" << GetFetchOption();
-
     return out.str();
   }
 
  private:
   boost::optional<std::string> partition_id_;
-  boost::optional<int64_t> catalog_metadata_version_;
+  boost::optional<int64_t> catalog_version_;
   boost::optional<std::string> data_handle_;
   boost::optional<std::string> billing_tag_;
-  FetchOptions fetch_option_ = OnlineIfNotFound;
+  FetchOptions fetch_option_{OnlineIfNotFound};
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/DataServiceReadApi.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/DataServiceReadApi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "olp/core/porting/export.h"
+#include <olp/core/porting/export.h>
 
 #ifdef DATASERVICE_READ_SHARED_LIBRARY
 #ifdef DATASERVICE_READ_LIBRARY

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PartitionsRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PartitionsRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,10 +22,9 @@
 #include <sstream>
 #include <string>
 
-#include <olp/core/porting/deprecated.h>
+#include <olp/dataservice/read/DataServiceReadApi.h>
+#include <olp/dataservice/read/FetchOptions.h>
 #include <boost/optional.hpp>
-#include "DataServiceReadApi.h"
-#include "FetchOptions.h"
 
 namespace olp {
 namespace dataservice {
@@ -41,13 +40,13 @@ class DATASERVICE_READ_API PartitionsRequest final {
    * @brief Sets the catalog metadata version for the request of the requested
    * partitions.
    *
-   * @param catalogMetadataVersion The catalog metadata version of the requested
+   * @param catalog_version The catalog metadata version of the requested
    * partitions. If the version is not specified, the latest version is used.
    * @return A reference to the updated `PartitionsRequest` instance.
    */
   inline PartitionsRequest& WithVersion(
-      boost::optional<int64_t> catalogMetadataVersion) {
-    catalog_metadata_version_ = catalogMetadataVersion;
+      boost::optional<int64_t> catalog_version) {
+    catalog_version_ = std::move(catalog_version);
     return *this;
   }
 
@@ -57,7 +56,7 @@ class DATASERVICE_READ_API PartitionsRequest final {
    * @return The catalog metadata version.
    */
   inline const boost::optional<std::int64_t>& GetVersion() const {
-    return catalog_metadata_version_;
+    return catalog_version_;
   }
 
   /**
@@ -79,7 +78,7 @@ class DATASERVICE_READ_API PartitionsRequest final {
    *
    * @see `GetBillingTag()` for usage and format.
    *
-   * @param billingTag The `BillingTag` string or `boost::none`.
+   * @param tag The `BillingTag` string or `boost::none`.
    *
    * @return A reference to the updated `PrefetchTilesRequest` instance.
    */
@@ -94,13 +93,13 @@ class DATASERVICE_READ_API PartitionsRequest final {
    *
    * @see `GetBillingTag()` for usage and format.
    *
-   * @param billingTag The rvalue reference to the `BillingTag` string or
+   * @param tag The rvalue reference to the `BillingTag` string or
    * `boost::none`.
    *
    * @return A reference to the updated `PrefetchTilesRequest` instance.
    */
-  inline PartitionsRequest& WithBillingTag(std::string&& billingTag) {
-    billing_tag_ = std::move(billingTag);
+  inline PartitionsRequest& WithBillingTag(std::string&& tag) {
+    billing_tag_ = std::move(tag);
     return *this;
   }
 
@@ -120,11 +119,11 @@ class DATASERVICE_READ_API PartitionsRequest final {
    *
    * @see `GetFetchOption()` for usage and format.
    *
-   * @param fetchoption The `FetchOption` enum.
+   * @param fetch_option The `FetchOption` enum.
    * @return A reference to the updated `PrefetchTilesRequest` instance.
    */
-  inline PartitionsRequest& WithFetchOption(FetchOptions fetchoption) {
-    fetch_option_ = fetchoption;
+  inline PartitionsRequest& WithFetchOption(FetchOptions fetch_option) {
+    fetch_option_ = fetch_option;
     return *this;
   }
 
@@ -138,25 +137,20 @@ class DATASERVICE_READ_API PartitionsRequest final {
   std::string CreateKey(const std::string& layer_id) const {
     std::stringstream out;
     out << layer_id;
-
     if (GetVersion()) {
       out << "@" << GetVersion().get();
     }
-
     if (GetBillingTag()) {
       out << "$" << GetBillingTag().get();
     }
-
     out << "^" << GetFetchOption();
-
     return out.str();
   }
 
  private:
-  std::string layer_id_;
-  boost::optional<int64_t> catalog_metadata_version_;
+  boost::optional<int64_t> catalog_version_;
   boost::optional<std::string> billing_tag_;
-  FetchOptions fetch_option_ = OnlineIfNotFound;
+  FetchOptions fetch_option_{OnlineIfNotFound};
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
@@ -24,9 +24,8 @@
 #include <vector>
 
 #include <olp/core/geo/tiling/TileKey.h>
-#include <olp/core/porting/deprecated.h>
+#include <olp/dataservice/read/DataServiceReadApi.h>
 #include <boost/optional.hpp>
-#include "DataServiceReadApi.h"
 
 namespace olp {
 namespace dataservice {


### PR DESCRIPTION
Most of the dataservice-read request classes are not fully implemented
using the Google coding style. This commit adapts them and also removes
some unused variables.

Relates-to: OLPEDGE-1366
Signed-off-by: Andrei Popescu <andrei.popescu@here.com>