### PR TITLE
Add StreamLayerClient Unsubscribe method

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
@@ -78,12 +78,17 @@ using PrefetchTilesResponse = Response<PrefetchTilesResult>;
 /// Prefetch completion callback type
 using PrefetchTilesResponseCallback = Callback<PrefetchTilesResult>;
 
-/// The subcribe ID type of the stream layer client.
+/// The subscribe ID type of the stream layer client.
 using SubscriptionId = std::string;
-/// The subscribe tiles response type of the stream layer client.
+/// The subscribe response type of the stream layer client.
 using SubscribeResponse = Response<SubscriptionId>;
 /// The subscribe completion callback type of the stream layer client.
 using SubscribeResponseCallback = Callback<SubscriptionId>;
+
+/// The unsubscribe response type of the stream layer client.
+using UnsubscribeResponse = Response<SubscriptionId>;
+/// The unsubscribe completion callback type of the stream layer client.
+using UnsubscribeResponseCallback = Callback<SubscriptionId>;
 
 }  // namespace read
 }  // namespace dataservice

--- a/olp-cpp-sdk-dataservice-read/src/StreamLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/StreamLayerClient.cpp
@@ -53,6 +53,16 @@ client::CancellableFuture<SubscribeResponse> StreamLayerClient::Subscribe(
   return impl_->Subscribe(std::move(request));
 }
 
+client::CancellationToken StreamLayerClient::Unsubscribe(
+    UnsubscribeResponseCallback callback) {
+  return impl_->Unsubscribe(std::move(callback));
+}
+
+olp::client::CancellableFuture<UnsubscribeResponse>
+StreamLayerClient::Unsubscribe() {
+  return impl_->Unsubscribe();
+}
+
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/StreamLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/StreamLayerClientImpl.h
@@ -47,6 +47,11 @@ class StreamLayerClientImpl {
   virtual client::CancellableFuture<SubscribeResponse> Subscribe(
       SubscribeRequest request);
 
+  virtual client::CancellationToken Unsubscribe(
+      UnsubscribeResponseCallback callback);
+
+  virtual client::CancellableFuture<UnsubscribeResponse> Unsubscribe();
+   
  private:
   /// A struct that aggregates the stream layer client parameters.
   struct StreamLayerClientContext {


### PR DESCRIPTION
Unsubscribe is used for disabling the consumption from the specific stream layer.
The result of successful unsubscribe operation is subscriptionID of the delete subscription.
If unsubscribe operation succeeds the client's internal state (related to subscription) is repealed.

Relates-To: OLPEDGE-1351

Signed-off-by: Dmytro Poberezhnyi <ext-dmytro.poberezhnyi@here.com>