### PR TITLE
Change DefaultCache constructor to take settings by value.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
@@ -64,7 +64,7 @@ class CORE_API DefaultCache : public KeyValueCache {
    *
    * @param settings The cache settings.
    */
-  DefaultCache(const CacheSettings& settings = CacheSettings());
+  explicit DefaultCache(CacheSettings settings = {});
   ~DefaultCache() override;
 
   /**

--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettingsFactory.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettingsFactory.h
@@ -89,7 +89,7 @@ class CORE_API OlpClientSettingsFactory final {
    * @return The `KeyValueCache` instance.
    */
   static std::unique_ptr<cache::KeyValueCache> CreateDefaultCache(
-      const cache::CacheSettings& settings);
+      cache::CacheSettings settings);
 };
 
 }  // namespace client

--- a/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
@@ -65,8 +65,8 @@ bool StoreExpiry(const std::string& key, olp::cache::DiskCache& disk_cache,
 namespace olp {
 namespace cache {
 
-DefaultCache::DefaultCache(const CacheSettings& settings)
-    : settings_(settings),
+DefaultCache::DefaultCache(CacheSettings settings)
+    : settings_(std::move(settings)),
       is_open_(false),
       memory_cache_(nullptr),
       mutable_cache_(nullptr),

--- a/olp-cpp-sdk-core/src/client/OlpClientSettingsFactory.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClientSettingsFactory.cpp
@@ -40,9 +40,8 @@ OlpClientSettingsFactory::CreateDefaultNetworkRequestHandler(
 }
 
 std::unique_ptr<cache::KeyValueCache>
-OlpClientSettingsFactory::CreateDefaultCache(
-    const cache::CacheSettings& settings) {
-  auto cache = std::make_unique<cache::DefaultCache>(settings);
+OlpClientSettingsFactory::CreateDefaultCache(cache::CacheSettings settings) {
+  auto cache = std::make_unique<cache::DefaultCache>(std::move(settings));
   cache->Open();
   return std::move(cache);
 }

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClient.h
@@ -24,6 +24,7 @@
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>
 #include <olp/core/client/OlpClientSettings.h>
+#include <olp/core/porting/deprecated.h>
 #include <olp/dataservice/write/DataServiceWriteApi.h>
 #include <olp/dataservice/write/StreamLayerClientSettings.h>
 #include <olp/dataservice/write/generated/model/ResponseOk.h>
@@ -46,9 +47,14 @@ class StreamLayerClientImpl;
  * @brief Creates an instance of the default cache with the provided settings.
  * @param settings Cache settings.
  * @return DefaultCache instance.
+ * @deprecated Use olp::client::OlpClientSettingsFactory::CreateDefaultCache()
+ * instead. Will be remove by 06.2020.
  */
+OLP_SDK_DEPRECATED(
+    "Please use OlpClientSettingsFactory::CreateDefaultCache() instead. "
+    "Will be removed by 06.2020")
 std::shared_ptr<cache::KeyValueCache> CreateDefaultCache(
-    const cache::CacheSettings& settings = cache::CacheSettings());
+    cache::CacheSettings settings = {});
 
 using PublishDataResult = olp::dataservice::write::model::ResponseOkSingle;
 using PublishDataResponse =
@@ -68,7 +74,8 @@ class DATASERVICE_WRITE_API StreamLayerClient {
 
   /**
    * @brief StreamLayerClient Constructor.
-   * @param catalog OLP HRN that specifies the catalog to which this client writes.
+   * @param catalog OLP HRN that specifies the catalog to which this client
+   * writes.
    * @param client_settings \c StreamLayerClient settings used to control
    * the behaviour of flush mechanism and other StreamLayerClient specific
    * properties.
@@ -149,8 +156,8 @@ class DATASERVICE_WRITE_API StreamLayerClient {
 
   /**
    * @brief Sends a list of SDII messages to an OLP stream layer.
-   * The SDII message data must be in the SDII MessageList protobuf format. For more
-   * information, please see the OLP Sensor Data Ingestion Interface
+   * The SDII message data must be in the SDII MessageList protobuf format. For
+   * more information, please see the OLP Sensor Data Ingestion Interface
    * documentation and schemas.
    * @param request PublishSdiiRequest object that represents the parameters for
    * this PublishSdii call.
@@ -161,8 +168,8 @@ class DATASERVICE_WRITE_API StreamLayerClient {
 
   /**
    * @brief Sends a list of SDII messages to an OLP stream layer.
-   * The SDII message data must be in the SDII MessageList protobuf format. For more
-   * information, please see the OLP Sensor Data Ingestion Interface
+   * The SDII message data must be in the SDII MessageList protobuf format. For
+   * more information, please see the OLP Sensor Data Ingestion Interface
    * documentation and schemas.
    * @param request PublishSdiiRequest object that represents the parameters for
    * this PublishSdii call.

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClient.cpp
@@ -28,10 +28,9 @@ namespace dataservice {
 namespace write {
 
 std::shared_ptr<cache::KeyValueCache> CreateDefaultCache(
-    const cache::CacheSettings& settings) {
-  auto cache = std::make_shared<cache::DefaultCache>(settings);
-  cache->Open();
-  return std::move(cache);
+    cache::CacheSettings settings) {
+  return client::OlpClientSettingsFactory::CreateDefaultCache(
+      std::move(settings));
 }
 
 StreamLayerClient::StreamLayerClient(client::HRN catalog,


### PR DESCRIPTION
Additionally makes constructor explicit. It is not a good practice
to take hide move oportunities from API users. Making the DefaultCache
constructor and the OlpClientSettingsFactory::CreateDefaultCache() method
take-in the CacheSettings by copy will allow user to pass-move and save
possible copies on the strings.
This also deprecates the olp::dataservice::write::StreamLayerClient
CreateDefaultCache() function as it is a duplicate to the
OlpClientSettingsFactory::CreateDefaultCache() method. Will be removed
by 06.2020. Until then this free function will use OlpClientSettingsFactory
internally to create the default cache instance.

Resolves: OLPEDGE-1509

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>
Signed-off-by: Andrei Popescu <andrei.popescu@here.com>