### PR TITLE
Add CommitOffsets and SeekToOffset public methods to the read StreamApi

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/generated/api/StreamApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/StreamApi.cpp
@@ -30,6 +30,7 @@
 #include "generated/parser/SubscribeResponseParser.h"
 #include <olp/core/generated/parser/JsonParser.h>
 #include "generated/serializer/ConsumerPropertiesSerializer.h"
+#include "generated/serializer/StreamOffsetsSerializer.h"
 #include "generated/serializer/JsonSerializer.h"
 // clang-format on
 
@@ -48,28 +49,27 @@ StreamApi::SubscribeApiResponse StreamApi::Subscribe(
     const boost::optional<std::string>& consumer_id,
     const boost::optional<ConsumerProperties>& subscription_properties,
     const client::CancellationContext& context, std::string& x_correlation_id) {
-  std::string metadata_uri = "/layers/" + layer_id + "/subscribe";
+  const std::string metadata_uri = "/layers/" + layer_id + "/subscribe";
 
   std::multimap<std::string, std::string> query_params;
   if (subscription_id) {
-    query_params.insert(
-        std::make_pair("subscriptionId", subscription_id.get()));
+    query_params.emplace("subscriptionId", subscription_id.get());
   }
 
   if (mode) {
-    query_params.insert(std::make_pair("mode", mode.get()));
+    query_params.emplace("mode", mode.get());
   }
 
   if (consumer_id) {
-    query_params.insert(std::make_pair("consumerId", consumer_id.get()));
+    query_params.emplace("consumerId", consumer_id.get());
   }
 
   std::multimap<std::string, std::string> header_params;
-  header_params.insert(std::make_pair("Accept", "application/json"));
+  header_params.emplace("Accept", "application/json");
 
   model::Data data;
   if (subscription_properties) {
-    auto serialized_subscription_properties =
+    const auto serialized_subscription_properties =
         serializer::serialize(subscription_properties.get());
     data = std::make_shared<std::vector<unsigned char>>(
         serialized_subscription_properties.begin(),
@@ -92,26 +92,44 @@ StreamApi::SubscribeApiResponse StreamApi::Subscribe(
   return parser::parse<model::SubscribeResponse>(http_response.response);
 }
 
+StreamApi::CommitOffsetsApiResponse StreamApi::CommitOffsets(
+    const client::OlpClient& client, const std::string& layer_id,
+    const model::StreamOffsets& commit_offsets,
+    const boost::optional<std::string>& subscription_id,
+    const boost::optional<std::string>& mode,
+    const client::CancellationContext& context, std::string& x_correlation_id) {
+  return HandleOffsets(client, layer_id, commit_offsets, subscription_id, mode,
+                       context, "offsets", x_correlation_id);
+}
+
+StreamApi::SeekToOffsetApiResponse StreamApi::SeekToOffset(
+    const client::OlpClient& client, const std::string& layer_id,
+    const model::StreamOffsets& commit_offsets,
+    const boost::optional<std::string>& subscription_id,
+    const boost::optional<std::string>& mode,
+    const client::CancellationContext& context, std::string& x_correlation_id) {
+  return HandleOffsets(client, layer_id, commit_offsets, subscription_id, mode,
+                       context, "seek", x_correlation_id);
+}
+
 StreamApi::UnsubscribeApiResponse StreamApi::DeleteSubscription(
     const client::OlpClient& client, const std::string& layer_id,
     const std::string& subscription_id, const std::string& mode,
-    const boost::optional<std::string>& x_correlation_id,
+    const std::string& x_correlation_id,
     const client::CancellationContext& context) {
-  std::string metadata_uri = "/layers/" + layer_id + "/subscribe";
+  const std::string metadata_uri = "/layers/" + layer_id + "/subscribe";
 
   std::multimap<std::string, std::string> query_params;
-  query_params.insert(std::make_pair("subscriptionId", subscription_id));
+  query_params.emplace("subscriptionId", subscription_id);
 
-  query_params.insert(std::make_pair("mode", mode));
+  query_params.emplace("mode", mode);
 
   std::multimap<std::string, std::string> header_params;
-  header_params.insert(std::make_pair("Accept", "application/json"));
-  if (x_correlation_id) {
-    header_params.insert(
-        std::make_pair("X-Correlation-Id", x_correlation_id.get()));
-  }
+  header_params.emplace("Accept", "application/json");
 
-  auto http_response = client.CallApi(
+  header_params.emplace("X-Correlation-Id", x_correlation_id);
+
+  const auto http_response = client.CallApi(
       metadata_uri, "DELETE", std::move(query_params), std::move(header_params),
       {}, nullptr, std::string{}, std::move(context));
   if (http_response.status != http::HttpStatusCode::OK) {
@@ -120,6 +138,48 @@ StreamApi::UnsubscribeApiResponse StreamApi::DeleteSubscription(
 
   OLP_SDK_LOG_DEBUG_F(kLogTag, "deleteSubscription, uri=%s, status=%d",
                       metadata_uri.c_str(), http_response.status);
+
+  return http_response.status;
+}
+
+Response<int> StreamApi::HandleOffsets(
+    const client::OlpClient& client, const std::string& layer_id,
+    const model::StreamOffsets& offsets,
+    const boost::optional<std::string>& subscription_id,
+    const boost::optional<std::string>& mode,
+    const client::CancellationContext& context, const std::string& endpoint,
+    std::string& x_correlation_id) {
+  const std::string metadata_uri = "/layers/" + layer_id + "/" + endpoint;
+
+  std::multimap<std::string, std::string> query_params;
+  if (subscription_id) {
+    query_params.emplace("subscriptionId", subscription_id.get());
+  }
+
+  if (mode) {
+    query_params.emplace("mode", mode.get());
+  }
+
+  std::multimap<std::string, std::string> header_params;
+  header_params.emplace("Accept", "application/json");
+  header_params.emplace("X-Correlation-Id", x_correlation_id);
+
+  const auto serialized_offsets = serializer::serialize(offsets);
+  const auto data = std::make_shared<std::vector<unsigned char>>(
+      serialized_offsets.begin(), serialized_offsets.end());
+
+  const auto http_response = client.CallApi(
+      metadata_uri, "PUT", std::move(query_params), std::move(header_params),
+      {}, data, "application/json", std::move(context));
+  if (http_response.status != http::HttpStatusCode::OK) {
+    return client::ApiError(http_response.status, http_response.response.str());
+  }
+
+  OLP_SDK_LOG_DEBUG_F(kLogTag, "handleOffsets, uri=%s, status=%d",
+                      metadata_uri.c_str(), http_response.status);
+
+  // TODO: Set x_correlation_id to the value received in http_response.header
+  // when http_response.header will be implemented.
 
   return http_response.status;
 }

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/StreamApi.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/StreamApi.h
@@ -25,6 +25,8 @@
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>
 #include <olp/dataservice/read/ConsumerProperties.h>
+#include <olp/dataservice/read/Types.h>
+#include <olp/dataservice/read/model/StreamOffsets.h>
 #include "generated/model/SubscribeResponse.h"
 
 namespace olp {
@@ -36,19 +38,21 @@ class CancellationContext;
 namespace dataservice {
 namespace read {
 
-/// Response template type
-template <typename ResultType>
-using Response = client::ApiResponse<ResultType, client::ApiError>;
-
 /**
- * @brief The `stream` service provides the ability to consume data from a
- * stream layer. With this service you can subscribe to a stream layer and
- * consume messages.
+ * @brief The `stream` service provides the ability to subscribe to a stream
+ * layer and consume data from subscribed layer.
  */
 class StreamApi {
  public:
   /// Subscribe response type.
   using SubscribeApiResponse = Response<model::SubscribeResponse>;
+
+  /// CommitOffsets response type. Returns status of the HTTP request on
+  /// success.
+  using CommitOffsetsApiResponse = Response<int>;
+
+  /// SeekToOffset response type. Returns status of the HTTP request on success.
+  using SeekToOffsetApiResponse = Response<int>;
 
   /// Unsubscribe response type. Returns status of the HTTP request on success.
   using UnsubscribeApiResponse = Response<int>;
@@ -68,19 +72,16 @@ class StreamApi {
    * @param subscription_id Include this parameter if you want to look up the
    * `nodeBaseURL` for a given subscriptionId.
    * @param mode Specifies whether to use serial or parallel subscription mode.
-   * For more details see [Get Data from a Stream
-   * Layer](https://developer.here.com/olp/documentation/data-store/data_dev_guide/rest/getting-data-stream.html).
    * @param consumer_id The ID to use to identify this consumer. It must be
    * unique within the consumer group. If you do not provide one, the system
    * will generate one.
-   * @param subscription_properties One or more Kafka Consumer properties to use
-   * for this subscription. For more information, see [Get Data from a Stream
-   * Layer](https://developer.here.com/olp/documentation/data-store/data_dev_guide/rest/getting-data-stream.html).
+   * @param subscription_properties One or more Consumer properties to use for
+   * this subscription.
    * @param context A CancellationContext, which can be used to cancel the
    * pending request.
    * @param[out] x_correlation_id A trace ID to use to associate this request
-   * with other requests in your process. The correlation ID is the value of the
-   * `/subscribe` response header `X-Correlation-Id`.
+   * with the next request in your process. The correlation ID is the value of
+   * the response header `X-Correlation-Id`.
    * @return The result of operation as a client::ApiResponse object.
    */
   static SubscribeApiResponse Subscribe(
@@ -93,17 +94,90 @@ class StreamApi {
       std::string& x_correlation_id);
 
   /**
-   * @brief Delete subscription to a layer.
+   * @brief Commits offsets of the last message read.
    *
-   * This operation removes the subscription from the service. The base path to
-   * use is the value of 'nodeBaseURL' returned from /subscribe POST request.
+   * After reading data, you should commit the offset of the last message read
+   * from each partition so that your application can resume reading new
+   * messages from the correct partition in the event that there is a disruption
+   * to the subscription, such as an application crash. An offset can also be
+   * useful if you delete a subscription then recreate a subscription for the
+   * same layer, because the new subscription can start reading data from the
+   * offset. To read messages already committed, use the `/seek` endpoint, then
+   * use `/partitions`. The base path to use is the value of 'nodeBaseURL'
+   * returned from `/subscribe` POST request.
    *
    * @param client Instance of OlpClient used to make REST request.
    * @param layer_id The ID of the stream layer.
+   * @param commit_offsets The offsets to commit. It should be same as the
+   * offset of the message you wish to commit. Do not pass offset + 1. The
+   * service adds one to the offset you specify.
+   * @param subscription_id The subscriptionId received in the response of the
+   * `/subscribe` request (required if mode=parallel).
+   * @param mode The subscription mode of this subscriptionId (as provided in
+   * `/subscribe` POST API).
+   * @param context A CancellationContext, which can be used to cancel the
+   * pending request.
+   * @param[in,out] x_correlation_id The correlation-id (value of Response
+   * Header 'X-Correlation-Id') from prior step in the process. See the [API
+   * Reference](https://developer.here.com/olp/documentation/data-store/api-reference.html)
+   * for the `stream` API. After the call it will be assigned to the
+   * correlation-id of the latest response in case of successful call.
+   * @return The result of operation as a client::ApiResponse object.
+   */
+  static CommitOffsetsApiResponse CommitOffsets(
+      const client::OlpClient& client, const std::string& layer_id,
+      const model::StreamOffsets& commit_offsets,
+      const boost::optional<std::string>& subscription_id,
+      const boost::optional<std::string>& mode,
+      const client::CancellationContext& context,
+      std::string& x_correlation_id);
+
+  /**
+   * @brief Seek to predefined offset.
+   *
+   * Enables you to start reading data from a specified offset. You can move the
+   * message pointer to any offset in the layer (topic). Message consumption
+   * will start from that offset. Once you seek to an offset, there is no
+   * returning to the initial offset, unless the initial offset is saved. The
+   * base path to use is the value of 'nodeBaseURL' returned from `/subscribe`
+   * POST request.
+   *
+   * @param client Instance of OlpClient used to make REST request.
+   * @param layer_id The ID of the stream layer.
+   * @param seek_offsets List of offsets and offset partitions.
    * @param subscription_id The subscriptionId received in the response of the
    * /subscribe request (required if mode=parallel).
    * @param mode The subscription mode of this subscriptionId (as provided in
    * /subscribe POST API).
+   * @param context A CancellationContext, which can be used to cancel the
+   * pending request.
+   * @param[in,out] x_correlation_id The correlation-id (value of Response
+   * Header 'X-Correlation-Id') from prior step in the process. See the [API
+   * Reference](https://developer.here.com/olp/documentation/data-store/api-reference.html)
+   * for the `stream` API. After the call it will be assigned to the
+   * correlation-id of the latest response in case of successful call.
+   * @return The result of operation as a client::ApiResponse object.
+   */
+  static SeekToOffsetApiResponse SeekToOffset(
+      const client::OlpClient& client, const std::string& layer_id,
+      const model::StreamOffsets& seek_offsets,
+      const boost::optional<std::string>& subscription_id,
+      const boost::optional<std::string>& mode,
+      const client::CancellationContext& context,
+      std::string& x_correlation_id);
+
+  /**
+   * @brief Delete subscription to a layer.
+   *
+   * This operation removes the subscription from the service. The base path to
+   * use is the value of 'nodeBaseURL' returned from `/subscribe` POST request.
+   *
+   * @param client Instance of OlpClient used to make REST request.
+   * @param layer_id The ID of the stream layer.
+   * @param subscription_id The subscriptionId received in the response of the
+   * `/subscribe` request (required if mode=parallel).
+   * @param mode The subscription mode of this subscriptionId (as provided in
+   * `/subscribe` POST API).
    * @param x_correlation_id A trace ID to use to associate this request with
    * other requests in your process. The correlation ID is the value of the
    * response header `X-Correlation-Id` from the prior request in your process.
@@ -116,8 +190,17 @@ class StreamApi {
   static UnsubscribeApiResponse DeleteSubscription(
       const client::OlpClient& client, const std::string& layer_id,
       const std::string& subscription_id, const std::string& mode,
-      const boost::optional<std::string>& x_correlation_id,
+      const std::string& x_correlation_id,
       const client::CancellationContext& context);
+
+ private:
+  static Response<int> HandleOffsets(
+      const client::OlpClient& client, const std::string& layer_id,
+      const model::StreamOffsets& commit_offsets,
+      const boost::optional<std::string>& subscription_id,
+      const boost::optional<std::string>& mode,
+      const client::CancellationContext& context, const std::string& endpoint,
+      std::string& x_correlation_id);
 };
 
 }  // namespace read


### PR DESCRIPTION
Will be used by StreamLayerClient to interact with OLP Stream Layer.

The only difference of these methods is the URI endpoint. So the logic
is extracted to one private method.

Relates-To: OLPEDGE-1196

Signed-off-by: Mykola Malik <ext-mykola.malik@here.com>