### PR TITLE
Revert "Added parsing of Client Id from Access Token"

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/SignInResult.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/SignInResult.h
@@ -78,14 +78,6 @@ class AUTHENTICATION_API SignInResult {
   const std::string& GetAccessToken() const;
 
   /**
-   * @brief Gets client ID
-   * @return The string that contains the client ID that is associated with the
-   * access token. In case of parsing errors this method will return empty
-   * string. Proper message will be printed to log.
-   */
-  const std::string& GetClientId() const;
-
-  /**
    * @brief Gets the access token type.
    *
    * @return The string containing the access token type (always a bearer

--- a/olp-cpp-sdk-authentication/src/SignInResult.cpp
+++ b/olp-cpp-sdk-authentication/src/SignInResult.cpp
@@ -44,10 +44,6 @@ const std::string& SignInResult::GetAccessToken() const {
   return impl_->GetAccessToken();
 }
 
-const std::string& SignInResult::GetClientId() const {
-  return impl_->GetClientId();
-}
-
 const std::string& SignInResult::GetTokenType() const {
   return impl_->GetTokenType();
 }

--- a/olp-cpp-sdk-authentication/src/SignInResultImpl.cpp
+++ b/olp-cpp-sdk-authentication/src/SignInResultImpl.cpp
@@ -19,29 +19,17 @@
 
 #include "SignInResultImpl.h"
 
-#include <vector>
-
 #include "Constants.h"
 #include "olp/core/http/HttpStatusCode.h"
-#include "olp/core/logging/Log.h"
-#include "olp/core/utils/Base64.h"
 
 namespace {
 constexpr auto kTokenType = "tokenType";
 constexpr auto kUserId = "userId";
 constexpr auto kScope = "scope";
-constexpr auto kLogTag = "SignIn";
-
 }  // namespace
 
 namespace olp {
 namespace authentication {
-
-namespace {
-bool IsJwtToken(const std::string& token) { return token.front() == 'e'; }
-
-bool IsHnToken(const std::string& token) { return token.front() == 'h'; }
-}  // namespace
 
 SignInResultImpl::SignInResultImpl() noexcept
     : SignInResultImpl(http::HttpStatusCode::SERVICE_UNAVAILABLE,
@@ -62,10 +50,8 @@ SignInResultImpl::SignInResultImpl(
       status_ = http::HttpStatusCode::SERVICE_UNAVAILABLE;
       error_.message = Constants::ERROR_HTTP_SERVICE_UNAVAILABLE;
     } else {
-      if (json_document->HasMember(Constants::ACCESS_TOKEN)) {
+      if (json_document->HasMember(Constants::ACCESS_TOKEN))
         access_token_ = (*json_document)[Constants::ACCESS_TOKEN].GetString();
-        client_id_ = ParseClientIdFromToken(access_token_.c_str());
-      }
       if (json_document->HasMember(kTokenType))
         token_type_ = (*json_document)[kTokenType].GetString();
       if (json_document->HasMember(Constants::REFRESH_TOKEN))
@@ -89,8 +75,6 @@ const std::string& SignInResultImpl::GetAccessToken() const {
   return access_token_;
 }
 
-const std::string& SignInResultImpl::GetClientId() const { return client_id_; }
-
 const std::string& SignInResultImpl::GetTokenType() const {
   return token_type_;
 }
@@ -112,70 +96,6 @@ const std::string& SignInResultImpl::GetUserIdentifier() const {
 const std::string& SignInResultImpl::GetScope() const { return scope_; }
 
 bool SignInResultImpl::IsValid() const { return is_valid_; }
-
-std::string SignInResultImpl::ParseJwtToken(const std::string& token) {
-  const std::string::size_type first_dot = token.find_first_of('.');
-  if (first_dot == std::string::npos) {
-    OLP_SDK_LOG_ERROR(kLogTag, "Cannot parse ClientId. Wrong token format.");
-    return std::string();
-  }
-
-  const std::string jws_header_encoded = token.substr(0, first_dot);
-
-  std::vector<std::uint8_t> decoded_bytes;
-  if (!utils::Base64Decode(jws_header_encoded, decoded_bytes)) {
-    OLP_SDK_LOG_ERROR(kLogTag,
-                      "Cannot parse ClientId. Non-decodable token format");
-    return std::string();
-  }
-
-  std::string jws_header_decoded;
-  std::copy(decoded_bytes.begin(), decoded_bytes.end(),
-            std::back_inserter(jws_header_decoded));
-
-  rapidjson::Document doc;
-  doc.Parse(jws_header_decoded.c_str());
-
-  if (doc.HasParseError() || !doc.IsObject()) {
-    OLP_SDK_LOG_ERROR(kLogTag, "Cannot parse ClientId. Defective token format");
-    return std::string();
-  }
-
-  auto client_id_field = doc.FindMember("aid");
-  if (client_id_field == doc.MemberEnd() ||
-      !client_id_field->value.IsString()) {
-    OLP_SDK_LOG_ERROR(kLogTag,
-                      "Cannot parse ClientId. Field does not exist or is not "
-                      "a string json value");
-    return std::string();
-  }
-
-  const std::string result = client_id_field->value.GetString();
-
-  if (result.empty()) {
-    OLP_SDK_LOG_ERROR(kLogTag,
-                      "Cannot parse ClientId. Incomplete token format");
-  }
-
-  return result;
-}
-
-std::string SignInResultImpl::ParseClientIdFromToken(const std::string& token) {
-  if (token.empty()) {
-    OLP_SDK_LOG_ERROR(kLogTag, "Token is empty");
-    return std::string();
-  }
-
-  if (IsJwtToken(token)) {
-    return ParseJwtToken(token);
-  } else if (IsHnToken(token)) {
-    OLP_SDK_LOG_ERROR(kLogTag, "hN Tokens are not supported!");
-    return std::string();
-  } else {
-    OLP_SDK_LOG_ERROR(kLogTag, "Unknown token format");
-    return std::string();
-  }
-}
 
 }  // namespace authentication
 }  // namespace olp

--- a/olp-cpp-sdk-authentication/src/SignInResultImpl.h
+++ b/olp-cpp-sdk-authentication/src/SignInResultImpl.h
@@ -52,13 +52,6 @@ class SignInResultImpl : public BaseResult {
   const std::string& GetTokenType() const;
 
   /**
-   * @brief The client ID getter method
-   * @return string containing the client id that is associated with the access
-   * token
-   */
-  const std::string& GetClientId() const;
-
-  /**
    * @brief Refresh token getter method
    * @return string containing a token which is used to obtain a new access
    * token using the refresh API. Refresh token is always issued unless
@@ -93,15 +86,11 @@ class SignInResultImpl : public BaseResult {
   const std::string& GetScope() const;
 
  private:
-  static std::string ParseJwtToken(const std::string&);
-  static std::string ParseClientIdFromToken(const std::string& token);
-
   bool is_valid_;
 
  protected:
   std::string access_token_;
   std::string token_type_;
-  std::string client_id_;
   time_t expiry_time_;
   std::chrono::seconds expires_in_;
   

--- a/olp-cpp-sdk-authentication/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-authentication/tests/CMakeLists.txt
@@ -17,7 +17,6 @@
 
 set(OLP_AUTHENTICATION_TEST_SOURCES
     AuthenticationCredentialsTest.cpp
-    SignInResultImplTest.cpp
 )
 
 if (ANDROID OR IOS)

--- a/scripts/linux/fv/olp-common.variables
+++ b/scripts/linux/fv/olp-common.variables
@@ -10,7 +10,6 @@ export index_layer="olp-cpp-sdk-ingestion-test-index-layer"
 ###
 export service_id="${appid}"
 export service_secret="${secret}"
-export service_client_id="${client_id}"
 export production_service_id="${production_service_id}"
 export production_service_secret="${production_service_secret}"
 export facebook_access_token="${facebook_access_token}"


### PR DESCRIPTION
This reverts commit 7dc665f.

* Due to new proper method of getting client id this change is
  removed. New public api call to get client id will be
  introduced

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>