### PR TITLE
Add unit tests for StreamOffsets and ConsumerProperties serializers

### DIFF
--- a/olp-cpp-sdk-dataservice-read/tests/SerializerTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/SerializerTest.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <chrono>
+#include <limits>
 #include <regex>
 #include <string>
 
@@ -27,8 +28,10 @@
 // Ordering Required - Serializer template specializations before JsonSerializer.h
 #include "generated/serializer/ApiSerializer.h"
 #include "generated/serializer/CatalogSerializer.h"
+#include "generated/serializer/ConsumerPropertiesSerializer.h"
 #include "generated/serializer/LayerVersionsSerializer.h"
 #include "generated/serializer/PartitionsSerializer.h"
+#include "generated/serializer/StreamOffsetsSerializer.h"
 #include "generated/serializer/VersionResponseSerializer.h"
 #include "generated/serializer/JsonSerializer.h"
 
@@ -424,6 +427,86 @@ TEST(SerializerTest, VersionResponse) {
   RemoveWhitespaceAndNewlines(expectedOutput);
   RemoveWhitespaceAndNewlines(json);
   ASSERT_EQ(expectedOutput, json);
+}
+
+TEST(SerializerTest, ConsumerProperties) {
+  std::string expected_output =
+      "{\
+    \"kafkaConsumerProperties\":{\
+    \"key_string\":\"value_string\",\
+    \"key_c-string\":\"value_c-string\",\
+    \"key_int32\":\"42\",\
+    \"key_bool\":\"1\"\
+    }\
+    }";
+
+  olp::dataservice::read::ConsumerOptions expected_options = {
+      olp::dataservice::read::ConsumerOption("key_string",
+                                             std::string("value_string")),
+      olp::dataservice::read::ConsumerOption("key_c-string", "value_c-string"),
+      olp::dataservice::read::ConsumerOption("key_int32", (int32_t)42),
+      olp::dataservice::read::ConsumerOption("key_bool", true)};
+
+  olp::dataservice::read::ConsumerProperties props(expected_options);
+
+  const auto& options = props.GetProperties();
+  ASSERT_EQ(expected_options.size(), options.size());
+  for (size_t i = 0; i < expected_options.size(); ++i) {
+    EXPECT_EQ(expected_options[i].GetKey(), options[i].GetKey());
+    EXPECT_EQ(expected_options[i].GetValue(), options[i].GetValue());
+  }
+
+  auto json = olp::serializer::serialize(props);
+
+  RemoveWhitespaceAndNewlines(expected_output);
+  RemoveWhitespaceAndNewlines(json);
+
+  EXPECT_EQ(expected_output, json);
+}
+
+TEST(SerializerTest, StreamOffset) {
+  constexpr auto kMinInt32_t = std::numeric_limits<int32_t>::min();
+  constexpr auto kMaxInt64_t = std::numeric_limits<int64_t>::max();
+
+  std::string expected_output =
+      "{\"offsets\":[\
+    {\
+        \"partition\":7,\
+        \"offset\":38562\
+    },\
+    {\
+        \"partition\":-2147483648,\
+        \"offset\":9223372036854775807\
+    }\
+    ]}";
+
+  StreamOffset kOffset1;
+  kOffset1.SetPartition(7);
+  kOffset1.SetOffset(38562);
+
+  StreamOffset kOffset2;
+  kOffset2.SetPartition(kMinInt32_t);
+  kOffset2.SetOffset(kMaxInt64_t);
+
+  const std::vector<StreamOffset> expected_offsets = {kOffset1, kOffset2};
+
+  StreamOffsets offsets;
+  offsets.SetOffsets(expected_offsets);
+
+  const auto& offsets_vec = offsets.GetOffsets();
+  ASSERT_EQ(expected_offsets.size(), offsets_vec.size());
+  for (size_t i = 0; i < expected_offsets.size(); ++i) {
+    EXPECT_EQ(expected_offsets[i].GetPartition(),
+              offsets_vec[i].GetPartition());
+    EXPECT_EQ(expected_offsets[i].GetOffset(), offsets_vec[i].GetOffset());
+  }
+
+  auto json = olp::serializer::serialize(offsets);
+
+  RemoveWhitespaceAndNewlines(expected_output);
+  RemoveWhitespaceAndNewlines(json);
+
+  EXPECT_EQ(expected_output, json);
 }
 
 }  // namespace

--- a/olp-cpp-sdk-dataservice-read/tests/SerializerTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/SerializerTest.cpp
@@ -444,18 +444,10 @@ TEST(SerializerTest, ConsumerProperties) {
       olp::dataservice::read::ConsumerOption("key_string",
                                              std::string("value_string")),
       olp::dataservice::read::ConsumerOption("key_c-string", "value_c-string"),
-      olp::dataservice::read::ConsumerOption("key_int32", (int32_t)42),
+      olp::dataservice::read::ConsumerOption("key_int32", int32_t{42}),
       olp::dataservice::read::ConsumerOption("key_bool", true)};
 
   olp::dataservice::read::ConsumerProperties props(expected_options);
-
-  const auto& options = props.GetProperties();
-  ASSERT_EQ(expected_options.size(), options.size());
-  for (size_t i = 0; i < expected_options.size(); ++i) {
-    EXPECT_EQ(expected_options[i].GetKey(), options[i].GetKey());
-    EXPECT_EQ(expected_options[i].GetValue(), options[i].GetValue());
-  }
-
   auto json = olp::serializer::serialize(props);
 
   RemoveWhitespaceAndNewlines(expected_output);
@@ -465,8 +457,8 @@ TEST(SerializerTest, ConsumerProperties) {
 }
 
 TEST(SerializerTest, StreamOffset) {
-  constexpr auto kMinInt32_t = std::numeric_limits<int32_t>::min();
-  constexpr auto kMaxInt64_t = std::numeric_limits<int64_t>::max();
+  constexpr auto kMinInt32 = std::numeric_limits<int32_t>::min();
+  constexpr auto kMaxInt64 = std::numeric_limits<int64_t>::max();
 
   std::string expected_output =
       "{\"offsets\":[\
@@ -485,21 +477,13 @@ TEST(SerializerTest, StreamOffset) {
   kOffset1.SetOffset(38562);
 
   StreamOffset kOffset2;
-  kOffset2.SetPartition(kMinInt32_t);
-  kOffset2.SetOffset(kMaxInt64_t);
+  kOffset2.SetPartition(kMinInt32);
+  kOffset2.SetOffset(kMaxInt64);
 
   const std::vector<StreamOffset> expected_offsets = {kOffset1, kOffset2};
 
   StreamOffsets offsets;
   offsets.SetOffsets(expected_offsets);
-
-  const auto& offsets_vec = offsets.GetOffsets();
-  ASSERT_EQ(expected_offsets.size(), offsets_vec.size());
-  for (size_t i = 0; i < expected_offsets.size(); ++i) {
-    EXPECT_EQ(expected_offsets[i].GetPartition(),
-              offsets_vec[i].GetPartition());
-    EXPECT_EQ(expected_offsets[i].GetOffset(), offsets_vec[i].GetOffset());
-  }
 
   auto json = olp::serializer::serialize(offsets);
 


### PR DESCRIPTION
Add units tests for StreamOffsetsSerializer and ConsumerPropertiesSerialzer.

Relates-to: OLPEDGE-1385

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>