### PR TITLE
Add StreamLayerClient GetData method

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/StreamLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/StreamLayerClient.h
@@ -28,6 +28,7 @@
 #include <olp/dataservice/read/DataServiceReadApi.h>
 #include <olp/dataservice/read/SubscribeRequest.h>
 #include <olp/dataservice/read/Types.h>
+#include <olp/dataservice/read/model/Messages.h>
 
 namespace olp {
 namespace dataservice {
@@ -161,6 +162,41 @@ class DATASERVICE_READ_API StreamLayerClient final {
    * this request.
    */
   client::CancellableFuture<UnsubscribeResponse> Unsubscribe();
+
+  /**
+   * @brief Downloads message data using a data handle from the given message
+   * metadata.
+   *
+   * Users should use this method to download data only for messages that
+   * include a data handle and that have the size of the data greater than 1 MB.
+   * Message with data size less then 1 MB will have the data embedded.
+   *
+   * @param message  The `Message` instance that was retrieved using `Poll`
+   * method.
+   * @param callback The `DataResponseCallback` object that is invoked when the
+   * get data request is completed.
+   *
+   * @return A token that can be used to cancel this request.
+   */
+  client::CancellationToken GetData(const model::Message& message,
+                                    DataResponseCallback callback);
+
+  /**
+   * @brief Downloads message data using a data handle from the given message
+   * metadata.
+   *
+   * Users should use this method to download data only for messages that
+   * include a data handle and that have the size of the data greater than 1 MB.
+   * Message with data size less then 1 MB will have the data embedded.
+   *
+   * @param message  The `Message` instance that was retrieved using `Poll`
+   * method.
+   *
+   * @return `CancellableFuture` that contains `DataResult` or an error. You can
+   * also use `CancellableFuture` to cancel this request.
+   */
+  client::CancellableFuture<DataResponse> GetData(
+      const model::Message& message);
 
  private:
   std::unique_ptr<StreamLayerClientImpl> impl_;

--- a/olp-cpp-sdk-dataservice-read/src/StreamLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/StreamLayerClient.cpp
@@ -58,9 +58,19 @@ client::CancellationToken StreamLayerClient::Unsubscribe(
   return impl_->Unsubscribe(std::move(callback));
 }
 
-olp::client::CancellableFuture<UnsubscribeResponse>
+client::CancellableFuture<UnsubscribeResponse>
 StreamLayerClient::Unsubscribe() {
   return impl_->Unsubscribe();
+}
+
+client::CancellationToken StreamLayerClient::GetData(
+    const model::Message& message, DataResponseCallback callback) {
+  return impl_->GetData(message, callback);
+}
+
+client::CancellableFuture<DataResponse> StreamLayerClient::GetData(
+    const model::Message& message) {
+  return impl_->GetData(message);
 }
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/StreamLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/StreamLayerClientImpl.h
@@ -27,6 +27,7 @@
 #include <olp/core/client/PendingRequests.h>
 #include <olp/dataservice/read/SubscribeRequest.h>
 #include <olp/dataservice/read/Types.h>
+#include <olp/dataservice/read/model/Messages.h>
 
 namespace olp {
 namespace dataservice {
@@ -51,7 +52,13 @@ class StreamLayerClientImpl {
       UnsubscribeResponseCallback callback);
 
   virtual client::CancellableFuture<UnsubscribeResponse> Unsubscribe();
-   
+
+  virtual client::CancellationToken GetData(const model::Message& message,
+                                            DataResponseCallback callback);
+
+  virtual client::CancellableFuture<DataResponse> GetData(
+      const model::Message& message);
+
  private:
   /// A struct that aggregates the stream layer client parameters.
   struct StreamLayerClientContext {


### PR DESCRIPTION
GetData will be used for download the data for the messages that does
not include the data embedded, but includes a data handle and the data
size greater than 1 MB.

Resolves: OLPEDGE-1354

Signed-off-by: Mykola Malik <ext-mykola.malik@here.com>