### PR TITLE
Adapts part of the olp::client classes to coding style.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/ApiError.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/ApiError.h
@@ -29,17 +29,29 @@
 
 namespace olp {
 namespace client {
+
+/**
+ * @brief A wrapper around an internal error or HTTP status code.
+ */
 class CORE_API ApiError {
  public:
-  /**
-   * @brief ApiError Error information container
-   */
   ApiError() = default;
 
-  ApiError(const ErrorCode& error_code, const std::string& message,
-           bool is_retryable = false)
+  /**
+   * @brief Creates the `ApiError` instance with the internal error.
+   *
+   * Represents the internal error that is not related to any HTTP status
+   * returned during the request. You can call this constructor using the error
+   * code and error message.
+   *
+   * @param error_code The internal error code.
+   * @param message The text message of the error.
+   * @param is_retryable Indicates if the error is permanent or temporary
+   * and if the user can retry the operation.
+   */
+  ApiError(ErrorCode error_code, std::string message, bool is_retryable = false)
       : error_code_(error_code),
-        message_(message),
+        message_(std::move(message)),
         is_retryable_(is_retryable) {
     if (error_code == ErrorCode::Cancelled) {
       http_status_code_ =
@@ -47,24 +59,40 @@ class CORE_API ApiError {
     }
   }
 
-  ApiError(int http_status_code, const std::string& message = "")
+  /**
+   * @brief Creates the `ApiError` instance with the HTTP status code.
+   *
+   * Represents the server status. Evaluates the HTTP status code and sets the
+   * `error_code_` and `is_retriable_ flag` parameters . You can call this
+   * constructor using the HTTP status code and error text message.
+   *
+   * @param http_status_code The HTTP status code returned by the server.
+   * @param message The text message of the error.
+   */
+  ApiError(int http_status_code, std::string message = "")
       : error_code_(http::HttpStatusCode::GetErrorCode(http_status_code)),
         http_status_code_(http_status_code),
-        message_(message),
+        message_(std::move(message)),
         is_retryable_(http::HttpStatusCode::IsRetryable(http_status_code)) {}
 
   /**
-   * Gets the error code
+   * Gets the error code.
+   *
+   * @return The code associated with the error.
    */
   inline ErrorCode GetErrorCode() const { return error_code_; }
 
   /**
-   * Gets the HTTP status code
+   * Gets the HTTP status code.
+   *
+   * @return The HTTP status code.
    */
   inline int GetHttpStatusCode() const { return http_status_code_; }
 
   /**
    * Gets the error message.
+   *
+   * @return The error message associated with the error.
    */
   inline const std::string& GetMessage() const { return message_; }
 
@@ -77,9 +105,10 @@ class CORE_API ApiError {
   // TODO: merge error_code_ and http_status_code_ by shifting ErrorCode values
   // to negatives
   ErrorCode error_code_{ErrorCode::Unknown};
-  int http_status_code_{static_cast<int>(olp::http::ErrorCode::UNKNOWN_ERROR)};
+  int http_status_code_{static_cast<int>(http::ErrorCode::UNKNOWN_ERROR)};
   std::string message_;
   bool is_retryable_{false};
 };
+
 }  // namespace client
 }  // namespace olp

--- a/olp-cpp-sdk-core/include/olp/core/client/CancellationToken.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/CancellationToken.h
@@ -26,30 +26,33 @@
 
 namespace olp {
 namespace client {
+
 /**
- * @brief Control object for cancelling service requests
+ * @brief Cancels service requests
  */
 class CORE_API CancellationToken {
  public:
-  /**
-   * @brief Default constructor
-   */
+  /// The alias for the cancellation function.
+  using CancelFuncType = std::function<void()>;
+
   CancellationToken() = default;
 
   /**
-   * @brief Constructor
-   * @param func an operation that should be used to cancel an authentication
-   * request.
+   * @brief Creates the `CancellationToken` instance.
+   *
+   * @param func The operation that should be used to cancel the ongoing.
+   * operation.
    */
-  CancellationToken(std::function<void()> func);
+  CancellationToken(CancelFuncType func);
 
   /**
-   * @brief Cancels the current operation, calls the func_ instance variable.
+   * @brief Cancels the current operation and calls the `func_` instance.
    */
   void Cancel() const;
 
  private:
-  std::function<void()> func_{};
+  CancelFuncType func_;
 };
+
 }  // namespace client
 }  // namespace olp

--- a/olp-cpp-sdk-core/include/olp/core/client/ErrorCode.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/ErrorCode.h
@@ -21,66 +21,72 @@
 
 namespace olp {
 namespace client {
+
+/**
+ * @brief Represents all possible errors that might happen during a user
+ * request.
+ */
 enum class ErrorCode {
   /**
-   * Unknown error, see error message for details
+   * An unknown error. See the error message for details.
    */
   Unknown = 0,
 
   /**
-   * Request was cancelled (usually by the user)
+   * The request was cancelled (usually by the user).
    */
   Cancelled,
 
   /**
-   * Request passed invalid aruguments
+   * The request passed invalid arguments.
    */
   InvalidArgument,
 
   /**
-   * Request exceeded timeout limit
+   * The request exceeded the timeout limit.
    */
   RequestTimeout,
 
   /**
-   * Internal server failure
+   * Internal server failure.
    */
   InternalFailure,
 
   /**
-   * Request service is unavailable
+   * The requested service is not available.
    */
   ServiceUnavailable,
 
   /**
-   * Access denied to service due to insufficient credentials
+   * The access to the service was denied due to insufficient credentials.
    */
   AccessDenied,
 
   /**
-   * Request malformed
+   * The URL malformed or some data parameters are not formed correctly.
    */
   BadRequest,
 
   /**
-   * Conditions to access service are unmet
+   * The conditions required to access the service are not met.
    */
   PreconditionFailed,
 
   /**
-   * Requested resource not found
+   * The requested resource was not found.
    */
   NotFound,
 
   /**
-   * Too many requests sent in a given amount of time
+   * Too many requests sent in a given amount of time.
    */
   SlowDown,
 
   /**
-   * Network connection error detected
+   * The network connection error.
    */
   NetworkConnection
 };
-}
+
+}  // namespace client
 }  // namespace olp

--- a/olp-cpp-sdk-core/src/client/CancellationToken.cpp
+++ b/olp-cpp-sdk-core/src/client/CancellationToken.cpp
@@ -21,7 +21,8 @@
 
 namespace olp {
 namespace client {
-CancellationToken::CancellationToken(std::function<void()> func)
+
+CancellationToken::CancellationToken(CancelFuncType func)
     : func_(std::move(func)) {}
 
 void CancellationToken::Cancel() const {


### PR DESCRIPTION
Some of the most commonly used olp::client namespace classes
are now aligned with the coding style. This also enhances doxygen
documentation, introduces some usefull aliases.
Additionally this alters ApiError and CancellableFuture constructors
to use pass by value for efficient moving instead of by reference.

Relates-to: OLPEDGE-567

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>