### PR TITLE
Add seek method for StreamLayerClient.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/SeekRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/SeekRequest.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <vector>
+
+#include <olp/dataservice/read/model/StreamOffsets.h>
+
+namespace olp {
+namespace dataservice {
+namespace read {
+
+/**
+ * @brief Requests to seek an offset for a stream layer.
+ */
+class DATASERVICE_READ_API SeekRequest final {
+ public:
+  /// The alias type of the stream offsets.
+  using StreamOffsets = model::StreamOffsets;
+
+  /**
+   * @brief Sets offsets for the request.
+   *
+   * No offset by default.
+   *
+   * @param offsets The stream offsets.
+   *
+   * @return A reference to the updated `SeekRequest` instance.
+   */
+  SeekRequest& WithOffsets(StreamOffsets offsets) {
+    stream_offsets_ = offsets;
+    return *this;
+  }
+
+  /**
+   * @brief Gets the stream offsets of the request.
+   *
+   * @return The current stream offsets.
+   */
+  const model::StreamOffsets& GetOffsets() const { return stream_offsets_; }
+
+ private:
+  StreamOffsets stream_offsets_;
+};
+
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/StreamLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/StreamLayerClient.h
@@ -26,6 +26,7 @@
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/dataservice/read/DataServiceReadApi.h>
+#include <olp/dataservice/read/SeekRequest.h>
 #include <olp/dataservice/read/SubscribeRequest.h>
 #include <olp/dataservice/read/Types.h>
 #include <olp/dataservice/read/model/Messages.h>
@@ -226,6 +227,42 @@ class DATASERVICE_READ_API StreamLayerClient final {
    * can also use `CancellableFuture` to cancel this request.
    */
   client::CancellableFuture<PollResponse> Poll();
+
+  /**
+   * @brief Allows changing the data stream reading offset.
+   *
+   * If the commit is successful, the message consumption starts from the
+   * specified offset.
+   *
+   * Only possible if subscribed successfully.
+   * Offsets shouldn't be empty.
+   *
+   * @param request The `SeekRequest` instance that contains a complete set
+   * of request parameters.
+   * @param callback The `SeekResponseCallback` object that is invoked when
+   * the `Seek` request is completed.
+   *
+   * @return A token that can be used to cancel this request.
+   */
+  client::CancellationToken Seek(SeekRequest request,
+                                 SeekResponseCallback callback);
+
+  /**
+   * @brief Allows changing the data stream reading offset.
+   *
+   * If the commit is successful, the message consumption starts from the
+   * specified offset.
+   *
+   * Only possible if subscribed successfully.
+   * Offsets shouldn't be empty.
+   *
+   * @param request The `SeekRequest` instance that contains a complete set
+   * of request parameters.
+   *
+   * @return `CancellableFuture` that contains `SeekResponse` or an error. You
+   * can also use `CancellableFuture` to cancel this request.
+   */
+  client::CancellableFuture<SeekResponse> Seek(SeekRequest request);
 
  private:
   std::unique_ptr<StreamLayerClientImpl> impl_;

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
@@ -97,6 +97,16 @@ using MessagesResult = model::Messages;
 using PollResponse = Response<MessagesResult>;
 /// The poll completion callback type of the stream layer client.
 using PollResponseCallback = Callback<MessagesResult>;
+
+/** @brief The alias of the seek response result.
+ *
+ * The status of the HTTP request.
+ */
+using SeekResult = int;
+/// The seek response type of the stream layer client.
+using SeekResponse = Response<SeekResult>;
+/// The seek completion callback type of the stream layer client.
+using SeekResponseCallback = Callback<SeekResult>;
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/StreamLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/StreamLayerClient.cpp
@@ -82,6 +82,16 @@ client::CancellableFuture<PollResponse> StreamLayerClient::Poll() {
   return impl_->Poll();
 }
 
+client::CancellationToken StreamLayerClient::Seek(
+    SeekRequest request, SeekResponseCallback callback) {
+  return impl_->Seek(std::move(request), std::move(callback));
+}
+
+client::CancellableFuture<SeekResponse> StreamLayerClient::Seek(
+    SeekRequest request) {
+  return impl_->Seek(std::move(request));
+}
+
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/StreamLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/StreamLayerClientImpl.h
@@ -25,6 +25,7 @@
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/core/client/PendingRequests.h>
+#include <olp/dataservice/read/SeekRequest.h>
 #include <olp/dataservice/read/SubscribeRequest.h>
 #include <olp/dataservice/read/Types.h>
 #include <olp/dataservice/read/model/Messages.h>
@@ -65,6 +66,10 @@ class StreamLayerClientImpl {
 
   virtual client::CancellationToken Poll(PollResponseCallback callback);
   virtual client::CancellableFuture<PollResponse> Poll();
+
+  virtual client::CancellationToken Seek(SeekRequest request,
+                                         SeekResponseCallback callback);
+  virtual client::CancellableFuture<SeekResponse> Seek(SeekRequest request);
 
  private:
   /// A struct that aggregates the stream layer client parameters.

--- a/tests/integration/olp-cpp-sdk-dataservice-read/HttpResponses.h
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/HttpResponses.h
@@ -117,6 +117,9 @@
 #define URL_LOOKUP_STREAM \
   R"(https://api-lookup.data.api.platform.here.com/lookup/v1/resources/)"+GetTestCatalog()+R"(/apis/stream/v2)"
 
+#define URL_SEEK_STREAM \
+  R"(https://some.stream.url/stream/v2/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2/layers/testlayer/seek?mode=serial&subscriptionId=subscribe_id_12345)"
+
 #define CONFIG_BASE_URL "https://config.data.api.platform.in.here.com/config/v1"
 
 #define HTTP_RESPONSE_LOOKUP_CONFIG                                                    \


### PR DESCRIPTION
It's now possible to start reading messages from specified offset.
SeekRequest can be used to specify desired offsets.
Some unit tests are added to cover new methods.

Resolves: OLPEDGE-1352

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>