### PR TITLE
Add poll method to stream layer client.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/StreamLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/StreamLayerClient.h
@@ -201,10 +201,10 @@ class DATASERVICE_READ_API StreamLayerClient final {
 
   /**
    * @brief Reads messages from a stream layer and commits successfully
-   * consumed messages before handing them over to you.
+   * consumed messages before returning them to you.
    *
    * Only possible if subscribed successfully.
-   * If the payload is more the 1 MB, then it is not embedded into the metadata.
+   * If the payload is more than 1 MB, then it is not embedded into the metadata.
    * To download the data, call `GetData(Message)`.
    *
    * @param callback The `PollResponseCallback` object that is invoked when
@@ -216,10 +216,10 @@ class DATASERVICE_READ_API StreamLayerClient final {
 
   /**
    * @brief Reads messages from a stream layer and commits successfully
-   * consumed messages before handing them over to you.
+   * consumed messages before returning them to you.
    *
    * Only possible if subscribed successfully.
-   * If the payload is more the 1 MB, then it is not embedded into the metadata.
+   * If the payload is more than 1 MB, then it is not embedded into the metadata.
    * To download the data, call `GetData(Message)`.
    *
    * @return `CancellableFuture` that contains `PollResponse` or an error. You

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/StreamLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/StreamLayerClient.h
@@ -199,6 +199,34 @@ class DATASERVICE_READ_API StreamLayerClient final {
   client::CancellableFuture<DataResponse> GetData(
       const model::Message& message);
 
+  /**
+   * @brief Reads messages from a stream layer and commits successfully
+   * consumed messages before handing them over to you.
+   *
+   * Only possible if subscribed successfully.
+   * If the payload is more the 1 MB, then it is not embedded into the metadata.
+   * To download the data, call `GetData(Message)`.
+   *
+   * @param callback The `PollResponseCallback` object that is invoked when
+   * the `Poll` request is completed.
+   *
+   * @return A token that can be used to cancel this request.
+   */
+  client::CancellationToken Poll(PollResponseCallback callback);
+
+  /**
+   * @brief Reads messages from a stream layer and commits successfully
+   * consumed messages before handing them over to you.
+   *
+   * Only possible if subscribed successfully.
+   * If the payload is more the 1 MB, then it is not embedded into the metadata.
+   * To download the data, call `GetData(Message)`.
+   *
+   * @return `CancellableFuture` that contains `PollResponse` or an error. You
+   * can also use `CancellableFuture` to cancel this request.
+   */
+  client::CancellableFuture<PollResponse> Poll();
+
  private:
   std::unique_ptr<StreamLayerClientImpl> impl_;
 };

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
@@ -26,6 +26,7 @@
 
 #include <olp/dataservice/read/model/Catalog.h>
 #include <olp/dataservice/read/model/Data.h>
+#include <olp/dataservice/read/model/Messages.h>
 #include <olp/dataservice/read/model/Partitions.h>
 #include <olp/dataservice/read/model/VersionResponse.h>
 
@@ -90,6 +91,12 @@ using UnsubscribeResponse = Response<SubscriptionId>;
 /// The unsubscribe completion callback type of the stream layer client.
 using UnsubscribeResponseCallback = Callback<SubscriptionId>;
 
+/// The alias type of the messages result.
+using MessagesResult = model::Messages;
+/// The poll response type of the stream layer client.
+using PollResponse = Response<MessagesResult>;
+/// The poll completion callback type of the stream layer client.
+using PollResponseCallback = Callback<MessagesResult>;
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/StreamLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/StreamLayerClient.cpp
@@ -73,6 +73,15 @@ client::CancellableFuture<DataResponse> StreamLayerClient::GetData(
   return impl_->GetData(message);
 }
 
+client::CancellationToken StreamLayerClient::Poll(
+    PollResponseCallback callback) {
+  return impl_->Poll(callback);
+}
+
+client::CancellableFuture<PollResponse> StreamLayerClient::Poll() {
+  return impl_->Poll();
+}
+
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/StreamLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/StreamLayerClientImpl.h
@@ -30,6 +30,10 @@
 #include <olp/dataservice/read/model/Messages.h>
 
 namespace olp {
+namespace client {
+class OlpClient;
+}
+
 namespace dataservice {
 namespace read {
 
@@ -59,22 +63,25 @@ class StreamLayerClientImpl {
   virtual client::CancellableFuture<DataResponse> GetData(
       const model::Message& message);
 
+  virtual client::CancellationToken Poll(PollResponseCallback callback);
+  virtual client::CancellableFuture<PollResponse> Poll();
+
  private:
   /// A struct that aggregates the stream layer client parameters.
   struct StreamLayerClientContext {
     StreamLayerClientContext(std::string subscription_id,
                              std::string subscription_mode,
-                             std::string node_base_url,
-                             std::string x_correlation_id)
+                             std::string x_correlation_id,
+                             std::shared_ptr<client::OlpClient> client)
         : subscription_id(subscription_id),
           subscription_mode(subscription_mode),
-          node_base_url(node_base_url),
-          x_correlation_id(x_correlation_id) {}
+          x_correlation_id(x_correlation_id),
+          client(client) {}
 
     std::string subscription_id;
     std::string subscription_mode;
-    std::string node_base_url;
     std::string x_correlation_id;
+    std::shared_ptr<client::OlpClient> client;
   };
 
   client::HRN catalog_;


### PR DESCRIPTION
Reads messages from a stream layer and commits successfully consumed messages before handing them over to user.
Create OlpClient on subscription, an use later in StreamApi calls.

Resolves: OLPEDGE-1353

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>