### PR TITLE
Performance improvements.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/HttpResponse.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/HttpResponse.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <sstream>
+#include <vector>
 
 #include <olp/core/CoreApi.h>
 #include <olp/core/http/NetworkTypes.h>
@@ -51,6 +52,20 @@ class CORE_API HttpResponse {
       : status(status), response(std::move(response)) {}
 
   /**
+   * @brief Copy `HttpResponse` content to a vector of unsigned chars.
+   *
+   * @param output Reference to a vector.
+   */
+  void GetResponse(std::vector<unsigned char>& output);
+
+  /**
+   * @brief Copy `HttpResponse` content to a string.
+   *
+   * @param output Reference to a string.
+   */
+  void GetResponse(std::string& output);
+
+  /**
    * @brief The HTTP status.
    *
    * @see `ErrorCode` for information on negative status
@@ -64,6 +79,17 @@ class CORE_API HttpResponse {
    */
   std::stringstream response;
 };
+
+inline void HttpResponse::GetResponse(std::vector<unsigned char>& output) {
+  response.seekg(0, std::ios::end);
+  output.resize(response.tellg());
+  response.seekg(0, std::ios::beg);
+  response.read(reinterpret_cast<char*>(output.data()), output.size());
+}
+
+inline void HttpResponse::GetResponse(std::string& output) {
+  output = response.str();
+}
 
 }  // namespace client
 }  // namespace olp

--- a/olp-cpp-sdk-core/src/cache/DiskCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.cpp
@@ -237,7 +237,7 @@ void DiskCache::SetOpenError(const leveldb::Status& status) {
   error_ = client::ApiError(code, std::move(error_message));
 }
 
-bool DiskCache::Put(const std::string& key, const std::string& value) {
+bool DiskCache::Put(const std::string& key, leveldb::Slice slice) {
   if (!database_) {
     return false;
   }
@@ -247,8 +247,8 @@ bool DiskCache::Put(const std::string& key, const std::string& value) {
     return false;
   }
 
-  const auto status = database_->Put(
-      leveldb::WriteOptions(), ToLeveldbSlice(key), ToLeveldbSlice(value));
+  const auto status =
+      database_->Put(leveldb::WriteOptions(), ToLeveldbSlice(key), slice);
   if (!status.ok()) {
     OLP_SDK_LOG_ERROR(kLogTag, "Put: failed, status=" << status.ToString());
     return false;

--- a/olp-cpp-sdk-core/src/cache/DiskCache.h
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.h
@@ -91,10 +91,9 @@ class DiskCache {
   bool Clear();
   client::ApiError OpenError() const { return error_; }
 
-  bool Put(const std::string& key, const std::string& value);
-  boost::optional<std::string> Get(const std::string& key);
+  bool Put(const std::string& key, leveldb::Slice slice);
 
-  size_t Size() const;
+  boost::optional<std::string> Get(const std::string& key);
 
   /// Remove single key/value from DB.
   bool Remove(const std::string& key);
@@ -103,7 +102,6 @@ class DiskCache {
 
  private:
   void SetOpenError(const leveldb::Status& status);
-  bool ApplyBatch(std::unique_ptr<leveldb::WriteBatch> batch);
 
  private:
   std::string disk_cache_path_;

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/BlobApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/BlobApi.cpp
@@ -53,13 +53,13 @@ BlobApi::DataResponse BlobApi::GetBlob(const client::OlpClient& client,
           client.CallApi(metadata_uri, "GET", query_params, header_params,
   {}, nullptr, "", context);
 
-  auto str_response = api_response.response.str();
   if (api_response.status != http::HttpStatusCode::OK) {
-    return ApiError(api_response.status, str_response);
+    return ApiError(api_response.status, api_response.response.str());
   }
 
-  return std::make_shared<std::vector<unsigned char>>(str_response.begin(),
-                                                      str_response.end());
+  auto result = std::make_shared<std::vector<unsigned char>>();
+  api_response.GetResponse(*result);
+  return result;
 }
 }  // namespace read
 }  // namespace dataservice

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/VolatileBlobApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/VolatileBlobApi.cpp
@@ -44,17 +44,17 @@ VolatileBlobApi::DataResponse VolatileBlobApi::GetVolatileBlob(
 
   std::multimap<std::string, std::string> form_params;
   std::string metadata_uri = "/layers/" + layer_id + "/data/" + data_handle;
-  auto response =
+  auto api_response =
       client.CallApi(metadata_uri, "GET", query_params, header_params,
                      form_params, nullptr, "", context);
-  
-  auto str_response = response.response.str();
-  if (response.status != http::HttpStatusCode::OK) {
-    return ApiError(response.status, str_response);
+
+  if (api_response.status != http::HttpStatusCode::OK) {
+    return ApiError(api_response.status, api_response.response.str());
   }
 
-  return std::make_shared<std::vector<unsigned char>>(str_response.begin(),
-                                                      str_response.end());
+  auto result = std::make_shared<std::vector<unsigned char>>();
+  api_response.GetResponse(*result);
+  return result;
 }
 }  // namespace read
 }  // namespace dataservice


### PR DESCRIPTION
Remove conversion from vector of chars to string.
Remove byte-to-byte copy when retrieving data from disk cache.
Remove byte-to-byte copy in BlobApi, VolatileBlobApi

Relates-To: OLPEDGE-1517

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>