### PR TITLE
Refactor the ApiClientLookup::LookupApiClient to use synchronous API

### DIFF
--- a/olp-cpp-sdk-dataservice-write/src/generated/PlatformApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/PlatformApi.cpp
@@ -35,17 +35,18 @@ namespace dataservice {
 namespace write {
 client::CancellationToken PlatformApi::GetApis(
     std::shared_ptr<client::OlpClient> client, const std::string& service,
-    const std::string& serviceVersion, const ApisCallback& apisCallback) {
-  std::multimap<std::string, std::string> headerParams;
-  headerParams.insert(std::make_pair("Accept", "application/json"));
-  std::multimap<std::string, std::string> queryParams;
-  std::multimap<std::string, std::string> formParams;
+    const std::string& service_version, const ApisCallback& apisCallback) {
+  std::multimap<std::string, std::string> header_params;
+  header_params.insert(std::make_pair("Accept", "application/json"));
+  std::multimap<std::string, std::string> query_params;
+  std::multimap<std::string, std::string> form_params;
 
-  std::string platformUrl = "/platform/apis/" + service + "/" + serviceVersion;
+  std::string platform_url =
+      "/platform/apis/" + service + "/" + service_version;
 
   client::NetworkAsyncCallback callback = [apisCallback](
                                               client::HttpResponse response) {
-    if (response.status != 200) {
+    if (response.status != olp::http::HttpStatusCode::OK) {
       apisCallback(ApisResponse(
           client::ApiError(response.status, response.response.str())));
     } else {
@@ -55,8 +56,31 @@ client::CancellationToken PlatformApi::GetApis(
     }
   };
 
-  return client->CallApi(platformUrl, "GET", queryParams, headerParams,
-                         formParams, nullptr, "", callback);
+  return client->CallApi(platform_url, "GET", query_params, header_params,
+                         form_params, nullptr, "", callback);
+}
+
+PlatformApi::ApisResponse PlatformApi::GetApis(
+    const client::OlpClient& client, const std::string& service,
+    const std::string& service_version,
+    client::CancellationContext cancel_context) {
+  std::multimap<std::string, std::string> header_params;
+  header_params.insert(std::make_pair("Accept", "application/json"));
+  std::multimap<std::string, std::string> query_params;
+  std::multimap<std::string, std::string> form_params;
+
+  std::string platform_url =
+      "/platform/apis/" + service + "/" + service_version;
+
+  auto http_response =
+      client.CallApi(std::move(platform_url), "GET", std::move(query_params),
+                     std::move(header_params), std::move(form_params), nullptr,
+                     "", cancel_context);
+  if (http_response.status != olp::http::HttpStatusCode::OK) {
+    return client::ApiError(http_response.status, http_response.response.str());
+  }
+
+  return ApisResponse(parser::parse<model::Apis>(http_response.response));
 }
 
 }  // namespace write

--- a/olp-cpp-sdk-dataservice-write/src/generated/PlatformApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/PlatformApi.h
@@ -23,6 +23,7 @@
 #include <string>
 
 #include <olp/core/client/ApiResponse.h>
+#include <olp/core/client/CancellationContext.h>
 #include "generated/model/Api.h"
 #include "olp/core/client/ApiError.h"
 
@@ -54,6 +55,14 @@ class PlatformApi {
   static client::CancellationToken GetApis(
       std::shared_ptr<client::OlpClient> client, const std::string& service,
       const std::string& serviceVersion, const ApisCallback& callback);
+
+  /**
+   * @brief Synchronous version of \c GetApis method.
+   */
+  static ApisResponse GetApis(const client::OlpClient& client,
+                              const std::string& service,
+                              const std::string& service_version,
+                              client::CancellationContext context);
 };
 
 }  // namespace write

--- a/olp-cpp-sdk-dataservice-write/src/generated/ResourcesApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/ResourcesApi.cpp
@@ -36,18 +36,18 @@ client::CancellationToken ResourcesApi::GetApis(
     std::shared_ptr<client::OlpClient> client, const std::string& hrn,
     const std::string& service, const std::string& service_version,
     const ApisCallback& apisCallback) {
-  std::multimap<std::string, std::string> headerParams;
-  headerParams.insert(std::make_pair("Accept", "application/json"));
-  std::multimap<std::string, std::string> queryParams;
-  std::multimap<std::string, std::string> formParams;
+  std::multimap<std::string, std::string> header_params;
+  header_params.insert(std::make_pair("Accept", "application/json"));
+  std::multimap<std::string, std::string> query_params;
+  std::multimap<std::string, std::string> form_params;
 
   // scan apis at resource endpoint
-  std::string resourceUrl =
+  std::string resource_url =
       "/resources/" + hrn + "/apis/" + service + "/" + service_version;
 
   client::NetworkAsyncCallback callback = [apisCallback](
                                               client::HttpResponse response) {
-    if (response.status != 200) {
+    if (response.status != olp::http::HttpStatusCode::OK) {
       apisCallback(ApisResponse(
           client::ApiError(response.status, response.response.str())));
     } else {
@@ -56,8 +56,30 @@ client::CancellationToken ResourcesApi::GetApis(
       apisCallback(ApisResponse(parser::parse<model::Apis>(response.response)));
     }
   };
-  return client->CallApi(resourceUrl, "GET", queryParams, headerParams,
-                         formParams, nullptr, "", callback);
+  return client->CallApi(resource_url, "GET", query_params, header_params,
+                         form_params, nullptr, "", callback);
+}
+
+ResourcesApi::ApisResponse ResourcesApi::GetApis(
+    const client::OlpClient& client, const std::string& hrn,
+    const std::string& service, const std::string& service_version,
+    olp::client::CancellationContext cancel_context) {
+  std::multimap<std::string, std::string> header_params;
+  header_params.insert(std::make_pair("Accept", "application/json"));
+  std::multimap<std::string, std::string> query_params;
+  std::multimap<std::string, std::string> form_params;
+
+  // scan apis at resource endpoint
+  std::string resource_url =
+      "/resources/" + hrn + "/apis/" + service + "/" + service_version;
+  auto http_response =
+      client.CallApi(std::move(resource_url), "GET", std::move(query_params),
+                     std::move(header_params), std::move(form_params), nullptr,
+                     "", cancel_context);
+  if (http_response.status != olp::http::HttpStatusCode::OK) {
+    return client::ApiError(http_response.status, http_response.response.str());
+  }
+  return ApisResponse(parser::parse<model::Apis>(http_response.response));
 }
 
 }  // namespace write

--- a/olp-cpp-sdk-dataservice-write/src/generated/ResourcesApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/ResourcesApi.h
@@ -23,6 +23,7 @@
 #include <string>
 
 #include <olp/core/client/ApiResponse.h>
+#include <olp/core/client/CancellationContext.h>
 #include "generated/model/Api.h"
 #include "olp/core/client/ApiError.h"
 
@@ -56,6 +57,15 @@ class ResourcesApi {
       std::shared_ptr<client::OlpClient> client, const std::string& hrn,
       const std::string& service, const std::string& service_version,
       const ApisCallback& callback);
+
+  /**
+   * @brief Synchronous version of \c GetApis method.
+   */
+  static ApisResponse GetApis(const client::OlpClient& client,
+                              const std::string& hrn,
+                              const std::string& service,
+                              const std::string& service_version,
+                              olp::client::CancellationContext cancel_context);
 };
 
 }  // namespace write

--- a/olp-cpp-sdk-dataservice-write/tests/StreamLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/StreamLayerClientImplTest.cpp
@@ -312,11 +312,7 @@ TEST_F(StreamLayerClientImplTest, FaliedPublishDataLessThanTwentyMib) {
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(olp::http::HttpStatusCode::BAD_REQUEST,
               response.GetError().GetHttpStatusCode());
-    // For some reason the OlpClient return error string as:
-    // 'Error occured. Please check HTTP status code.'
-    // Maybe we should reconsider this...
-    EXPECT_EQ("Error occured. Please check HTTP status code.",
-              response.GetError().GetMessage());
+    EXPECT_TRUE(response.GetError().GetMessage().empty());
   }
 
   {


### PR DESCRIPTION
1. Adds the synchronous version of the ResourcesApi and PlatformApi.
2. Refactor the ApiClientLookup::LookupApiClient to use sync ResourceApi and PlatformApi. This will ease supporting of the API lookup code and will eventually get rid of static network in the tests.
3. Add assertion on leaked network and task scheduler in DataserviceWriteStreamLayerClientTest.

Relates-to: OLPEDGE-1331, OLPEDGE-1424

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>