### PR TITLE
[Don't Merge] Use HttpVerb to specify HTTP methods instead of plain strings.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClient.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClient.h
@@ -83,6 +83,7 @@ class CORE_API OlpClient {
    *
    * @return A method to call to cancel the request.
    */
+  OLP_SDK_DEPRECATED("Deprecated. Will be removed in 06.2020. Please use other overloads")
   CancellationToken CallApi(
       const std::string& path, const std::string& method,
       const std::multimap<std::string, std::string>& query_params,
@@ -111,7 +112,61 @@ class CORE_API OlpClient {
    *
    * @return The `HttpResponse` instance.
    */
+  OLP_SDK_DEPRECATED("Deprecated. Will be removed in 06.2020. Please use other overloads")
   HttpResponse CallApi(std::string path, std::string method,
+                       std::multimap<std::string, std::string> query_params,
+                       std::multimap<std::string, std::string> header_params,
+                       std::multimap<std::string, std::string> form_params,
+                       std::shared_ptr<std::vector<unsigned char>> post_body,
+                       std::string content_type,
+                       CancellationContext context) const;
+
+  /**
+   * @brief Execute the REST request through the network stack
+   * @param path Path that is appended to the base url.
+   * @param method The request HTTP method.
+   * @param query_params Params that is appended to the path url.
+   * @param header_params Headers to customize request.
+   * @param form_params For a POST request, form_params or post_body should be
+   * populated, but not both.
+   * @param post_body For a POST request, form_params or post_body should be
+   * populated, but not both.
+   * This data must not be modified until the request is completed.
+   * @param content_type Content type for the post_body or form_params.
+   * @param callback a function callback to receive the HttpResponse.
+   *
+   * @return A method to call to cancel the request.
+   */
+  CancellationToken CallApi(
+      const std::string& path, http::NetworkRequest::HttpVerb method,
+      const std::multimap<std::string, std::string>& query_params,
+      const std::multimap<std::string, std::string>& header_params,
+      const std::multimap<std::string, std::string>& form_params,
+      const std::shared_ptr<std::vector<unsigned char>>& post_body,
+      const std::string& content_type,
+      const NetworkAsyncCallback& callback) const;
+
+  /**
+   * @brief Executes the REST request through the network stack in a blocking
+   * way.
+   * @param path The path that is appended to the base URL.
+   * @param method The request HTTP method.
+   * @param query_params The parameters that are appended to the path URL.
+   * @param header_params The headers used to customize request.
+   * @param form_params (For the POST request) Populate one of the following
+   * parameters: `form_params` or `post_body`.
+   * @param post_body (For the POST request) Populate one of the following
+   * parameters: `form_params` or `post_body`. This data must not be modified
+   * until the request is completed.
+   * @param content_type The content type of the `post_body` or `form_params`
+   * parameters.
+   * @param context The `CancellationContext` instance that is used to cancel
+   * the request.
+   *
+   * @return The `HttpResponse` instance.
+   */
+  HttpResponse CallApi(std::string path,
+                       http::NetworkRequest::HttpVerb method,
                        std::multimap<std::string, std::string> query_params,
                        std::multimap<std::string, std::string> header_params,
                        std::multimap<std::string, std::string> form_params,
@@ -122,6 +177,13 @@ class CORE_API OlpClient {
  private:
   std::shared_ptr<http::NetworkRequest> CreateRequest(
       const std::string& path, const std::string& method,
+      const std::multimap<std::string, std::string>& query_params,
+      const std::multimap<std::string, std::string>& header_params,
+      const std::shared_ptr<std::vector<unsigned char>>& post_body,
+      const std::string& content_type) const;
+
+  std::shared_ptr<http::NetworkRequest> CreateRequest(
+      const std::string& path, olp::http::NetworkRequest::HttpVerb method,
       const std::multimap<std::string, std::string>& query_params,
       const std::multimap<std::string, std::string>& header_params,
       const std::shared_ptr<std::vector<unsigned char>>& post_body,

--- a/olp-cpp-sdk-core/src/client/OlpClient.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClient.cpp
@@ -197,10 +197,20 @@ std::shared_ptr<http::NetworkRequest> OlpClient::CreateRequest(
     const std::multimap<std::string, std::string>& header_params,
     const std::shared_ptr<std::vector<unsigned char>>& post_body,
     const std::string& content_type) const {
+  auto http_verb = GetHttpVerb(method);
+  return CreateRequest(path, http_verb, query_params, header_params, post_body,
+                       content_type);
+}
+
+std::shared_ptr<http::NetworkRequest> OlpClient::CreateRequest(
+    const std::string& path, http::NetworkRequest::HttpVerb http_verb,
+    const std::multimap<std::string, std::string>& query_params,
+    const std::multimap<std::string, std::string>& header_params,
+    const std::shared_ptr<std::vector<unsigned char>>& post_body,
+    const std::string& content_type) const {
   auto network_request = std::make_shared<http::NetworkRequest>(
       olp::utils::Url::Construct(base_url_, path, query_params));
 
-  http::NetworkRequest::HttpVerb http_verb = GetHttpVerb(method);
   network_request->WithVerb(http_verb);
 
   if (settings_.authentication_settings &&
@@ -291,6 +301,19 @@ CancellationToken OlpClient::CallApi(
     const std::shared_ptr<std::vector<unsigned char>>& post_body,
     const std::string& content_type,
     const NetworkAsyncCallback& callback) const {
+  auto http_verb = GetHttpVerb(method);
+  return CallApi(path, http_verb, query_params, header_params, form_params,
+                 post_body, content_type, callback);
+}
+
+CancellationToken OlpClient::CallApi(
+    const std::string& path, http::NetworkRequest::HttpVerb method,
+    const std::multimap<std::string, std::string>& query_params,
+    const std::multimap<std::string, std::string>& header_params,
+    const std::multimap<std::string, std::string>& form_params,
+    const std::shared_ptr<std::vector<unsigned char>>& post_body,
+    const std::string& content_type,
+    const NetworkAsyncCallback& callback) const {
   auto network_request = CreateRequest(path, method, query_params,
                                        header_params, post_body, content_type);
 
@@ -342,13 +365,25 @@ HttpResponse OlpClient::CallApi(
     std::string path, std::string method,
     std::multimap<std::string, std::string> query_params,
     std::multimap<std::string, std::string> header_params,
-    std::multimap<std::string, std::string> forms_params,
+    std::multimap<std::string, std::string> form_params,
+    std::shared_ptr<std::vector<unsigned char>> post_body,
+    std::string content_type, CancellationContext context) const {
+  auto http_verb = GetHttpVerb(method);
+  return CallApi(path, http_verb, query_params, header_params, form_params,
+                 post_body, content_type, context);
+}
+
+HttpResponse OlpClient::CallApi(
+    std::string path, http::NetworkRequest::HttpVerb method,
+    std::multimap<std::string, std::string> query_params,
+    std::multimap<std::string, std::string> header_params,
+    std::multimap<std::string, std::string> form_params,
     std::shared_ptr<std::vector<unsigned char>> post_body,
     std::string content_type, CancellationContext context) const {
   http::NetworkRequest network_request(
       olp::utils::Url::Construct(base_url_, path, query_params));
 
-  network_request.WithVerb(GetHttpVerb(method));
+  network_request.WithVerb(method);
 
   if (settings_.authentication_settings &&
       settings_.authentication_settings.get().provider) {

--- a/olp-cpp-sdk-core/tests/client/OlpClientTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/OlpClientTest.cpp
@@ -39,7 +39,7 @@ using ::testing::_;
 class CallApiWrapper {
  public:
   virtual HttpResponse CallApi(
-      std::string path, std::string method,
+      std::string path, olp::http::NetworkRequest::HttpVerb method,
       std::multimap<std::string, std::string> query_params,
       std::multimap<std::string, std::string> header_params,
       std::multimap<std::string, std::string> form_params,
@@ -54,7 +54,7 @@ class CallApiSync : public CallApiWrapper {
       : client_{client} {}
 
   HttpResponse CallApi(
-      std::string path, std::string method,
+      std::string path, olp::http::NetworkRequest::HttpVerb method,
       std::multimap<std::string, std::string> query_params,
       std::multimap<std::string, std::string> header_params,
       std::multimap<std::string, std::string> form_params,
@@ -77,7 +77,7 @@ class CallApiAsync : public CallApiWrapper {
       : client_{client} {}
 
   HttpResponse CallApi(
-      std::string path, std::string method,
+      std::string path, olp::http::NetworkRequest::HttpVerb method,
       std::multimap<std::string, std::string> query_params,
       std::multimap<std::string, std::string> header_params,
       std::multimap<std::string, std::string> form_params,
@@ -180,7 +180,8 @@ TEST_P(OlpClientTest, NumberOfAttempts) {
   client_.SetSettings(client_settings_);
 
   auto response = call_wrapper_->CallApi(
-      std::string(), "GET", std::multimap<std::string, std::string>(),
+      std::string(), olp::http::NetworkRequest::HttpVerb::GET,
+      std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(), nullptr, std::string());
 
@@ -208,7 +209,7 @@ TEST_P(OlpClientTest, ZeroAttempts) {
   client_.SetSettings(client_settings_);
 
   auto response = call_wrapper_->CallApi(
-      std::string(), "GET", std::multimap<std::string, std::string>(),
+      std::string(), olp::http::NetworkRequest::HttpVerb::GET, std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(), nullptr, std::string());
 
@@ -233,7 +234,7 @@ TEST_P(OlpClientTest, DefaultRetryCondition) {
   client_.SetSettings(client_settings_);
 
   auto response = call_wrapper_->CallApi(
-      std::string(), "GET", std::multimap<std::string, std::string>(),
+      std::string(), olp::http::NetworkRequest::HttpVerb::GET, std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(), nullptr, std::string());
 
@@ -272,7 +273,7 @@ TEST_P(OlpClientTest, RetryCondition) {
   client_.SetSettings(client_settings_);
 
   auto response = call_wrapper_->CallApi(
-      std::string(), "GET", std::multimap<std::string, std::string>(),
+      std::string(), olp::http::NetworkRequest::HttpVerb::GET, std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(), nullptr, std::string());
 
@@ -301,7 +302,7 @@ TEST_P(OlpClientTest, RetryTimeLinear) {
       });
 
   auto response = call_wrapper_->CallApi(
-      std::string(), "GET", std::multimap<std::string, std::string>(),
+      std::string(), olp::http::NetworkRequest::HttpVerb::GET, std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(), nullptr, std::string());
 
@@ -340,7 +341,7 @@ TEST_P(OlpClientTest, RetryTimeExponential) {
       });
 
   auto response = call_wrapper_->CallApi(
-      std::string(), "GET", std::multimap<std::string, std::string>(),
+      std::string(), olp::http::NetworkRequest::HttpVerb::GET, std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(), nullptr, std::string());
 
@@ -378,7 +379,7 @@ TEST_P(OlpClientTest, SetInitialBackdownPeriod) {
         return olp::http::SendOutcome(olp::http::RequestId(5));
       });
   auto response = call_wrapper_->CallApi(
-      std::string(), "GET", std::multimap<std::string, std::string>(),
+      std::string(), olp::http::NetworkRequest::HttpVerb::GET, std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(), nullptr, std::string());
 
@@ -411,7 +412,7 @@ TEST_P(OlpClientTest, Timeout) {
       });
 
   auto response = call_wrapper_->CallApi(
-      std::string(), "GET", std::multimap<std::string, std::string>(),
+      std::string(), olp::http::NetworkRequest::HttpVerb::GET, std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(), nullptr, std::string());
 
@@ -455,7 +456,7 @@ TEST_P(OlpClientTest, Proxy) {
       });
 
   auto response = call_wrapper_->CallApi(
-      std::string(), "GET", std::multimap<std::string, std::string>(),
+      std::string(), olp::http::NetworkRequest::HttpVerb::GET, std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(), nullptr, std::string());
 
@@ -501,7 +502,7 @@ TEST_P(OlpClientTest, EmptyProxy) {
       });
 
   auto response = call_wrapper_->CallApi(
-      std::string(), "GET", std::multimap<std::string, std::string>(),
+      std::string(), olp::http::NetworkRequest::HttpVerb::GET, std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(), nullptr, std::string());
 
@@ -526,7 +527,7 @@ TEST_P(OlpClientTest, HttpResponse) {
       });
 
   auto response = call_wrapper_->CallApi(
-      std::string(), "GET", std::multimap<std::string, std::string>(),
+      std::string(), olp::http::NetworkRequest::HttpVerb::GET, std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(), nullptr, std::string());
   ASSERT_EQ("content", response.response.str());
@@ -552,7 +553,7 @@ TEST_P(OlpClientTest, Paths) {
       });
 
   auto response = call_wrapper_->CallApi(
-      "/index", "GET", std::multimap<std::string, std::string>(),
+      "/index", olp::http::NetworkRequest::HttpVerb::GET, std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(), nullptr, std::string());
 
@@ -577,7 +578,7 @@ TEST_P(OlpClientTest, MethodGET) {
       });
 
   auto response = call_wrapper_->CallApi(
-      std::string(), "GET", std::multimap<std::string, std::string>(),
+      std::string(), olp::http::NetworkRequest::HttpVerb::GET, std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(), nullptr, std::string());
   ASSERT_EQ(olp::http::NetworkRequest::HttpVerb::GET, verb);
@@ -601,7 +602,7 @@ TEST_P(OlpClientTest, MethodPOST) {
       });
 
   auto response = call_wrapper_->CallApi(
-      std::string(), "POST", std::multimap<std::string, std::string>(),
+      std::string(), olp::http::NetworkRequest::HttpVerb::POST, std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(), nullptr, std::string());
   ASSERT_EQ(olp::http::NetworkRequest::HttpVerb::POST, verb);
@@ -631,7 +632,7 @@ TEST_P(OlpClientTest, MethodPUT) {
       };
 
   auto response = call_wrapper_->CallApi(
-      std::string(), "PUT", std::multimap<std::string, std::string>(),
+      std::string(), olp::http::NetworkRequest::HttpVerb::PUT, std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(), nullptr, std::string());
   ASSERT_EQ(olp::http::NetworkRequest::HttpVerb::PUT, verb);
@@ -655,7 +656,8 @@ TEST_P(OlpClientTest, MethodDELETE) {
       });
 
   auto response = call_wrapper_->CallApi(
-      std::string(), "DELETE", std::multimap<std::string, std::string>(),
+      std::string(),
+      olp::http::NetworkRequest::HttpVerb::DEL, std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(), nullptr, std::string());
   ASSERT_EQ(olp::http::NetworkRequest::HttpVerb::DEL, verb);
@@ -683,7 +685,7 @@ TEST_P(OlpClientTest, QueryParam) {
   queryParams.insert(std::make_pair("var2", "2"));
 
   auto response = call_wrapper_->CallApi(
-      "index", "GET", queryParams, std::multimap<std::string, std::string>(),
+      "index", olp::http::NetworkRequest::HttpVerb::GET, queryParams, std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(), nullptr, std::string());
 
   ASSERT_EQ("index?var1=&var2=2", url);
@@ -710,7 +712,7 @@ TEST_P(OlpClientTest, HeaderParams) {
       });
 
   auto response = call_wrapper_->CallApi(
-      std::string(), "GET", std::multimap<std::string, std::string>(),
+      std::string(), olp::http::NetworkRequest::HttpVerb::GET, std::multimap<std::string, std::string>(),
       header_params, std::multimap<std::string, std::string>(), nullptr,
       std::string());
 
@@ -744,7 +746,7 @@ TEST_P(OlpClientTest, DefaultHeaderParams) {
       });
 
   auto response = call_wrapper_->CallApi(
-      std::string(), "GET", std::multimap<std::string, std::string>(),
+      std::string(), olp::http::NetworkRequest::HttpVerb::GET, std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(),
       std::multimap<std::string, std::string>(), nullptr, std::string());
 
@@ -780,7 +782,7 @@ TEST_P(OlpClientTest, CombineHeaderParams) {
       });
 
   auto response = call_wrapper_->CallApi(
-      std::string(), "GET", std::multimap<std::string, std::string>(),
+      std::string(), olp::http::NetworkRequest::HttpVerb::GET, std::multimap<std::string, std::string>(),
       header_params, std::multimap<std::string, std::string>(), nullptr,
       std::string());
 
@@ -828,7 +830,7 @@ TEST_P(OlpClientTest, Content) {
       };
 
   auto response = call_wrapper_->CallApi(
-      std::string(), "GET", std::multimap<std::string, std::string>(),
+      std::string(), olp::http::NetworkRequest::HttpVerb::GET, std::multimap<std::string, std::string>(),
       header_params, std::multimap<std::string, std::string>(), content,
       "plain-text");
   ASSERT_LE(3u, result_headers.size());
@@ -880,7 +882,7 @@ TEST_P(OlpClientTest, CancelBeforeResponse) {
   olp::client::CancellationContext context;
 
   auto response_future = std::async(std::launch::async, [&]() {
-    return call_wrapper_->CallApi(std::string(), "GET",
+    return call_wrapper_->CallApi(std::string(), olp::http::NetworkRequest::HttpVerb::GET,
                                   std::multimap<std::string, std::string>(),
                                   std::multimap<std::string, std::string>(),
                                   std::multimap<std::string, std::string>(),
@@ -905,7 +907,7 @@ TEST_P(OlpClientTest, CancelBeforeExecution) {
   EXPECT_CALL(*network, Send(_, _, _, _, _)).Times(0);
   olp::client::CancellationContext context;
   context.CancelOperation();
-  auto response = client_.CallApi(std::string(), "GET",
+  auto response = client_.CallApi(std::string(), olp::http::NetworkRequest::HttpVerb::GET,
                                   std::multimap<std::string, std::string>(),
                                   std::multimap<std::string, std::string>(),
                                   std::multimap<std::string, std::string>(),
@@ -943,7 +945,7 @@ TEST_P(OlpClientTest, CancelAfterCompletion) {
         promise.set_value(std::move(http_response));
       };
 
-  auto cancel_token = client_.CallApi(std::string(), "GET",
+  auto cancel_token = client_.CallApi(std::string(), olp::http::NetworkRequest::HttpVerb::GET,
                                       std::multimap<std::string, std::string>(),
                                       std::multimap<std::string, std::string>(),
                                       std::multimap<std::string, std::string>(),
@@ -991,7 +993,7 @@ TEST_P(OlpClientTest, CancelDuplicate) {
         promise.set_value(std::move(http_response));
       };
 
-  auto cancel_token = client_.CallApi(std::string(), "GET",
+  auto cancel_token = client_.CallApi(std::string(), olp::http::NetworkRequest::HttpVerb::GET,
                                       std::multimap<std::string, std::string>(),
                                       std::multimap<std::string, std::string>(),
                                       std::multimap<std::string, std::string>(),
@@ -1046,7 +1048,8 @@ TEST_P(OlpClientTest, CancelRetry) {
   olp::client::CancellationContext context;
 
   auto response = std::async(std::launch::async, [&]() {
-    return call_wrapper_->CallApi(std::string(), std::string(),
+    return call_wrapper_->CallApi(std::string(),
+                                  olp::http::NetworkRequest::HttpVerb(),
                                   std::multimap<std::string, std::string>(),
                                   std::multimap<std::string, std::string>(),
                                   std::multimap<std::string, std::string>(),
@@ -1095,9 +1098,9 @@ TEST_P(OlpClientTest, QueryMultiParams) {
 
   std::multimap<std::string, std::string> form_params;
 
-  auto response = call_wrapper_->CallApi(std::string(), std::string(),
-                                         queryParams, header_params,
-                                         form_params, nullptr, std::string());
+  auto response = call_wrapper_->CallApi(
+      std::string(), olp::http::NetworkRequest::HttpVerb(), queryParams,
+      header_params, form_params, nullptr, std::string());
   // query test
   for (auto q : queryParams) {
     std::string param_equal_value = q.first + "=" + q.second;


### PR DESCRIPTION
# Use HttpVerb to specify HTTP methods instead of plain strings.

Make OlpClient API more difficult to use incorrectly.

Relates-To: OLPEDGE-1398

Signed-off-by: Kirill Zhuchkov <kirill.zhuchkov@here.com>