### PR TITLE
Added CancelPendingRequests to dataservice-write clients

### DIFF
--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/IndexLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/IndexLayerClient.h
@@ -23,6 +23,7 @@
 #include <olp/core/client/ApiNoResult.h>
 #include <olp/core/client/ApiResponse.h>
 #include <olp/core/client/OlpClientSettings.h>
+#include <olp/core/porting/deprecated.h>
 #include <olp/dataservice/write/DataServiceWriteApi.h>
 #include <olp/dataservice/write/generated/model/ResponseOkSingle.h>
 #include <olp/dataservice/write/model/DeleteIndexDataRequest.h>
@@ -56,17 +57,29 @@ using UpdateIndexCallback = std::function<void(UpdateIndexResponse response)>;
 /// @brief Client that is responsible for writing data to an OLP index layer.
 class DATASERVICE_WRITE_API IndexLayerClient {
  public:
-
   /**
    * @brief IndexLayerClient Constructor.
-   * @param catalog OLP HRN that specifies the catalog to which this client writes.
+   * @param catalog OLP HRN that specifies the catalog to which this client
+   * writes.
    * @param settings Client settings used to control the behavior of the client
    * instance.
    */
   IndexLayerClient(client::HRN catalog, client::OlpClientSettings settings);
 
   /// @brief Cancels all pending requests.
+  /// @deprecated Use \ref CancelPendingRequests intead.
+  OLP_SDK_DEPRECATED(
+      "Use CancelPendingRequests instead. Will be removed in 05.2020")
   void CancelAll();
+
+  /**
+   * @brief Cancels all the ongoing operations that this client started.
+   *
+   * Returns instantly and does not wait for the callbacks.
+   * Use this operation to cancel all the pending requests without
+   * destroying the actual client instance.
+   */
+  void CancelPendingRequests();
 
   /**
    * @brief Publishes an index to an OLP index layer.

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClient.h
@@ -83,7 +83,7 @@ class DATASERVICE_WRITE_API StreamLayerClient {
    * @brief Cancels all the ongoing publish operations that this client started.
    *
    * Returns instantly and does not wait for the callbacks.
-   * Use this operation to cancel all the submitted publish requests without
+   * Use this operation to cancel all the pending publish requests without
    * destroying the actual client instance.
    * @note This operation does not cancel publish requests queued by the \ref
    * Queue method.

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VersionedLayerClient.h
@@ -24,6 +24,7 @@
 #include <olp/core/client/ApiResponse.h>
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClientSettings.h>
+#include <olp/core/porting/deprecated.h>
 
 #include <olp/dataservice/write/DataServiceWriteApi.h>
 #include <olp/dataservice/write/generated/model/Publication.h>
@@ -176,8 +177,20 @@ class DATASERVICE_WRITE_API VersionedLayerClient {
    * cancel operations that have been started, so you will need to call
    * CancelBatch after this if you have a batch operation in progress
    * (StartBatch successfully completed).
+   * @deprecated Use \ref CancelPendingRequests intead.
    */
+  OLP_SDK_DEPRECATED(
+      "Use CancelPendingRequests instead. Will be removed in 05.2020")
   void CancelAll();
+
+  /**
+   * @brief Cancels all the ongoing operations that this client started.
+   *
+   * Returns instantly and does not wait for the callbacks.
+   * Use this operation to cancel all the pending requests without
+   * destroying the actual client instance.
+   */
+  void CancelPendingRequests();
 
   /**
    * @brief Call to publish data into an OLP Versioned Layer.

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VolatileLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VolatileLayerClient.h
@@ -23,6 +23,7 @@
 #include <olp/core/client/ApiNoResult.h>
 #include <olp/core/client/ApiResponse.h>
 #include <olp/core/client/OlpClientSettings.h>
+#include <olp/core/porting/deprecated.h>
 
 #include <olp/dataservice/write/DataServiceWriteApi.h>
 #include <olp/dataservice/write/generated/model/Publication.h>
@@ -89,8 +90,20 @@ class DATASERVICE_WRITE_API VolatileLayerClient {
 
   /**
    * @brief Cancel all pending requests.
+   * @deprecated Use \ref CancelPendingRequests intead.
    */
+  OLP_SDK_DEPRECATED(
+      "Use CancelPendingRequests instead. Will be removed in 05.2020")
   void CancelAll();
+
+  /**
+   * @brief Cancels all the ongoing operations that this client started.
+   *
+   * Returns instantly and does not wait for the callbacks.
+   * Use this operation to cancel all the pending requests without
+   * destroying the actual client instance.
+   */
+  void CancelPendingRequests();
 
   /**
    * @brief Call to publish data into an OLP Volatile Layer.

--- a/olp-cpp-sdk-dataservice-write/src/IndexLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/IndexLayerClient.cpp
@@ -30,6 +30,10 @@ IndexLayerClient::IndexLayerClient(client::HRN catalog,
 
 void IndexLayerClient::CancelAll() { impl_->CancelAll(); }
 
+void IndexLayerClient::CancelPendingRequests() {
+  impl_->CancelPendingRequests();
+}
+
 olp::client::CancellableFuture<PublishIndexResponse>
 IndexLayerClient::PublishIndex(model::PublishIndexRequest request) {
   return impl_->PublishIndex(request);

--- a/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.cpp
@@ -55,9 +55,13 @@ IndexLayerClientImpl::IndexLayerClientImpl(HRN catalog,
       apiclient_config_(nullptr),
       apiclient_blob_(nullptr),
       apiclient_index_(nullptr),
+      pending_requests_(std::make_shared<client::PendingRequests>()),
       init_in_progress_(false) {}
 
-IndexLayerClientImpl::~IndexLayerClientImpl() { CancelAll(); }
+IndexLayerClientImpl::~IndexLayerClientImpl() {
+  CancelAll();
+  pending_requests_->CancelAllAndWait();
+}
 
 olp::client::CancellationToken IndexLayerClientImpl::InitApiClients(
     std::shared_ptr<client::CancellationContext> cancel_context,
@@ -142,6 +146,8 @@ olp::client::CancellationToken IndexLayerClientImpl::InitApiClients(
 }
 
 void IndexLayerClientImpl::CancelAll() { tokenList_.CancelAll(); }
+
+void IndexLayerClientImpl::CancelPendingRequests() { CancelAll(); }
 
 CancellationToken IndexLayerClientImpl::InitCatalogModel(
     const model::PublishIndexRequest& request,

--- a/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.h
@@ -24,6 +24,7 @@
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClient.h>
 #include <olp/core/client/OlpClientFactory.h>
+#include <olp/core/client/PendingRequests.h>
 #include "ApiClientLookup.h"
 #include "CancellationTokenList.h"
 
@@ -53,6 +54,8 @@ class IndexLayerClientImpl
   virtual ~IndexLayerClientImpl();
 
   void CancelAll();
+
+  void CancelPendingRequests();
 
   olp::client::CancellableFuture<PublishIndexResponse> PublishIndex(
       const model::PublishIndexRequest& request);
@@ -96,6 +99,8 @@ class IndexLayerClientImpl
   std::shared_ptr<client::OlpClient> apiclient_index_;
 
   CancellationTokenList tokenList_;
+
+  std::shared_ptr<client::PendingRequests> pending_requests_;
 
   std::mutex mutex_;
   std::condition_variable cond_var_;

--- a/olp-cpp-sdk-dataservice-write/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/VersionedLayerClient.cpp
@@ -30,7 +30,6 @@ VersionedLayerClient::VersionedLayerClient(client::HRN catalog,
     : impl_(std::make_shared<VersionedLayerClientImpl>(std::move(catalog),
                                                        std::move(settings))) {}
 
-
 olp::client::CancellableFuture<StartBatchResponse>
 VersionedLayerClient::StartBatch(model::StartBatchRequest request) {
   return impl_->StartBatch(request);
@@ -82,6 +81,10 @@ olp::client::CancellationToken VersionedLayerClient::CancelBatch(
 }
 
 void VersionedLayerClient::CancelAll() { impl_->CancelAll(); }
+
+void VersionedLayerClient::CancelPendingRequests() {
+  impl_->CancelPendingRequests();
+}
 
 olp::client::CancellableFuture<PublishPartitionDataResponse>
 VersionedLayerClient::PublishToBatch(

--- a/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.cpp
@@ -53,9 +53,13 @@ VersionedLayerClientImpl::VersionedLayerClientImpl(
       apiclient_metadata_(nullptr),
       apiclient_publish_(nullptr),
       apiclient_query_(nullptr),
+      pending_requests_(std::make_shared<client::PendingRequests>()),
       init_in_progress_(false) {}
 
-VersionedLayerClientImpl::~VersionedLayerClientImpl() { CancelAll(); }
+VersionedLayerClientImpl::~VersionedLayerClientImpl() {
+  CancelAll();
+  pending_requests_->CancelAllAndWait();
+}
 
 olp::client::CancellationToken VersionedLayerClientImpl::InitApiClients(
     std::shared_ptr<client::CancellationContext> cancel_context,
@@ -494,6 +498,8 @@ olp::client::CancellationToken VersionedLayerClientImpl::CancelBatch(
 }
 
 void VersionedLayerClientImpl::CancelAll() { tokenList_.CancelAll(); }
+
+void VersionedLayerClientImpl::CancelPendingRequests() { CancelAll(); }
 
 olp::client::CancellableFuture<PublishPartitionDataResponse>
 VersionedLayerClientImpl::PublishToBatch(

--- a/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.h
@@ -25,6 +25,7 @@
 #include <generated/model/PublishPartitions.h>
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/OlpClient.h>
+#include <olp/core/client/PendingRequests.h>
 #include "CancellationTokenList.h"
 #include "generated/model/Catalog.h"
 
@@ -90,6 +91,8 @@ class VersionedLayerClientImpl
 
   void CancelAll();
 
+  void CancelPendingRequests();
+
   client::CancellableFuture<PublishPartitionDataResponse> PublishToBatch(
       const model::Publication& pub,
       const model::PublishPartitionDataRequest& request);
@@ -141,6 +144,8 @@ class VersionedLayerClientImpl
   std::shared_ptr<client::OlpClient> apiclient_query_;
 
   CancellationTokenList tokenList_;
+
+  std::shared_ptr<client::PendingRequests> pending_requests_;
 
   std::mutex mutex_;
   std::condition_variable cond_var_;

--- a/olp-cpp-sdk-dataservice-write/src/VolatileLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/VolatileLayerClient.cpp
@@ -31,6 +31,10 @@ VolatileLayerClient::VolatileLayerClient(client::HRN catalog,
 
 void VolatileLayerClient::CancelAll() { impl_->CancelAll(); }
 
+void VolatileLayerClient::CancelPendingRequests() {
+  impl_->CancelPendingRequests();
+}
+
 olp::client::CancellableFuture<PublishPartitionDataResponse>
 VolatileLayerClient::PublishPartitionData(
     model::PublishPartitionDataRequest request) {

--- a/olp-cpp-sdk-dataservice-write/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/VolatileLayerClientImpl.cpp
@@ -48,9 +48,14 @@ namespace dataservice {
 namespace write {
 VolatileLayerClientImpl::VolatileLayerClientImpl(HRN catalog,
                                                  OlpClientSettings settings)
-    : catalog_(std::move(catalog)), settings_(std::move(settings)) {}
+    : catalog_(std::move(catalog)),
+      settings_(std::move(settings)),
+      pending_requests_(std::make_shared<client::PendingRequests>()) {}
 
-VolatileLayerClientImpl::~VolatileLayerClientImpl() { CancelAll(); }
+VolatileLayerClientImpl::~VolatileLayerClientImpl() {
+  CancelAll();
+  pending_requests_->CancelAllAndWait();
+}
 
 olp::client::CancellationToken VolatileLayerClientImpl::InitApiClients(
     std::shared_ptr<client::CancellationContext> cancel_context,
@@ -174,6 +179,8 @@ olp::client::CancellationToken VolatileLayerClientImpl::InitApiClients(
 }
 
 void VolatileLayerClientImpl::CancelAll() { tokenList_.CancelAll(); }
+
+void VolatileLayerClientImpl::CancelPendingRequests() { CancelAll(); }
 
 CancellationToken VolatileLayerClientImpl::InitCatalogModel(
     const model::PublishPartitionDataRequest& /*request*/,

--- a/olp-cpp-sdk-dataservice-write/src/VolatileLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/VolatileLayerClientImpl.h
@@ -25,6 +25,7 @@
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClient.h>
 #include <olp/core/client/OlpClientFactory.h>
+#include <olp/core/client/PendingRequests.h>
 #include "ApiClientLookup.h"
 
 #include <olp/dataservice/write/VolatileLayerClient.h>
@@ -63,6 +64,8 @@ class VolatileLayerClientImpl
       GetBaseVersionCallback callback);
 
   void CancelAll();
+
+  void CancelPendingRequests();
 
   olp::client::CancellableFuture<PublishPartitionDataResponse>
   PublishPartitionData(const model::PublishPartitionDataRequest& request);
@@ -129,6 +132,8 @@ class VolatileLayerClientImpl
   std::shared_ptr<client::OlpClient> apiclient_query_;
 
   CancellationTokenList tokenList_;
+
+  std::shared_ptr<client::PendingRequests> pending_requests_;
 
   std::mutex mutex_;
   std::condition_variable cond_var_;


### PR DESCRIPTION
Implemented CancelPendingRequests in the public API of next dataservice-write clients:
 - IndexLayerClient;
 - VolatileLayertClient;
 - VersionedLayerClient.
This was done in order to not confuse readers with slightly incorrect previous naming.

Note that current implemenatation uses `CancelAll()` method until all these clients will be moved to the tasks approach.

Relates-to: OLPEDGE-1361

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>