### PR TITLE
Add new ctor for VersionedLayerClient which accepts catalog version

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <boost/optional.hpp>
 #include <memory>
 #include <vector>
 
@@ -96,8 +97,29 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    * @param layer_id The layer ID of the versioned layer from which you want to
    * get data.
    * @param settings The `OlpClientSettings` instance.
+   *
+   * @deprecated This ctor will be removed by 06.2020.
+   */
+  OLP_SDK_DEPRECATED(
+      "Use ctor with explicitly specified version. This ctor will be removed "
+      "by 06.2020")
+  VersionedLayerClient(client::HRN catalog, std::string layer_id,
+                       client::OlpClientSettings settings);
+  /**
+   * @brief Creates the `VersionedLayerClient` instance with specific catalog
+   * version.
+   *
+   * @param catalog The HERE Resource Name (HRN) of the catalog that contains
+   * the versioned layer from which you want to get data.
+   * @param layer_id The layer ID of the versioned layer from which you want to
+   * get data.
+   * @param catalog_version The version of the catalog from which you want
+   * retrieve data. If no version is specified, last available version will be
+   * used instead.
+   * @param settings The `OlpClientSettings` instance.
    */
   VersionedLayerClient(client::HRN catalog, std::string layer_id,
+                       boost::optional<int64_t> catalog_version,
                        client::OlpClientSettings settings);
 
   /// Movable, non-copyable

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -98,25 +98,29 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    * get data.
    * @param settings The `OlpClientSettings` instance.
    *
-   * @deprecated This ctor will be removed by 06.2020.
+   * @deprecated Will be removed by 06.2020.
    */
   OLP_SDK_DEPRECATED(
-      "Use ctor with explicitly specified version. This ctor will be removed "
+      "Use the ctor with the explicitly specified version. This ctor is "
+      "deprecated and will be removed "
       "by 06.2020")
   VersionedLayerClient(client::HRN catalog, std::string layer_id,
                        client::OlpClientSettings settings);
   /**
-   * @brief Creates the `VersionedLayerClient` instance with specific catalog
-   * version.
+   * @brief Creates the `VersionedLayerClient` instance with the specified
+   * catalog version.
    *
    * @param catalog The HERE Resource Name (HRN) of the catalog that contains
    * the versioned layer from which you want to get data.
    * @param layer_id The layer ID of the versioned layer from which you want to
    * get data.
    * @param catalog_version The version of the catalog from which you want
-   * retrieve data. If no version is specified, last available version will be
+   * to get data. If no version is specified, the last available version is
    * used instead.
    * @param settings The `OlpClientSettings` instance.
+   *
+   * @return The `VersionedLayerClient` instance with the specified catalog
+   * version.
    */
   VersionedLayerClient(client::HRN catalog, std::string layer_id,
                        boost::optional<int64_t> catalog_version,

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -19,9 +19,10 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
 #include <memory>
 #include <vector>
+
+#include <boost/optional.hpp>
 
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>
@@ -109,6 +110,15 @@ class DATASERVICE_READ_API VersionedLayerClient final {
   /**
    * @brief Creates the `VersionedLayerClient` instance with the specified
    * catalog version.
+   *
+   * The instance of this client is locked to the specified catalog version
+   * passed to the constructor and can't be changed. This way we assure data
+   * consistency. Keep in mind that catalog version provided with requests like
+   * \ref DataRequest, \ref PartitionsRequest, and \ref PrefetchTilesRequest
+   * will be ignored.
+   *
+   * @note if you didn't specify the catalog version, the last available version
+   * is used instead.
    *
    * @param catalog The HERE Resource Name (HRN) of the catalog that contains
    * the versioned layer from which you want to get data.

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
@@ -30,7 +30,16 @@ VersionedLayerClient::VersionedLayerClient(client::HRN catalog,
                                            std::string layer_id,
                                            client::OlpClientSettings settings)
     : impl_(std::make_unique<VersionedLayerClientImpl>(
-          std::move(catalog), std::move(layer_id), std::move(settings))) {}
+          std::move(catalog), std::move(layer_id), boost::none,
+          std::move(settings))) {}
+
+VersionedLayerClient::VersionedLayerClient(
+    client::HRN catalog, std::string layer_id,
+    boost::optional<int64_t> catalog_version,
+    client::OlpClientSettings settings)
+    : impl_(std::make_unique<VersionedLayerClientImpl>(
+          std::move(catalog), std::move(layer_id), std::move(catalog_version),
+          std::move(settings))) {}
 
 VersionedLayerClient::VersionedLayerClient(
     VersionedLayerClient&& other) noexcept = default;

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -43,9 +43,11 @@ constexpr auto kLogTag = "VersionedLayerClientImpl";
 
 VersionedLayerClientImpl::VersionedLayerClientImpl(
     client::HRN catalog, std::string layer_id,
+    boost::optional<int64_t> catalog_version,
     client::OlpClientSettings settings)
     : catalog_(std::move(catalog)),
       layer_id_(std::move(layer_id)),
+      catalog_version_(std::move(catalog_version)),
       settings_(std::move(settings)),
       pending_requests_(std::make_shared<client::PendingRequests>()) {
   if (!settings_.cache) {

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <boost/optional.hpp>
 #include <memory>
 
 #include <olp/core/client/CancellationContext.h>
@@ -47,6 +48,7 @@ class PrefetchTilesRepository;
 class VersionedLayerClientImpl {
  public:
   VersionedLayerClientImpl(client::HRN catalog, std::string layer_id,
+                           boost::optional<int64_t> catalog_version,
                            client::OlpClientSettings settings);
 
   virtual ~VersionedLayerClientImpl();
@@ -75,6 +77,7 @@ class VersionedLayerClientImpl {
  private:
   client::HRN catalog_;
   std::string layer_id_;
+  boost::optional<int64_t> catalog_version_;
   client::OlpClientSettings settings_;
   std::shared_ptr<client::PendingRequests> pending_requests_;
 };

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -19,8 +19,9 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
 #include <memory>
+
+#include <boost/optional.hpp>
 
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/CancellationToken.h>


### PR DESCRIPTION
Add new constructor for dataserivce-read::VersionedLayerClient, which in addition to previous ctor's parameters, also accepts catalog version. Mark previous ctor as deprecated.

Relates-to: OLPEDGE-1513

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>