### PR TITLE
Add curl_global_init/cleanup to NetworkCurl

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettingsFactory.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettingsFactory.h
@@ -58,6 +58,17 @@ class CORE_API OlpClientSettingsFactory final {
    *
    * Defaulted to platform-specific implementation.
    *
+   * On UNIX platforms, the default network request handler is libcurl-based and
+   * has the known issue of static initialization and cleanup that needs special
+   * care. Therefore, we recommend initializing this network request handler at
+   * a very early stage, preferably as global static or from the main thread,
+   * and pass it on to every created client. For this matter, it is also not
+   * recommended to create multiple network request handlers.
+   *
+   * @see [cURL documentation]
+   * (Lhttps://curl.haxx.se/libcurl/c/curl_global_init.html) for more
+   * information.
+   *
    * @return The `Network` instance.
    */
   static std::shared_ptr<http::Network> CreateDefaultNetworkRequestHandler(

--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.h
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.h
@@ -333,6 +333,9 @@ class NetworkCurl : public olp::http::Network,
   /// network transfer.
   std::unique_ptr<std::mutex[]> ssl_mutexes_{};
 #endif
+
+  /// Stores value if `curl_global_init()` was successful on construction.
+  bool curl_initialized_;
 };
 
 }  // namespace http


### PR DESCRIPTION
* Added curl_global_init() and curl_global_cleanup()
  function calls to linux network implementation which
  uses curl to do proper initialization/deinitialization
  in network.

Resolves: OLPEDGE-1536

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>