### PR TITLE
Retry unsuccessful HTTP requests on 500 and 503 errors by default.

### DIFF
--- a/olp-cpp-sdk-core/src/client/OlpClientSettings.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClientSettings.cpp
@@ -19,6 +19,7 @@
 
 #include "olp/core/client/OlpClientSettings.h"
 #include "olp/core/client/HttpResponse.h"
+#include "olp/core/http/HttpStatusCode.h"
 
 namespace olp {
 namespace client {
@@ -26,7 +27,15 @@ unsigned int DefaultBackdownPolicy(unsigned int milliseconds) {
   return milliseconds;
 }
 
-bool DefaultRetryCondition(const HttpResponse&) { return false; }
+bool DefaultRetryCondition(const HttpResponse& response) {
+  switch (response.status) {
+    case http::HttpStatusCode::INTERNAL_SERVER_ERROR:
+    case http::HttpStatusCode::SERVICE_UNAVAILABLE:
+      return true;
+    default:
+      return false;
+  }
+}
 
 }  // namespace client
 }  // namespace olp


### PR DESCRIPTION
### Retry unsuccessful HTTP requests on 500 and 503 errors by default.

The error code 500 Internal Error indicates that a server is unable
to handle the request at that time. The error code 503 Slow Down
typically means that the request rate to the server bucket is
too high. Hence, it makes sense to resolve such errors by retrying
the request.

Related-To: OLPEDGE-1398

Signed-off-by: Kirill Zhuchkov <kirill.zhuchkov@here.com>