### PR TITLE
Migrate PSV Linux Clang build Travis>Azure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp
 os: linux
-dist: xenial
+dist: bionic
 env:
   global:
   - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
@@ -12,20 +12,12 @@ addons:
     - libboost-all-dev
     - libssl-dev
     - libcurl4-openssl-dev
-    - clang
-    - nodejs
 matrix:
-  include:
-  - compiler: clang
-    cache: ccache
-    env: BUILD_TYPE=RelWithDebInfo WORKSPACE=$TRAVIS_BUILD_DIR
-    name: Linux Build using clang
-    script: $WORKSPACE/scripts/linux/psv/travis_build_psv.sh
   - compiler: gcc
     cache: ccache
     env: BUILD_TYPE=COVERAGE WORKSPACE=$TRAVIS_BUILD_DIR
     name: Linux Build using gcc & tests & code coverage
-    script: $WORKSPACE/scripts/linux/psv/travis_build_psv.sh && $WORKSPACE/scripts/linux/psv/travis_test_psv.sh
+    script: $WORKSPACE/scripts/linux/psv/build_psv.sh && $WORKSPACE/scripts/linux/psv/travis_test_psv.sh
 branches:
   only:
   - master

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ The HERE OLP SDK for C++ is a C++ client for the <a href="https://platform.here.
 
 | Platform | Status                                                                                                                                                                                                                                                                                |
 | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Linux    | <a href="https://travis-ci.com/heremaps/here-olp-sdk-cpp" target="_blank"><img src="https://travis-ci.com/heremaps/here-olp-sdk-cpp.svg?branch=master" alt="Linux build status"/></a>                                                                                                 |
+| Linux GCC   | <a href="https://travis-ci.com/heremaps/here-olp-sdk-cpp" target="_blank"><img src="https://travis-ci.com/heremaps/here-olp-sdk-cpp.svg?branch=master" alt="Linux build status"/></a>                                                                                                 |
+| Linux Clang | <a href="https://dev.azure.com/heremaps/github/_build/latest?definitionId=2&branchName=master" target="_blank"><img src="https://dev.azure.com/heremaps/github/_apis/build/status/heremaps.here-olp-sdk-cpp?branchName=master&jobName=Linux_build_clang" alt="Android build status"/></a> |
 | MacOS    | <a href="https://dev.azure.com/heremaps/github/_build/latest?definitionId=2&branchName=master" target="_blank"><img src="https://dev.azure.com/heremaps/github/_apis/build/status/heremaps.here-olp-sdk-cpp?branchName=master&jobName=Windows_build" alt="macOS build status"/></a>   |
 | iOS      | <a href="https://dev.azure.com/heremaps/github/_build/latest?definitionId=2&branchName=master" target="_blank"><img src="https://dev.azure.com/heremaps/github/_apis/build/status/heremaps.here-olp-sdk-cpp?branchName=master&jobName=MacOS_build" alt="iOS build status"/></a>       |
 | Windows  | <a href="https://dev.azure.com/heremaps/github/_build/latest?definitionId=2&branchName=master" target="_blank"><img src="https://dev.azure.com/heremaps/github/_apis/build/status/heremaps.here-olp-sdk-cpp?branchName=master&jobName=iOS_build" alt="Windows build status"/></a>     |
@@ -41,7 +42,7 @@ The table below lists the platforms on which the OLP SDK for C++ has been tested
 
 | Platform                   | Minimum requirement     |
 | :------------------------- | :---------------------- |
-| Ubuntu                     | GCC 5.4 and Clang 7.0   |
+| Ubuntu                     | GCC 7.4 and Clang 7.0   |
 | Embedded Linux (32/64 bit) | GCC-arm/GCC-aarch64 5.4 |
 | Windows                    | MSVC++ 2017             |
 | macOS                      | Apple Clang 11.0.0      |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,18 +18,21 @@ jobs:
     vmImage: 'vs2017-win2016'
   steps:
   - bash: scripts/windows/build.sh
+    displayName: 'Windows Build'
 
 - job: MacOS_build
   pool:
     vmImage: 'macOS-10.14'
   steps:
   - bash: scripts/macos/psv/azure_macos_build_psv.sh
+    displayName: 'MacOS Build'
 
 - job: iOS_build
   pool:
     vmImage: 'macOS-10.14'
   steps:
   - bash: scripts/ios/azure_ios_build_psv.sh
+    displayName: 'iOS Build'
 
 - job: Android_build
   pool:
@@ -40,6 +43,28 @@ jobs:
     SEGFAULT_SIGNALS: "all"
   steps:
     - bash: ls -la $(ANDROID_NDK_HOME)/build/cmake/android.toolchain.cmake
-      displayName: Verification of cmake script exist.
+      displayName: 'Verification of cmake script'
     - bash: ANDROID_NDK_HOME=$(ANDROID_NDK_HOME) && scripts/android/build.sh
-      displayName: Android build and Examples.
+      displayName: 'Android build and Examples'
+
+- job: Linux_build_clang
+  pool:
+    vmImage: 'ubuntu-18.04'
+  variables:
+    LD_PRELOAD: "/lib/x86_64-linux-gnu/libSegFault.so"
+    SEGFAULT_SIGNALS: "all"
+    CC: clang-7
+    CXX: clang++-7
+    CCACHE_DIR: $(Pipeline.Workspace)/ccache
+  steps:
+  - bash: |
+        sudo apt-get install libcurl4-openssl-dev clang-7 ccache -y --no-install-recommends
+        echo "##vso[task.prependpath]/usr/lib/ccache"
+    displayName: 'Install dependencies'
+  - task: Cache@2
+    inputs:
+        key: 'ccache | "$(Agent.OS)"'
+        path: $(CCACHE_DIR)
+    displayName: ccache
+  - bash: scripts/linux/psv/build_psv.sh
+    displayName: 'Linux Clang Build'

--- a/scripts/linux/psv/build_psv.sh
+++ b/scripts/linux/psv/build_psv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 #
 # Copyright (C) 2019 HERE Europe B.V.
 #
@@ -17,6 +17,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
+# Show initial ccache data
+ccache -s
 
 # For core dump backtrace
 ulimit -c unlimited
@@ -31,4 +33,6 @@ cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
     ..
 
 make -j$(nproc)
+
+# Show last ccache data
 ccache -s


### PR DESCRIPTION
Azure is much more stable platform. Will decrease queues
on Travis in peak time. Travis image update from old
xenial to new bionic. Travis claims some faster image
loading and improvements in bionic. Also removed not
needed packages. Fix 2 minor errors in geo/tiling and Auth.

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>