### PR TITLE
Add unit tests for MessagesParser and SubscribeResponseParser

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/generated/parser/MessagesParser.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/parser/MessagesParser.cpp
@@ -30,12 +30,13 @@ using namespace olp::dataservice::read;
 
 void from_json(const rapidjson::Value& value, model::Metadata& x) {
   x.SetPartition(parse<std::string>(value, "partition"));
-  x.SetChecksum(parse<std::string>(value, "checksum"));
-  x.SetCompressedDataSize(parse<int64_t>(value, "compressedDataSize"));
-  x.SetDataSize(parse<int64_t>(value, "dataSize"));
+  x.SetChecksum(parse<boost::optional<std::string>>(value, "checksum"));
+  x.SetCompressedDataSize(
+      parse<boost::optional<int64_t>>(value, "compressedDataSize"));
+  x.SetDataSize(parse<boost::optional<int64_t>>(value, "dataSize"));
   x.SetData(parse<model::Data>(value, "data"));
-  x.SetDataHandle(parse<std::string>(value, "dataHandle"));
-  x.SetTimestamp(parse<int64_t>(value, "timestamp"));
+  x.SetDataHandle(parse<boost::optional<std::string>>(value, "dataHandle"));
+  x.SetTimestamp(parse<boost::optional<int64_t>>(value, "timestamp"));
 }
 
 void from_json(const rapidjson::Value& value, model::Message& x) {


### PR DESCRIPTION
Add unit tests covering parse of Metadata, StreamOffset, Message classes (MessageParser.h) and SusbscribeResponse class.

Relates-to: OLPEDGE-1385

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>