### PR TITLE
Add new backdown strategy to RetrySettings

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -60,6 +60,7 @@ set(OLP_SDK_CLIENT_HEADERS
     ./include/olp/core/client/ApiError.h
     ./include/olp/core/client/ApiNoResult.h
     ./include/olp/core/client/ApiResponse.h
+    ./include/olp/core/client/BackdownStrategy.h
     ./include/olp/core/client/CancellationContext.h
     ./include/olp/core/client/CancellationContext.inl
     ./include/olp/core/client/CancellationToken.h

--- a/olp-cpp-sdk-core/include/olp/core/client/BackdownStrategy.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/BackdownStrategy.h
@@ -46,11 +46,10 @@ struct CORE_API ExponentialBackdownStrategy {
    * @brief Function to compute next retry attempt wait time based on number of
    * retries and initial backdown period.
    *
-   * @param initial_backdown_period_msec Initial backdown period in
-   * milliseconds.
+   * @param initial_backdown_period Initial backdown period.
    * @param retry_count Number of retries already made.
    *
-   * @return Wait time in milliseconds for the next retry attempt.
+   * @return Timeout for the next retry attempt.
    */
   std::chrono::milliseconds operator()(
       std::chrono::milliseconds initial_backdown_period, size_t retry_count) {

--- a/olp-cpp-sdk-core/include/olp/core/client/BackdownStrategy.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/BackdownStrategy.h
@@ -19,8 +19,9 @@
 
 #pragma once
 
-#include <olp/core/CoreApi.h>
+#include <chrono>
 #include <random>
+#include <olp/core/CoreApi.h>
 
 namespace olp {
 namespace client {
@@ -42,7 +43,7 @@ namespace client {
 struct CORE_API ExponentialBackdownStrategy {
  public:
   /**
-   * @brief Function to compute next retry attemp wait time based on number of
+   * @brief Function to compute next retry attempt wait time based on number of
    * retries and initial backdown period.
    *
    * @param initial_backdown_period_msec Initial backdown period in
@@ -51,13 +52,15 @@ struct CORE_API ExponentialBackdownStrategy {
    *
    * @return Wait time in milliseconds for the next retry attempt.
    */
-  int operator()(int initial_backdown_period_msec, size_t retry_count) {
+  std::chrono::milliseconds operator()(
+      std::chrono::milliseconds initial_backdown_period, size_t retry_count) {
     const auto exponential_wait_time =
-        initial_backdown_period_msec * (1 << retry_count);
+        initial_backdown_period.count() * (1 << retry_count);
 
-    static thread_local std::mt19937 generator(std::random_device{}());
-    std::uniform_int_distribution<int> dist(0, exponential_wait_time);
-    return dist(generator);
+    static thread_local std::mt19937 kGenerator(std::random_device{}());
+    std::uniform_int_distribution<std::chrono::milliseconds::rep> dist(
+        0, exponential_wait_time);
+    return std::chrono::milliseconds(dist(kGenerator));
   }
 };
 

--- a/olp-cpp-sdk-core/include/olp/core/client/BackdownStrategy.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/BackdownStrategy.h
@@ -34,8 +34,10 @@ namespace client {
  * randomization.
  *
  * The actual formula can be described as:
- * ``` wait_time = random_between(0, initial_backdown_period_msec * (2 ^
- * cap(retry_count, 3)))```
+ * @code{.unparsed}
+ * wait_time = random_between(0, initial_backdown_period_msec * (2 ^
+ * retry_count))
+ * @endcode
  */
 struct CORE_API ExponentialBackdownStrategy {
  public:
@@ -50,10 +52,8 @@ struct CORE_API ExponentialBackdownStrategy {
    * @return Wait time in milliseconds for the next retry attempt.
    */
   int operator()(int initial_backdown_period_msec, size_t retry_count) {
-    constexpr size_t kMaxRetries = 3;
     const auto exponential_wait_time =
-        initial_backdown_period_msec *
-        (1 << std::min<size_t>(retry_count, kMaxRetries));
+        initial_backdown_period_msec * (1 << retry_count);
 
     static thread_local std::mt19937 generator(std::random_device{}());
     std::uniform_int_distribution<int> dist(0, exponential_wait_time);

--- a/olp-cpp-sdk-core/include/olp/core/client/BackdownStrategy.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/BackdownStrategy.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <olp/core/CoreApi.h>
+#include <random>
+
+namespace olp {
+namespace client {
+
+/**
+ * @brief Functor which computes wait time for the next retry attempt via
+ * exponential backoff with added jitter.
+ *
+ * This backoff strategy is based on the exponential wait time approach, i.e.
+ * when wait time exponentially grows with each retry attempt, but with added
+ * randomization.
+ *
+ * The actual formula can be described as:
+ * ``` wait_time = random_between(0, initial_backdown_period_msec * (2 ^
+ * cap(retry_count, 3)))```
+ */
+struct CORE_API ExponentialBackdownStrategy {
+ public:
+  /**
+   * @brief Function to compute next retry attemp wait time based on number of
+   * retries and initial backdown period.
+   *
+   * @param initial_backdown_period_msec Initial backdown period in
+   * milliseconds.
+   * @param retry_count Number of retries already made.
+   *
+   * @return Wait time in milliseconds for the next retry attempt.
+   */
+  int operator()(int initial_backdown_period_msec, size_t retry_count) {
+    constexpr size_t kMaxRetries = 3;
+    const auto exponential_wait_time =
+        initial_backdown_period_msec *
+        (1 << std::min<size_t>(retry_count, kMaxRetries));
+
+    static thread_local std::mt19937 generator(std::random_device{}());
+    std::uniform_int_distribution<int> dist(0, exponential_wait_time);
+    return dist(generator);
+  }
+};
+
+}  // namespace client
+}  // namespace olp

--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
@@ -25,6 +25,7 @@
 
 #include <boost/optional.hpp>
 
+#include <olp/core/client/BackdownStrategy.h>
 #include "olp/core/client/CancellationToken.h"
 #include "olp/core/client/HttpResponse.h"
 #include "olp/core/http/Network.h"
@@ -152,6 +153,16 @@ struct RetrySettings {
   using BackdownPolicy = std::function<int(int)>;
 
   /**
+   * @brief A strategy which takes the initial backdown period in milliseconds
+   * with current retry count, and returns what should be used for the next wait
+   * timeout.
+   *
+   * Is superior to the \ref BackdownPolicy, as it computes wait time based on
+   * the retry count as well.
+   */
+  using BackdownStrategy = std::function<int(int, size_t)>;
+
+  /**
    * @brief Checks whether the retry is desired.
    *
    * @see `HttpResponse` for more details.
@@ -178,10 +189,24 @@ struct RetrySettings {
 
   /**
    * @brief The backdown policy that should be used for the retry attempts.
+   * 
+   * @deprecated Use \ref backdown_strategy instead.
    *
    * @return The backdown policy.
    */
   BackdownPolicy backdown_policy = DefaultBackdownPolicy;
+
+  /**
+   * @brief The strategy used for retry attempts.
+   *
+   * The backdown strategy used to compute new wait time to retry failed
+   * requests. By default it is not specified and, if specified, it will used
+   * instead \ref backdown_policy.
+   *
+   * @note You can use the \ref ExponentialBackdownStrategy from OLP SDK as new
+   * backdown strategy.
+   */
+  BackdownStrategy backdown_strategy = nullptr;
 
   /**
    * @brief Evaluates responses to determine if the retry should be attempted.

--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <string>
@@ -153,14 +154,11 @@ struct RetrySettings {
   using BackdownPolicy = std::function<int(int)>;
 
   /**
-   * @brief A strategy which takes the initial backdown period in milliseconds
-   * with current retry count, and returns what should be used for the next wait
-   * timeout.
-   *
-   * Is superior to the \ref BackdownPolicy, as it computes wait time based on
-   * the retry count as well.
+   * @brief A strategy for calculating retry timeouts based on
+   * the initial backdown duration in milliseconds and retry count.
    */
-  using BackdownStrategy = std::function<int(int, size_t)>;
+  using BackdownStrategy = std::function<std::chrono::milliseconds(
+      std::chrono::milliseconds, size_t)>;
 
   /**
    * @brief Checks whether the retry is desired.
@@ -189,21 +187,22 @@ struct RetrySettings {
 
   /**
    * @brief The backdown policy that should be used for the retry attempts.
-   * 
-   * @deprecated Use \ref backdown_strategy instead.
+   *
+   * @deprecated Use \ref backdown_strategy instead. Will be removed by 06.2020.
    *
    * @return The backdown policy.
    */
   BackdownPolicy backdown_policy = DefaultBackdownPolicy;
 
   /**
-   * @brief The strategy used for retry attempts.
+   * @brief Backdown strategy.
    *
-   * The backdown strategy used to compute new wait time to retry failed
-   * requests. By default it is not specified and, if specified, it will used
-   * instead \ref backdown_policy.
+   * Used for calculating retry timeouts for failed requests. It is superior to
+   * the \ref backdown_policy, as it computes wait time based on
+   * the retry count as well. By default, it is unset, and \ref backdown_policy
+   * is used.
    *
-   * @note You can use the \ref ExponentialBackdownStrategy from OLP SDK as new
+   * @note You can use the \ref ExponentialBackdownStrategy as the new
    * backdown strategy.
    */
   BackdownStrategy backdown_strategy = nullptr;

--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
@@ -155,7 +155,7 @@ struct RetrySettings {
 
   /**
    * @brief A strategy for calculating retry timeouts based on
-   * the initial backdown duration in milliseconds and retry count.
+   * the initial backdown duration and retry count.
    */
   using BackdownStrategy = std::function<std::chrono::milliseconds(
       std::chrono::milliseconds, size_t)>;

--- a/olp-cpp-sdk-core/src/client/OlpClientSettings.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClientSettings.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "olp/core/client/OlpClientSettings.h"
+#include <random>
 #include "olp/core/client/HttpResponse.h"
 #include "olp/core/http/HttpStatusCode.h"
 

--- a/olp-cpp-sdk-core/src/client/OlpClientSettings.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClientSettings.cpp
@@ -17,8 +17,8 @@
  * License-Filename: LICENSE
  */
 
-#include "olp/core/client/OlpClientSettings.h"
 #include <random>
+#include "olp/core/client/OlpClientSettings.h"
 #include "olp/core/client/HttpResponse.h"
 #include "olp/core/http/HttpStatusCode.h"
 

--- a/olp-cpp-sdk-core/tests/client/OlpClientTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/OlpClientTest.cpp
@@ -369,7 +369,7 @@ TEST_P(OlpClientTest, RetryTimeExponential) {
 }
 
 TEST_P(OlpClientTest, RetryWithExponentialBackdownStrategy) {
-  const std::chrono::milliseconds::rep kInitialBackdownPeriod = 100;  // msec
+  const std::chrono::milliseconds::rep kInitialBackdownPeriod = 100;
   size_t expected_retry_count = 0;
   std::vector<std::chrono::milliseconds::rep> wait_times = {
       kInitialBackdownPeriod};
@@ -397,9 +397,7 @@ TEST_P(OlpClientTest, RetryWithExponentialBackdownStrategy) {
   // previous version of backdown policy shouldn't be called,
   // if the new backdown policy was specified
   client_settings_.retry_settings.backdown_policy = [](int period) -> int {
-    // we can't invoke FAIL directly from the callback:
-    auto fail_helper = []() { FAIL(); };
-    fail_helper();
+    ADD_FAILURE();
     return period;
   };
 
@@ -435,14 +433,11 @@ TEST_P(OlpClientTest, RetryWithExponentialBackdownStrategy) {
 }
 
 TEST_P(OlpClientTest, RetryTimeout) {
-  const auto kInitialBackdownPeriod = 400;  // msec
   const size_t kMaxRetries = 3;
-  const size_t kTimeout = 1;  // seconds
   // Setup retry settings:
-  client_settings_.retry_settings.initial_backdown_period =
-      kInitialBackdownPeriod;
+  client_settings_.retry_settings.initial_backdown_period = 400;  // msec
   client_settings_.retry_settings.max_attempts = kMaxRetries;
-  client_settings_.retry_settings.timeout = kTimeout;
+  client_settings_.retry_settings.timeout = 1;  // seconds
 
   client_settings_.retry_settings.retry_condition =
       ([](const olp::client::HttpResponse&) { return true; });
@@ -465,8 +460,7 @@ TEST_P(OlpClientTest, RetryTimeout) {
             // the test shouldn't reach the last retry due to timeout
             // restrictions in retry settings
             if (current_attempt == kSuccessfulAttempt) {
-              auto fail_helper = []() { FAIL(); };
-              fail_helper();
+              ADD_FAILURE();
 
               callback(olp::http::NetworkResponse().WithStatus(
                   olp::http::HttpStatusCode::OK));


### PR DESCRIPTION
- Add new backdown strategy for RetrySettings (backdown_strategy filed in RetrySettings);
- Implement default implementation of `backdown_strategy`  - ExponentialBackdownStrategy;
- fix minor bug with retry attempt without any backdown policy.

Relates-to: OLPEDGE-1419

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>