### PR TITLE
Deprecate WithVersion methods in request classes.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/DataRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/DataRequest.h
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <string>
 
+#include <olp/core/porting/deprecated.h>
 #include <olp/dataservice/read/DataServiceReadApi.h>
 #include <olp/dataservice/read/FetchOptions.h>
 #include <boost/optional.hpp>
@@ -48,7 +49,11 @@ class DATASERVICE_READ_API DataRequest final {
    * retrieved.
    *
    * @return A reference to the updated `DataRequest` instance.
+   *
+   * @deprecated The version is now a part of the VersionedLayerClient
+   * constructor.
    */
+  OLP_SDK_DEPRECATED("Deprecated, to be removed in 06.2020")
   inline DataRequest& WithVersion(boost::optional<int64_t> catalog_version) {
     catalog_version_ = catalog_version;
     return *this;
@@ -58,7 +63,11 @@ class DATASERVICE_READ_API DataRequest final {
    * @brief Gets the catalog metadata version of the requested partitions.
    *
    * @return The catalog metadata version.
+   *
+   * @deprecated The version is now a part of the VersionedLayerClient
+   * constructor.
    */
+  OLP_SDK_DEPRECATED("Deprecated, to be removed in 06.2020")
   inline const boost::optional<std::int64_t>& GetVersion() const {
     return catalog_version_;
   }

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PartitionsRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PartitionsRequest.h
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <string>
 
+#include <olp/core/porting/deprecated.h>
 #include <olp/dataservice/read/DataServiceReadApi.h>
 #include <olp/dataservice/read/FetchOptions.h>
 #include <boost/optional.hpp>
@@ -44,7 +45,11 @@ class DATASERVICE_READ_API PartitionsRequest final {
    * retrieved.
    *
    * @return A reference to the updated `PartitionsRequest` instance.
+   *
+   * @deprecated The version is now a part of the VersionedLayerClient
+   * constructor.
    */
+  OLP_SDK_DEPRECATED("Deprecated, to be removed in 06.2020")
   inline PartitionsRequest& WithVersion(
       boost::optional<int64_t> catalog_version) {
     catalog_version_ = std::move(catalog_version);
@@ -55,7 +60,11 @@ class DATASERVICE_READ_API PartitionsRequest final {
    * @brief Gets the catalog metadata version of the requested partitions.
    *
    * @return The catalog metadata version.
+   *
+   * @deprecated The version is now a part of the VersionedLayerClient
+   * constructor.
    */
+  OLP_SDK_DEPRECATED("Deprecated, to be removed in 06.2020")
   inline const boost::optional<std::int64_t>& GetVersion() const {
     return catalog_version_;
   }

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include <olp/core/geo/tiling/TileKey.h>
+#include <olp/core/porting/deprecated.h>
 #include <olp/dataservice/read/DataServiceReadApi.h>
 #include <boost/optional.hpp>
 
@@ -122,7 +123,11 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
    * version is specified, the latest version is retrieved.
    *
    * @return A reference to the updated `PrefetchTilesRequest` instance.
+   * 
+   * @deprecated The version is now a part of the VersionedLayerClient
+   * constructor.
    */
+  OLP_SDK_DEPRECATED("Deprecated, to be removed in 06.2020")
   inline PrefetchTilesRequest& WithVersion(boost::optional<int64_t> version) {
     catalog_version_ = std::move(version);
     return *this;
@@ -133,7 +138,11 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
    *
    * @return The catalog version or `boost::none` if the catalog version is not
    * set.
+   *
+   * @deprecated The version is now a part of the VersionedLayerClient
+   * constructor.
    */
+  OLP_SDK_DEPRECATED("Deprecated, to be removed in 06.2020")
   inline const boost::optional<std::int64_t>& GetVersion() const {
     return catalog_version_;
   }


### PR DESCRIPTION
VersionedLayerClient needs to serve consistent data for all requests
which are triggered on a particular instance. If user do not know the
catalog version up front and always use boost::none for version, the
risk of returning different catalog versions data is high. Therefore
we lock the catalog version in the constructor of the VersionLayerClient
instance and all requests are therefore served with that particular catalog
version. Hence we do not need the WithVersion() methods in the requests
structures anymore and they will be ignore during requests and the constructor
passed catalog version will be taken instead.

Relates-To: OLPEDGE-1514

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>
Signed-off-by: Andrei Popescu <andrei.popescu@here.com>