### PR TITLE
Enable -Werror (treat warnings as errors)

### DIFF
--- a/scripts/linux/psv/travis_build_psv.sh
+++ b/scripts/linux/psv/travis_build_psv.sh
@@ -24,7 +24,7 @@ ulimit -c unlimited
 mkdir -p build
 cd build
 cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-    -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wno-deprecated-declarations -Wno-unused-parameter" \
+    -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -Wno-deprecated-declarations -Wno-unused-parameter -Wno-unused-function -Wno-attributes" \
     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
     -DOLP_SDK_BUILD_EXAMPLES=ON \
     -DBUILD_SHARED_LIBS=ON \


### PR DESCRIPTION
Disable unused function warning, attribute warning (bug in old gcc)

Relates-To: OLPEDGE-1083

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>