### PR TITLE
Add SubscribeResponse model for Stream API

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/generated/model/SubscribeResponse.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/model/SubscribeResponse.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+
+namespace olp {
+namespace dataservice {
+namespace read {
+namespace model {
+
+class SubscribeResponse final {
+ public:
+  const std::string& GetNodeBaseURL() const {
+    return node_base_url_;
+  }
+  void SetNodeBaseURL(std::string value) { node_base_url_ = std::move(value); }
+
+  const std::string& GetSubscriptionId() const {
+    return subscription_id_;
+  }
+  void SetSubscriptionId(std::string value) {
+    subscription_id_ = std::move(value);
+  }
+
+ private:
+  /// A subscription is created in a specific server instance. This base URL
+  /// represents the specific server node on which this subscription was
+  /// created. This base URL should be used instead of the base URL returned by
+  /// the `lookup` service when making further calls to StreamApi methods.
+  std::string node_base_url_;
+
+  /// A unique identifier of the subscription. It is used to make further calls
+  /// to StreamApi methods.
+  std::string subscription_id_;
+};
+
+}  // namespace model
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/generated/parser/SubscribeResponseParser.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/parser/SubscribeResponseParser.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "SubscribeResponseParser.h"
+
+#include <olp/core/generated/parser/ParserWrapper.h>
+
+namespace olp {
+namespace parser {
+using namespace olp::dataservice::read;
+
+void from_json(const rapidjson::Value& value, model::SubscribeResponse& x) {
+  x.SetNodeBaseURL(parse<std::string>(value, "nodeBaseURL"));
+  x.SetSubscriptionId(parse<std::string>(value, "subscriptionId"));
+}
+
+}  // namespace parser
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/generated/parser/SubscribeResponseParser.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/parser/SubscribeResponseParser.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <rapidjson/document.h>
+#include "generated/model/SubscribeResponse.h"
+
+namespace olp {
+namespace parser {
+
+void from_json(const rapidjson::Value& value,
+               olp::dataservice::read::model::SubscribeResponse& x);
+
+}  // namespace parser
+}  // namespace olp


### PR DESCRIPTION
Holds subscription info to use to pass further requests to the OLP
stream layer.

Relates-To: OLPEDGE-1373

Signed-off-by: Mykola Malik <ext-mykola.malik@here.com>