### PR TITLE
Adapt DefaultCache and other cache files to coding style.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/cache/CacheSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/CacheSettings.h
@@ -21,12 +21,10 @@
 
 #include <string>
 
+#include <olp/core/porting/deprecated.h>
 #include <boost/optional.hpp>
 
-#include <olp/core/porting/deprecated.h>
-
 namespace olp {
-
 namespace cache {
 
 /**
@@ -109,5 +107,4 @@ struct CacheSettings {
 };
 
 }  // namespace cache
-
 }  // namespace olp

--- a/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
@@ -64,8 +64,7 @@ class CORE_API DefaultCache : public KeyValueCache {
    * @param settings Settings for the cache.
    */
   DefaultCache(const CacheSettings& settings = CacheSettings());
-
-  virtual ~DefaultCache();
+  ~DefaultCache() override;
 
   /**
    * @brief Opens the cache to start read/write operations.
@@ -95,8 +94,8 @@ class CORE_API DefaultCache : public KeyValueCache {
    * @param expiry Time in seconds to when pair will expire
    * @return Returns true if the operation is successfull, false otherwise.
    */
-  virtual bool Put(const std::string& key, const boost::any& value,
-                   const Encoder& encoder, time_t expiry);
+  bool Put(const std::string& key, const boost::any& value,
+           const Encoder& encoder, time_t expiry) override;
 
   /**
    * @brief Stores the raw binary data as value into the cache.
@@ -105,9 +104,8 @@ class CORE_API DefaultCache : public KeyValueCache {
    * @param expiry Time in seconds to when pair will expire
    * @return Returns true if the operation is successfull, false otherwise.
    */
-  virtual bool Put(const std::string& key,
-                   const std::shared_ptr<std::vector<unsigned char>> value,
-                   time_t expiry);
+  bool Put(const std::string& key, const KeyValueCache::ValueTypePtr value,
+           time_t expiry) override;
 
   /**
    * @brief Gets the key-value pair from the cache.
@@ -115,14 +113,13 @@ class CORE_API DefaultCache : public KeyValueCache {
    * @param decoder A method is provided to decode a value from a string if
    * needed
    */
-  virtual boost::any Get(const std::string& key, const Decoder& decoder);
+  boost::any Get(const std::string& key, const Decoder& decoder) override;
 
   /**
    * @brief Gets the key and binary data from the cache.
    * @param key Key to look for
    */
-  virtual std::shared_ptr<std::vector<unsigned char>> Get(
-      const std::string& key);
+  KeyValueCache::ValueTypePtr Get(const std::string& key) override;
 
   /**
    * @brief Removes the key-value pair from the cache.
@@ -130,7 +127,7 @@ class CORE_API DefaultCache : public KeyValueCache {
    *
    * @return Returns true if the operation is successfull, false otherwise.
    */
-  virtual bool Remove(const std::string& key);
+  bool Remove(const std::string& key) override;
 
   /**
    * @brief Removes the values with the keys matching the given
@@ -139,11 +136,10 @@ class CORE_API DefaultCache : public KeyValueCache {
    *
    * @return Returns true on removal, false otherwise.
    */
-  virtual bool RemoveKeysWithPrefix(const std::string& prefix);
+  bool RemoveKeysWithPrefix(const std::string& prefix) override;
 
  private:
   StorageOpenResult SetupStorage();
-
   boost::optional<std::pair<std::string, time_t>> GetFromDiscCache(
       const std::string& key);
 

--- a/olp-cpp-sdk-core/include/olp/core/cache/KeyValueCache.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/KeyValueCache.h
@@ -26,12 +26,10 @@
 #include <string>
 #include <vector>
 
+#include <olp/core/CoreApi.h>
 #include <boost/any.hpp>
 
-#include <olp/core/CoreApi.h>
-
 namespace olp {
-
 namespace cache {
 
 using Encoder = std::function<std::string()>;
@@ -42,6 +40,13 @@ using Decoder = std::function<boost::any(const std::string&)>;
  */
 class CORE_API KeyValueCache {
  public:
+  /// No expiry by default.
+  static constexpr time_t kDefaultExpiry = std::numeric_limits<time_t>::max();
+  /// Value type to be stored in the DB.
+  using ValueType = std::vector<unsigned char>;
+  /// Shared pointer type to the DB entry.
+  using ValueTypePtr = std::shared_ptr<ValueType>;
+
   virtual ~KeyValueCache() = default;
 
   /**
@@ -54,8 +59,7 @@ class CORE_API KeyValueCache {
    * @return Returns true if the operation is successfull, false otherwise.
    */
   virtual bool Put(const std::string& key, const boost::any& value,
-                   const Encoder& encoder,
-                   time_t expiry = (std::numeric_limits<time_t>::max)()) = 0;
+                   const Encoder& encoder, time_t expiry = kDefaultExpiry) = 0;
 
   /**
    * @brief Store raw binary data as value into the cache
@@ -64,9 +68,8 @@ class CORE_API KeyValueCache {
    * @param expiry Time in seconds to when pair will expire
    * @return Returns true if the operation is successfull, false otherwise.
    */
-  virtual bool Put(const std::string& key,
-                   const std::shared_ptr<std::vector<unsigned char>> value,
-                   time_t expiry = (std::numeric_limits<time_t>::max)()) = 0;
+  virtual bool Put(const std::string& key, const ValueTypePtr value,
+                   time_t expiry = kDefaultExpiry) = 0;
 
   /**
    * @brief Get key,value pair from the cache
@@ -80,8 +83,7 @@ class CORE_API KeyValueCache {
    * @brief Get key and binary data from the cache
    * @param key Key to look for
    */
-  virtual std::shared_ptr<std::vector<unsigned char>> Get(
-      const std::string& key) = 0;
+  virtual ValueTypePtr Get(const std::string& key) = 0;
 
   /**
    * @brief Remove a key,value pair from the cache
@@ -101,5 +103,4 @@ class CORE_API KeyValueCache {
 };
 
 }  // namespace cache
-
 }  // namespace olp

--- a/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
@@ -39,7 +39,7 @@ std::string CreateExpiryKey(const std::string& key) { return key + "::expiry"; }
 time_t GetRemainingExpiryTime(const std::string& key,
                               olp::cache::DiskCache& disk_cache) {
   auto expiry_key = CreateExpiryKey(key);
-  auto expiry = (std::numeric_limits<time_t>::max)();
+  auto expiry = olp::cache::KeyValueCache::kDefaultExpiry;
   auto expiry_value = disk_cache.Get(expiry_key);
   if (expiry_value) {
     expiry = std::stol(*expiry_value);
@@ -87,28 +87,28 @@ DefaultCache::DefaultCache(const CacheSettings& settings)
       mutable_cache_(nullptr),
       protected_cache_(nullptr) {}
 
-DefaultCache::~DefaultCache() {}
+DefaultCache::~DefaultCache() = default;
 
 DefaultCache::StorageOpenResult DefaultCache::Open() {
-  std::lock_guard<std::mutex> lk(cache_lock_);
+  std::lock_guard<std::mutex> lock(cache_lock_);
   is_open_ = true;
   return SetupStorage();
 }
 
 void DefaultCache::Close() {
-  std::lock_guard<std::mutex> lk(cache_lock_);
+  std::lock_guard<std::mutex> lock(cache_lock_);
   if (!is_open_) {
     return;
   }
+
   memory_cache_.reset();
   mutable_cache_.reset();
   protected_cache_.reset();
-
   is_open_ = false;
 }
 
 bool DefaultCache::Clear() {
-  std::lock_guard<std::mutex> lk(cache_lock_);
+  std::lock_guard<std::mutex> lock(cache_lock_);
   if (!is_open_) {
     return false;
   }
@@ -128,10 +128,11 @@ bool DefaultCache::Clear() {
 
 bool DefaultCache::Put(const std::string& key, const boost::any& value,
                        const Encoder& encoder, time_t expiry) {
-  std::lock_guard<std::mutex> lk(cache_lock_);
+  std::lock_guard<std::mutex> lock(cache_lock_);
   if (!is_open_) {
     return false;
   }
+
   auto encodedItem = encoder();
   if (memory_cache_) {
     if (!memory_cache_->Put(key, value, expiry, encodedItem.size()))
@@ -139,7 +140,7 @@ bool DefaultCache::Put(const std::string& key, const boost::any& value,
   }
 
   if (mutable_cache_) {
-    if (expiry < (std::numeric_limits<time_t>::max)()) {
+    if (expiry < KeyValueCache::kDefaultExpiry) {
       if (!StoreExpiry(key, *mutable_cache_, expiry)) {
         return false;
       }
@@ -149,13 +150,13 @@ bool DefaultCache::Put(const std::string& key, const boost::any& value,
       return false;
     }
   }
+
   return true;
 }
 
 bool DefaultCache::Put(const std::string& key,
-                       const std::shared_ptr<std::vector<unsigned char>> value,
-                       time_t expiry) {
-  std::lock_guard<std::mutex> lk(cache_lock_);
+                       const KeyValueCache::ValueTypePtr value, time_t expiry) {
+  std::lock_guard<std::mutex> lock(cache_lock_);
   if (!is_open_) {
     return false;
   }
@@ -167,7 +168,7 @@ bool DefaultCache::Put(const std::string& key,
   }
 
   if (mutable_cache_) {
-    if (expiry < (std::numeric_limits<time_t>::max)()) {
+    if (expiry < KeyValueCache::kDefaultExpiry) {
       if (!StoreExpiry(key, *mutable_cache_, expiry)) {
         return false;
       }
@@ -183,7 +184,7 @@ bool DefaultCache::Put(const std::string& key,
 }
 
 boost::any DefaultCache::Get(const std::string& key, const Decoder& decoder) {
-  std::lock_guard<std::mutex> lk(cache_lock_);
+  std::lock_guard<std::mutex> lock(cache_lock_);
   if (!is_open_) {
     return boost::any();
   }
@@ -209,9 +210,8 @@ boost::any DefaultCache::Get(const std::string& key, const Decoder& decoder) {
   return boost::any();
 }
 
-std::shared_ptr<std::vector<unsigned char>> DefaultCache::Get(
-    const std::string& key) {
-  std::lock_guard<std::mutex> lk(cache_lock_);
+KeyValueCache::ValueTypePtr DefaultCache::Get(const std::string& key) {
+  std::lock_guard<std::mutex> lock(cache_lock_);
   if (!is_open_) {
     return nullptr;
   }
@@ -220,15 +220,13 @@ std::shared_ptr<std::vector<unsigned char>> DefaultCache::Get(
     auto value = memory_cache_->Get(key);
 
     if (!value.empty()) {
-      return boost::any_cast<std::shared_ptr<std::vector<unsigned char>>>(
-          value);
+      return boost::any_cast<KeyValueCache::ValueTypePtr>(value);
     }
   }
 
   auto disc_cache = GetFromDiscCache(key);
-
   if (disc_cache) {
-    auto data = std::make_shared<std::vector<unsigned char>>(
+    auto data = std::make_shared<KeyValueCache::ValueType>(
         disc_cache->first.begin(), disc_cache->first.end());
 
     if (memory_cache_) {
@@ -241,7 +239,7 @@ std::shared_ptr<std::vector<unsigned char>> DefaultCache::Get(
 }
 
 bool DefaultCache::Remove(const std::string& key) {
-  std::lock_guard<std::mutex> lk(cache_lock_);
+  std::lock_guard<std::mutex> lock(cache_lock_);
   if (!is_open_) {
     return false;
   }
@@ -251,14 +249,16 @@ bool DefaultCache::Remove(const std::string& key) {
   }
 
   if (mutable_cache_) {
-    if (!mutable_cache_->Remove(key)) return false;
+    if (!mutable_cache_->Remove(key)) {
+      return false;
+    }
   }
 
   return true;
 }
 
 bool DefaultCache::RemoveKeysWithPrefix(const std::string& key) {
-  std::lock_guard<std::mutex> lk(cache_lock_);
+  std::lock_guard<std::mutex> lock(cache_lock_);
   if (!is_open_) {
     return false;
   }
@@ -271,7 +271,7 @@ bool DefaultCache::RemoveKeysWithPrefix(const std::string& key) {
     return mutable_cache_->RemoveKeysWithPrefix(key);
   }
   return true;
-}  // namespace cache
+}
 
 DefaultCache::StorageOpenResult DefaultCache::SetupStorage() {
   auto result = Success;
@@ -332,10 +332,9 @@ boost::optional<std::pair<std::string, time_t>> DefaultCache::GetFromDiscCache(
     const std::string& key) {
   if (protected_cache_) {
     auto result = protected_cache_->Get(key);
-
     if (result) {
-      return std::make_pair(std::move(result.value()),
-                            std::numeric_limits<time_t>::max());
+      auto default_expiry = KeyValueCache::kDefaultExpiry;
+      return std::make_pair(std::move(result.value()), default_expiry);
     }
   }
 

--- a/olp-cpp-sdk-core/src/cache/DiskCacheSizeLimitEnv.cpp
+++ b/olp-cpp-sdk-core/src/cache/DiskCacheSizeLimitEnv.cpp
@@ -18,11 +18,13 @@
  */
 
 #include "DiskCacheSizeLimitEnv.h"
+
 #include "DiskCacheSizeLimitWritableFile.h"
 
 namespace olp {
 namespace cache {
 namespace {
+
 bool IsLogFile(const std::string& name) {
   static constexpr char log_suffix[] = ".log";
   constexpr size_t log_suffix_length = 4;
@@ -49,8 +51,10 @@ DiskCacheSizeLimitEnv::DiskCacheSizeLimitEnv(leveldb::Env* env,
   if (target()->GetChildren(base_path, &children).ok()) {
     for (const std::string& child : children) {
       uint64_t size;
-      std::string fullPath(base_path + PathSeparator() + child);
-      if (target()->GetFileSize(fullPath, &size).ok()) total_size_ += size;
+      std::string full_path(base_path + PathSeparator() + child);
+      if (target()->GetFileSize(full_path, &size).ok()) {
+        total_size_ += size;
+      }
     }
   }
 }
@@ -64,13 +68,18 @@ leveldb::Status DiskCacheSizeLimitEnv::NewWritableFile(
     status = target()->NewWritableFile(f, &file);
   }
 
-  if (status.ok()) *r = new DiskCacheSizeLimitWritableFile(this, file);
+  if (status.ok()) {
+    *r = new DiskCacheSizeLimitWritableFile(this, file);
+  }
+
   return status;
 }
 
 leveldb::Status DiskCacheSizeLimitEnv::DeleteFile(const std::string& f) {
   uint64_t size = 0;
-  if (target()->GetFileSize(f, &size).ok()) total_size_ -= size;
+  if (target()->GetFileSize(f, &size).ok()) {
+    total_size_ -= size;
+  }
   return target()->DeleteFile(f);
 }
 

--- a/olp-cpp-sdk-core/src/cache/DiskCacheSizeLimitEnv.h
+++ b/olp-cpp-sdk-core/src/cache/DiskCacheSizeLimitEnv.h
@@ -33,6 +33,7 @@ class DiskCacheSizeLimitEnv : public leveldb::EnvWrapper {
   // Initialize an EnvWrapper that delegates all calls to *t
   DiskCacheSizeLimitEnv(leveldb::Env* env, const std::string& base_path,
                         bool enforce_strict_data_save);
+  ~DiskCacheSizeLimitEnv() override = default;
 
   leveldb::Status NewWritableFile(const std::string& f,
                                   leveldb::WritableFile** r) override;

--- a/olp-cpp-sdk-core/src/cache/DiskCacheSizeLimitWritableFile.cpp
+++ b/olp-cpp-sdk-core/src/cache/DiskCacheSizeLimitWritableFile.cpp
@@ -56,5 +56,6 @@ leveldb::Status DiskCacheSizeLimitWritableFile::Sync() {
   }
   return leveldb::Status::OK();
 }
+
 }  // namespace cache
 }  // namespace olp


### PR DESCRIPTION
KeyValueCache is now optimized with some aliases to be also used above
by parent class and users. DefaultCache is now marking overriden methods
from KeyValueCache with the override keyword. DiskCacheSizeLimitEnv and
DiskCacheSizeLimitWritableFile are also adapted where needed to coding style.

Relates-to: OLPEDGE-566

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>