### PR TITLE
Implemented the StreamLayerClient::Flush via TaskContext

### DIFF
--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.h
@@ -36,8 +36,7 @@ class PendingRequests;
 namespace dataservice {
 namespace write {
 
-class StreamLayerClientImpl
-    : public std::enable_shared_from_this<StreamLayerClientImpl> {
+class StreamLayerClientImpl {
  public:
   StreamLayerClientImpl(client::HRN catalog,
                         StreamLayerClientSettings client_settings,


### PR DESCRIPTION
- Changed the implementation of StreamLayerClient::Flush in a way to support client::TaskContext and pending requests. This is required in order to properly cancel all the scheduled Flush operations when client is destroyed. Also, this will allow user to cancel pending Flush requests via public CancelPendingRequests method;
- re-enabled FlushDataCancel tests;
- removed std::enable_shared_from_this from StreamLayerClientImpl, because all scheduled async operations using client instance will be cancelled and finished in StreamLayerClientImpl' dtor.

Relates-to: OLPEDGE-1184

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>