### PR TITLE
Enable clang/gcc warnings on CI

### DIFF
--- a/examples/ProtectedCacheExample.cpp
+++ b/examples/ProtectedCacheExample.cpp
@@ -38,8 +38,6 @@ constexpr auto kClientCacheDir = "\\catalog_client_example\\cache";
 #else
 constexpr auto kClientCacheDir = "/cata.log_client_example/cache";
 #endif
-constexpr size_t kMaxLayers(5);
-constexpr size_t kMaxPartitions(5);
 
 std::string first_layer_id("versioned-world-layer");
 std::string first_partition_id("1");

--- a/olp-cpp-sdk-core/src/cache/DiskCacheSizeLimitEnv.cpp
+++ b/olp-cpp-sdk-core/src/cache/DiskCacheSizeLimitEnv.cpp
@@ -32,7 +32,7 @@ bool IsLogFile(const std::string& name) {
                       log_suffix) == 0;
 }
 
-const char PathSeparator() {
+char PathSeparator() {
 #ifdef WIN32
   return '\\';
 #else

--- a/olp-cpp-sdk-core/tests/client/OlpClientTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/OlpClientTest.cpp
@@ -39,6 +39,8 @@ using ::testing::_;
 
 class CallApiWrapper {
  public:
+  virtual ~CallApiWrapper() = default;
+
   virtual HttpResponse CallApi(
       std::string path, std::string method,
       std::multimap<std::string, std::string> query_params,
@@ -267,8 +269,7 @@ TEST_P(OlpClientTest, RetryCondition) {
   client_settings_.network_request_handler = network;
   EXPECT_CALL(*network, Send(_, _, _, _, _))
       .Times(goodAttempt)
-      .WillRepeatedly([&current_attempt, goodAttempt](
-                          olp::http::NetworkRequest request,
+      .WillRepeatedly([&](olp::http::NetworkRequest request,
                           olp::http::Network::Payload payload,
                           olp::http::Network::Callback callback,
                           olp::http::Network::HeaderCallback header_callback,
@@ -450,8 +451,7 @@ TEST_P(OlpClientTest, RetryTimeout) {
   auto network = std::make_shared<NetworkMock>();
   client_settings_.network_request_handler = network;
   EXPECT_CALL(*network, Send(_, _, _, _, _))
-      .WillRepeatedly([&current_attempt, kSuccessfulAttempt](
-                          olp::http::NetworkRequest request,
+      .WillRepeatedly([&](olp::http::NetworkRequest request,
                           olp::http::Network::Payload payload,
                           olp::http::Network::Callback callback,
                           olp::http::Network::HeaderCallback header_callback,

--- a/olp-cpp-sdk-core/tests/thread/SyncQueueTest.cpp
+++ b/olp-cpp-sdk-core/tests/thread/SyncQueueTest.cpp
@@ -163,7 +163,7 @@ TEST(SyncQueueTest, ConcurrentUsage) {
 
   // Start threads push tasks to be handled
   for (size_t idx = 0; idx < kNumThreads; ++idx) {
-    threads.emplace_back([this, idx, &sync_queue] {
+    threads.emplace_back([idx, &sync_queue] {
       for (;;) {
         SyncIncType task;
         if (!sync_queue.Pull(task)) {

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -221,7 +221,7 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
         while (!context.IsCancelled() && it != tiles_result.end()) {
           auto promise = std::make_shared<PrefetchResultPromise>();
           auto flag = std::make_shared<std::atomic_bool>(false);
-          futures->emplace_back(std::move(promise->get_future()));
+          futures->emplace_back(promise->get_future());
 
           auto tile = it->first;
           auto handle = it->second;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
@@ -44,7 +44,6 @@ namespace repository {
 using namespace olp::client;
 
 namespace {
-constexpr auto kDataInlinePrefix = "data:";
 constexpr auto kLogTag = "DataRepository";
 constexpr auto kBlobService = "blob";
 constexpr auto kVolatileBlobService = "volatile-blob";

--- a/scripts/linux/psv/travis_build_psv.sh
+++ b/scripts/linux/psv/travis_build_psv.sh
@@ -24,9 +24,10 @@ ulimit -c unlimited
 mkdir -p build
 cd build
 cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+    -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wno-deprecated-declarations -Wno-unused-parameter" \
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
     -DOLP_SDK_BUILD_EXAMPLES=ON \
     -DBUILD_SHARED_LIBS=ON \
-    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
     ..
 
 make -j$(nproc)

--- a/tests/functional/olp-cpp-sdk-dataservice-read/ApiTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/ApiTest.cpp
@@ -101,14 +101,6 @@ TEST_F(ApiTest, GetCatalog) {
       << ApiErrorToString(client_response.GetError());
   auto config_client = client_response.MoveResult();
 
-  std::promise<olp::dataservice::read::ConfigApi::CatalogResponse>
-      catalog_promise;
-  auto catalog_callback =
-      [&catalog_promise](
-          olp::dataservice::read::ConfigApi::CatalogResponse catalog_response) {
-        catalog_promise.set_value(catalog_response);
-      };
-
   auto start_time = std::chrono::high_resolution_clock::now();
   auto catalog_response = olp::dataservice::read::ConfigApi::GetCatalog(
       config_client, GetTestCatalog(), boost::none,

--- a/tests/functional/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
@@ -69,12 +69,6 @@ std::ostream& operator<<(std::ostream& os, const CacheType cache_type) {
   }
 }
 
-void DumpTileKey(const olp::geo::TileKey& tile_key) {
-  std::cout << "Tile: " << tile_key.ToHereTile()
-            << ", level: " << tile_key.Level()
-            << ", parent: " << tile_key.Parent().ToHereTile() << std::endl;
-}
-
 class CatalogClientTest : public ::testing::TestWithParam<CacheType> {
  public:
   void SetUp() override {

--- a/tests/integration/olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
@@ -97,9 +97,9 @@ void TestAutoRefreshingTokenCancel(
   ASSERT_EQ(tokenResponses.size(), 2u);
   ASSERT_EQ(tokenResponses[0].GetResult().GetAccessToken(),
             tokenResponses[1].GetResult().GetAccessToken());
-  ASSERT_LE(abs(tokenResponses[1].GetResult().GetExpiryTime() -
-                tokenResponses[0].GetResult().GetExpiryTime()),
-            10);
+  ASSERT_LE(std::abs(tokenResponses[1].GetResult().GetExpiryTime() -
+                     tokenResponses[0].GetResult().GetExpiryTime()),
+            10ll);
 }
 
 }  // namespace

--- a/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
@@ -37,12 +37,6 @@ using namespace testing;
 using namespace olp::tests::common;
 using namespace olp::tests::integration;
 
-void DumpTileKey(const olp::geo::TileKey& tile_key) {
-  std::cout << "Tile: " << tile_key.ToHereTile()
-            << ", level: " << tile_key.Level()
-            << ", parent: " << tile_key.Parent().ToHereTile() << std::endl;
-}
-
 class CatalogClientTest : public CatalogClientTestBase {};
 
 TEST_P(CatalogClientTest, GetCatalog) {

--- a/tests/performance/MemoryTest.cpp
+++ b/tests/performance/MemoryTest.cpp
@@ -333,8 +333,6 @@ TEST_P(MemoryTest, PrefetchPartitionsFromVersionedLayer) {
         std::chrono::steady_clock::now() + parameter.runtime;
 
     while (end_timestamp > std::chrono::steady_clock::now()) {
-      const auto partition_id = request_counter_.fetch_add(1);
-
       const auto level = 10;
       const auto tile_count = 1 << level;
 

--- a/tests/performance/NetworkWrapper.h
+++ b/tests/performance/NetworkWrapper.h
@@ -29,8 +29,7 @@
  */
 class Http2HttpNetworkWrapper : public olp::http::Network {
  public:
-  Http2HttpNetworkWrapper()
-      : network_{std::move(olp::http::CreateDefaultNetwork(32))} {}
+  Http2HttpNetworkWrapper() : network_{olp::http::CreateDefaultNetwork(32)} {}
 
   olp::http::SendOutcome Send(olp::http::NetworkRequest request,
                               Payload payload, Callback callback,


### PR DESCRIPTION
Additionally disable deprecate warnings

Relates-To: OLPEDGE-1083

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>