### PR TITLE
Add version lock to VersionedLayerClient

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include <vector>
 
+#include <boost/optional.hpp>
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>
 #include <olp/core/client/CancellationToken.h>
@@ -96,8 +97,42 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    * @param layer_id The layer ID of the versioned layer from which you want to
    * get data.
    * @param settings The `OlpClientSettings` instance.
+   *
+   * @deprecated Will be removed by 06.2020.
+   */
+  OLP_SDK_DEPRECATED(
+      "Use the ctor with the explicitly specified version. This ctor is "
+      "deprecated and will be removed "
+      "by 06.2020")
+  VersionedLayerClient(client::HRN catalog, std::string layer_id,
+                       client::OlpClientSettings settings);
+  /**
+   * @brief Creates the `VersionedLayerClient` instance with the specified
+   * catalog version.
+   *
+   * The instance of this client is locked to the specified catalog version
+   * passed to the constructor and can't be changed. This way we assure data
+   * consistency. Keep in mind that catalog version provided with requests like
+   * \ref DataRequest, \ref PartitionsRequest, and \ref PrefetchTilesRequest
+   * will be ignored.
+   *
+   * @note If you didn't specify the catalog version, the last available version
+   * is requested once and used for the entire lifetime of this instance.
+   *
+   * @param catalog The HERE Resource Name (HRN) of the catalog that contains
+   * the versioned layer from which you want to get data.
+   * @param layer_id The layer ID of the versioned layer from which you want to
+   * get data.
+   * @param catalog_version The version of the catalog from which you want
+   * to get data. If no version is specified, the last available version is
+   * used instead.
+   * @param settings The `OlpClientSettings` instance.
+   *
+   * @return The `VersionedLayerClient` instance with the specified catalog
+   * version.
    */
   VersionedLayerClient(client::HRN catalog, std::string layer_id,
+                       boost::optional<int64_t> catalog_version,
                        client::OlpClientSettings settings);
 
   /// Movable, non-copyable

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
@@ -30,7 +30,16 @@ VersionedLayerClient::VersionedLayerClient(client::HRN catalog,
                                            std::string layer_id,
                                            client::OlpClientSettings settings)
     : impl_(std::make_unique<VersionedLayerClientImpl>(
-          std::move(catalog), std::move(layer_id), std::move(settings))) {}
+          std::move(catalog), std::move(layer_id), boost::none,
+          std::move(settings))) {}
+
+VersionedLayerClient::VersionedLayerClient(
+    client::HRN catalog, std::string layer_id,
+    boost::optional<int64_t> catalog_version,
+    client::OlpClientSettings settings)
+    : impl_(std::make_unique<VersionedLayerClientImpl>(
+          std::move(catalog), std::move(layer_id), std::move(catalog_version),
+          std::move(settings))) {}
 
 VersionedLayerClient::VersionedLayerClient(
     VersionedLayerClient&& other) noexcept = default;

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -21,6 +21,7 @@
 
 #include <memory>
 
+#include <boost/optional.hpp>
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/HRN.h>
@@ -47,6 +48,7 @@ class PrefetchTilesRepository;
 class VersionedLayerClientImpl {
  public:
   VersionedLayerClientImpl(client::HRN catalog, std::string layer_id,
+                           boost::optional<int64_t> catalog_version,
                            client::OlpClientSettings settings);
 
   virtual ~VersionedLayerClientImpl();
@@ -73,10 +75,15 @@ class VersionedLayerClientImpl {
       PrefetchTilesRequest request);
 
  private:
+  CatalogVersionResponse GetVersion(boost::optional<std::string> billing_tag,
+                                    const FetchOptions& fetch_options,
+                                    const client::CancellationContext& context);
+
   client::HRN catalog_;
   std::string layer_id_;
   client::OlpClientSettings settings_;
   std::shared_ptr<client::PendingRequests> pending_requests_;
+  std::atomic<int64_t> catalog_version_;
 };
 
 }  // namespace read

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -319,7 +319,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataFromPartitionAsync) {
   auto version = std::stoi(GetArgument("dataservice_read_test_layer_version"));
 
   auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
-      catalog, layer, *settings_);
+      catalog, layer, version, *settings_);
   ASSERT_TRUE(client);
 
   auto promise = std::make_shared<std::promise<DataResponse>>();
@@ -327,7 +327,6 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataFromPartitionAsync) {
   auto partition = GetArgument("dataservice_read_test_partition");
   auto token = client->GetData(
       olp::dataservice::read::DataRequest()
-          .WithVersion(version)
           .WithPartitionId(partition),
       [promise](DataResponse response) { promise->set_value(response); });
 
@@ -360,11 +359,10 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
   auto layer = GetArgument("dataservice_read_test_layer");
   auto version = std::stoi(GetArgument("dataservice_read_test_layer_version"));
   auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
-      catalog, layer, *settings_);
+      catalog, layer, version, *settings_);
 
   auto partition = GetArgument("dataservice_read_test_partition");
   auto data_request = olp::dataservice::read::DataRequest()
-                          .WithVersion(version)
                           .WithPartitionId(partition);
   auto cancellable_future = client->GetData(std::move(data_request));
 
@@ -400,7 +398,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataFromPartitionSync) {
   auto sync_settings = *settings_;
   sync_settings.task_scheduler.reset();
   auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
-      catalog, layer, sync_settings);
+      catalog, layer, version, sync_settings);
   ASSERT_TRUE(client);
 
   DataResponse response;
@@ -408,7 +406,6 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataFromPartitionSync) {
   auto partition = GetArgument("dataservice_read_test_partition");
   auto token = client->GetData(
       olp::dataservice::read::DataRequest()
-          .WithVersion(version)
           .WithPartitionId(partition),
       [&response](DataResponse resp) { response = std::move(resp); });
   ASSERT_TRUE(response.IsSuccessful());
@@ -440,12 +437,11 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
   auto sync_settings = *settings_;
   sync_settings.task_scheduler.reset();
   auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
-      catalog, layer, sync_settings);
+      catalog, layer, version, sync_settings);
   ASSERT_TRUE(client);
 
   auto partition = GetArgument("dataservice_read_test_partition");
   auto data_request = olp::dataservice::read::DataRequest()
-                          .WithVersion(version)
                           .WithPartitionId(partition);
   auto cancellable_future = client->GetData(std::move(data_request));
 
@@ -559,7 +555,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
   auto sync_settings = *settings_;
   sync_settings.task_scheduler.reset();
   auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
-      catalog, layer, sync_settings);
+      catalog, layer, 269, sync_settings);
   ASSERT_TRUE(client);
 
   DataResponse response;
@@ -567,7 +563,6 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
   auto partition = GetArgument("dataservice_read_test_partition");
   auto token = client->GetData(
       olp::dataservice::read::DataRequest()
-          .WithVersion(version)
           .WithPartitionId(partition)
           .WithFetchOption(FetchOptions::CacheWithUpdate),
       [&response](DataResponse resp) { response = std::move(resp); });
@@ -602,7 +597,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataEmptyPartitionsSync) {
   auto sync_settings = *settings_;
   sync_settings.task_scheduler.reset();
   auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
-      catalog, layer, sync_settings);
+      catalog, layer, version, sync_settings);
   ASSERT_TRUE(client);
 
   DataResponse response;
@@ -610,7 +605,6 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataEmptyPartitionsSync) {
   auto partition = GetArgument("dataservice_read_test_partition");
   auto token = client->GetData(
       olp::dataservice::read::DataRequest()
-          .WithVersion(version)
           .WithPartitionId(partition),
       [&response](DataResponse resp) { response = std::move(resp); });
   ASSERT_FALSE(response.IsSuccessful());
@@ -1393,7 +1387,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetPartitionsVersion2) {
   auto layer = GetArgument("dataservice_read_test_layer");
 
   auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
-      catalog, layer, *settings_);
+      catalog, layer, 2, *settings_);
 
   EXPECT_CALL(*network_mock_,
               Send(IsGetRequest(URL_LATEST_CATALOG_VERSION), _, _, _, _))
@@ -1402,7 +1396,6 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetPartitionsVersion2) {
       .Times(1);
 
   auto request = olp::dataservice::read::PartitionsRequest();
-  request.WithVersion(2);
   auto promise = std::make_shared<std::promise<PartitionsResponse>>();
   auto future = promise->get_future();
   auto token = client->GetPartitions(
@@ -1421,11 +1414,10 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetPartitionsInvalidVersion) {
   auto layer = GetArgument("dataservice_read_test_layer");
 
   auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
-      catalog, layer, *settings_);
+      catalog, layer, 10, *settings_);
 
   auto request = olp::dataservice::read::PartitionsRequest();
   {
-    request.WithVersion(10);
     auto promise = std::make_shared<std::promise<PartitionsResponse>>();
     auto future = promise->get_future();
     auto token =
@@ -2409,7 +2401,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
   olp::client::HRN hrn(GetTestCatalog());
 
   auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
-      hrn, "testlayer", *settings_);
+      hrn, "testlayer", 2, *settings_);
 
   EXPECT_CALL(*network_mock_,
               Send(IsGetRequest(URL_LATEST_CATALOG_VERSION), _, _, _, _))
@@ -2420,7 +2412,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
       .Times(0);
 
   auto request = olp::dataservice::read::DataRequest();
-  request.WithPartitionId("269").WithVersion(2);
+  request.WithPartitionId("269");
   auto data_response = client->GetData(request).GetFuture().get();
 
   ASSERT_TRUE(data_response.IsSuccessful())
@@ -2436,10 +2428,10 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
   olp::client::HRN hrn(GetTestCatalog());
 
   auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
-      hrn, "testlayer", *settings_);
+      hrn, "testlayer", 10, *settings_);
 
   auto request = olp::dataservice::read::DataRequest();
-  request.WithPartitionId("269").WithVersion(10);
+  request.WithPartitionId("269");
   auto data_response = client->GetData(request).GetFuture().get();
 
   ASSERT_FALSE(data_response.IsSuccessful());


### PR DESCRIPTION
Now version of request will be locked on first
call to any of VersionedLayerClient methods that
accept version field in request. Any further
requests with version specified will be ignored.
In case if first request will not contain version
parameter, SDK will request latest and lock to it.

Resolves: OLPEDGE-1515, OLPEDGE-1513

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>