### PR TITLE
Change copy constructor to default in TokenResult

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/TokenResult.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/TokenResult.h
@@ -68,16 +68,6 @@ class AUTHENTICATION_API TokenResult {
   TokenResult() = default;
 
   /**
-   * @brief Creates the `TokenResult` instance that is a copy
-   * of the `other` token result.
-   *
-   * @param other The `TokenResult` instance from which the access
-   * key ID, access key secret, expiry time, HTTP status code, and error
-   * description are copied.
-   */
-  TokenResult(const TokenResult& other);
-
-  /**
    * @brief Gets the access token issued by the authorization server.
    *
    * @return The access token issued by the authorization server.

--- a/olp-cpp-sdk-authentication/src/SignInResultImpl.cpp
+++ b/olp-cpp-sdk-authentication/src/SignInResultImpl.cpp
@@ -70,11 +70,12 @@ SignInResultImpl::SignInResultImpl(
         token_type_ = (*json_document)[kTokenType].GetString();
       if (json_document->HasMember(Constants::REFRESH_TOKEN))
         refresh_token_ = (*json_document)[Constants::REFRESH_TOKEN].GetString();
-      if (json_document->HasMember(Constants::EXPIRES_IN))
+      if (json_document->HasMember(Constants::EXPIRES_IN)) {
         expiry_time_ = std::time(nullptr) +
                        (*json_document)[Constants::EXPIRES_IN].GetUint();
-      expires_in_ = std::chrono::seconds(
-          (*json_document)[Constants::EXPIRES_IN].GetUint());
+        expires_in_ = std::chrono::seconds(
+            (*json_document)[Constants::EXPIRES_IN].GetUint());
+      }
       if (json_document->HasMember(kUserId))
         user_identifier_ = (*json_document)[kUserId].GetString();
       if (json_document->HasMember(kScope))

--- a/olp-cpp-sdk-authentication/src/TokenResult.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenResult.cpp
@@ -44,13 +44,6 @@ TokenResult::TokenResult(std::string access_token,
   expiry_time_ = std::time(nullptr) + expires_in_.count();
 }
 
-TokenResult::TokenResult(const TokenResult& other) {
-  this->access_token_ = other.access_token_;
-  this->expiry_time_ = other.expiry_time_;
-  this->http_status_ = other.http_status_;
-  this->error_ = other.error_;
-}
-
 const std::string& TokenResult::GetAccessToken() const { return access_token_; }
 
 time_t TokenResult::GetExpiryTime() const { return expiry_time_; }


### PR DESCRIPTION
 * Change copy constructor to default in TokenResult because it
   was the same.
 * Fixed functional tests for AutoRefreshingToken.

Resolves: OLPEDGE-1494, OLPEDGE-837

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>