### PR TITLE
Added a new API to authenticate OLP with a custom request body.

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
@@ -387,6 +387,32 @@ class AUTHENTICATION_API AuthenticationClient {
   client::CancellationToken SignInHereUser(
       const AuthenticationCredentials& credentials,
       const UserProperties& properties, const SignInUserCallback& callback);
+  
+  /**
+   * @brief Signs in with a custom request body.
+   *
+   * This method provides the mechanism to authenticate with the HERE Platform
+   * using a custom request body. You should use this method when the HERE
+   * Platform authentication backend offers you individual parameters or
+   * endpoint. 
+   *
+   * @param credentials The `AuthenticationCredentials` instance.
+   * @param request_body The request body that will be passed to the oauth
+   * endpoint.
+   * @param callback The `SignInUserCallback` method that is called when
+   * the user sign-in request is completed. If successful, the returned HTTP
+   * status is 200. If a new account is created as a part of the sign-in request
+   * and terms must be accepted, the returned HTTP status is 201  for the first
+   * time and 412 for subsequent requests as long as you accept the terms.
+   * Otherwise, check the response error.
+   *
+   * @return The `CancellationToken` instance that can be used to cancel
+   * the request.
+   */
+  client::CancellationToken SignInFederated(
+      AuthenticationCredentials credentials, std::string request_body,
+      SignInUserCallback callback);
+
   /**
    * @brief Signs in with your valid Facebook token and requests your user
    * access token.

--- a/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
@@ -150,6 +150,10 @@ class AuthenticationClient::Impl final {
       const AuthenticationClient::SignInUserCallback& callback);
 
   client::CancellationToken SignInFederated(
+      AuthenticationCredentials credentials, std::string request_body,
+      AuthenticationClient::SignInUserCallback callback);
+
+  client::CancellationToken SignInFederated(
       const AuthenticationCredentials& credentials,
       const FederatedSignInType& type,
       const AuthenticationClient::FederatedProperties& properties,
@@ -452,6 +456,15 @@ client::CancellationToken AuthenticationClient::Impl::SignInHereUser(
     const AuthenticationClient::SignInUserCallback& callback) {
   return HandleUserRequest(credentials, kOauthEndpoint,
                            generateUserBody(properties), callback);
+}
+
+client::CancellationToken AuthenticationClient::Impl::SignInFederated(
+    AuthenticationCredentials credentials, std::string request_body,
+    AuthenticationClient::SignInUserCallback callback) {
+  auto payload =
+      std::make_shared<std::vector<unsigned char>>(request_body.size());
+  std::memcpy(payload->data(), request_body.data(), request_body.size());
+  return HandleUserRequest(credentials, kOauthEndpoint, payload, callback);
 }
 
 client::CancellationToken AuthenticationClient::Impl::SignInRefresh(
@@ -1017,6 +1030,13 @@ client::CancellationToken AuthenticationClient::SignInHereUser(
     const AuthenticationCredentials& credentials,
     const UserProperties& properties, const SignInUserCallback& callback) {
   return impl_->SignInHereUser(credentials, properties, callback);
+}
+
+client::CancellationToken AuthenticationClient::SignInFederated(
+    AuthenticationCredentials credentials, std::string request_body,
+    SignInUserCallback callback) {
+  return impl_->SignInFederated(std::move(credentials), std::move(request_body),
+                                std::move(callback));
 }
 
 client::CancellationToken AuthenticationClient::SignInFacebook(

--- a/tests/common/matchers/NetworkUrlMatchers.h
+++ b/tests/common/matchers/NetworkUrlMatchers.h
@@ -21,6 +21,7 @@
 
 #include <gmock/gmock.h>
 
+#include <olp/core/http/NetworkConstants.h>
 #include <olp/core/http/NetworkRequest.h>
 
 namespace olp {
@@ -85,6 +86,17 @@ MATCHER_P(HeadersContain, expected_header, "") {
   const auto& headers = arg.GetHeaders();
   return std::find(headers.begin(), headers.end(), expected_header) !=
          headers.end();
+}
+
+MATCHER(HeadersContainAuthorization, "") {
+  const auto& headers = arg.GetHeaders();
+  // headers must contain "Authorization" key and "Bearer xxxx" value
+  return std::find_if(
+             headers.begin(), headers.end(),
+             [](const std::pair<std::string, std::string>& header) {
+               return header.first == olp::http::kAuthorizationHeader &&
+                      header.second.length() > strlen(olp::http::kBearer) + 2;
+             }) != headers.end();
 }
 
 }  // namespace common

--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -35,6 +35,7 @@ set(OLP_SDK_FUNCTIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-authentication/AuthenticationTestUtils.cpp
     ./olp-cpp-sdk-authentication/FacebookAuthenticationTest.cpp
     ./olp-cpp-sdk-authentication/GoogleAuthenticationTest.cpp
+    ./olp-cpp-sdk-authentication/FederatedAuthenticationTest.cpp
     ./olp-cpp-sdk-authentication/HereAccountOauth2ProductionTest.cpp
 )
 

--- a/tests/functional/olp-cpp-sdk-authentication/FederatedAuthenticationTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/FederatedAuthenticationTest.cpp
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <rapidjson/rapidjson.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+#include <olp/core/http/HttpStatusCode.h>
+#include <olp/core/porting/make_unique.h>
+#include "AuthenticationCommonTestFixture.h"
+#include "AuthenticationTestUtils.h"
+#include "TestConstants.h"
+
+using namespace ::olp::authentication;
+
+namespace {
+
+class FederatedAuthenticationTest : public AuthenticationCommonTestFixture {
+ protected:
+  void SetUp() override {
+    AuthenticationCommonTestFixture::SetUp();
+
+    ASSERT_TRUE(AuthenticationTestUtils::GetGoogleAccessToken(
+        *network_, olp::http::NetworkSettings(), token_));
+
+    id_ = kTestAppKeyId;
+    secret_ = kTestAppKeySecret;
+  }
+
+  void TearDown() override {
+    token_ = AuthenticationTestUtils::AccessTokenResponse{};
+
+    AuthenticationCommonTestFixture::TearDown();
+  }
+
+  AuthenticationClient::SignInUserResponse SignInFederated(std::string body) {
+    AuthenticationCredentials credentials(id_, secret_);
+    std::promise<AuthenticationClient::SignInUserResponse> request;
+    auto request_future = request.get_future();
+
+    client_->SignInFederated(
+        credentials, body,
+        [&](const AuthenticationClient::SignInUserResponse& response) {
+          request.set_value(response);
+        });
+
+    return request_future.get();
+  }
+
+  std::string GoogleAuthenticationBody(const std::string& email,
+                                       const std::string& access_token) {
+    rapidjson::StringBuffer data;
+
+    rapidjson::Writer<rapidjson::StringBuffer> writer(data);
+    writer.StartObject();
+    writer.Key("grantType");
+    writer.String("google");
+    writer.Key("accessToken");
+    writer.String(access_token.c_str());
+    writer.Key("countryCode");
+    writer.String("USA");
+    writer.Key("language");
+    writer.String("en");
+    writer.Key("email");
+    writer.String(email.c_str());
+    writer.EndObject();
+
+    return data.GetString();
+  }
+
+ protected:
+  AuthenticationTestUtils::AccessTokenResponse token_;
+};
+
+TEST_F(FederatedAuthenticationTest, SignInFederatedNoBody) {
+  AuthenticationClient::SignInUserResponse response = SignInFederated("");
+  EXPECT_EQ(olp::http::HttpStatusCode::BAD_REQUEST,
+            response.GetResult().GetStatus());
+  EXPECT_TRUE(response.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response.GetResult().GetPrivatePolicyUrlJson().empty());
+}
+
+TEST_F(FederatedAuthenticationTest, SignInFederatedEmptyJson) {
+  AuthenticationClient::SignInUserResponse response = SignInFederated("{}");
+  EXPECT_EQ(olp::http::HttpStatusCode::BAD_REQUEST,
+            response.GetResult().GetStatus());
+  EXPECT_EQ(kErrorFieldsCode, response.GetResult().GetErrorResponse().code);
+  EXPECT_EQ(kErrorFieldsMessage,
+            response.GetResult().GetErrorResponse().message);
+  EXPECT_TRUE(response.GetResult().GetAccessToken().empty());
+  EXPECT_TRUE(response.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response.GetResult().GetUserIdentifier().empty());
+  EXPECT_TRUE(response.GetResult().GetTermAcceptanceToken().empty());
+  EXPECT_TRUE(response.GetResult().GetTermsOfServiceUrl().empty());
+  EXPECT_TRUE(response.GetResult().GetTermsOfServiceUrlJson().empty());
+  EXPECT_TRUE(response.GetResult().GetPrivatePolicyUrl().empty());
+  EXPECT_TRUE(response.GetResult().GetPrivatePolicyUrlJson().empty());
+}
+
+TEST_F(FederatedAuthenticationTest, SignInGoogle) {
+  ASSERT_FALSE(token_.access_token.empty());
+
+  const std::string email = GetEmail();
+
+  {
+    SCOPED_TRACE("Create account");
+    AuthenticationClient::SignInUserResponse response =
+        SignInFederated(GoogleAuthenticationBody(email, token_.access_token));
+    EXPECT_EQ(olp::http::HttpStatusCode::CREATED,
+              response.GetResult().GetStatus());
+    EXPECT_EQ(kErrorPreconditionCreatedCode,
+              response.GetResult().GetErrorResponse().code);
+    EXPECT_EQ(kErrorPreconditionCreatedMessage,
+              response.GetResult().GetErrorResponse().message);
+    EXPECT_TRUE(response.GetResult().GetAccessToken().empty());
+    EXPECT_TRUE(response.GetResult().GetTokenType().empty());
+    EXPECT_TRUE(response.GetResult().GetRefreshToken().empty());
+    EXPECT_TRUE(response.GetResult().GetUserIdentifier().empty());
+    EXPECT_FALSE(response.GetResult().GetTermAcceptanceToken().empty());
+    EXPECT_FALSE(response.GetResult().GetTermsOfServiceUrl().empty());
+    EXPECT_FALSE(response.GetResult().GetTermsOfServiceUrlJson().empty());
+    EXPECT_FALSE(response.GetResult().GetPrivatePolicyUrl().empty());
+    EXPECT_FALSE(response.GetResult().GetPrivatePolicyUrlJson().empty());
+
+    SCOPED_TRACE("Accept Terms");
+    AuthenticationClient::SignInUserResponse response2 = AcceptTerms(response);
+    EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT,
+              response2.GetResult().GetStatus());
+    EXPECT_STREQ(kErrorNoContent.c_str(),
+                 response2.GetResult().GetErrorResponse().message.c_str());
+    EXPECT_TRUE(response2.GetResult().GetAccessToken().empty());
+    EXPECT_TRUE(response2.GetResult().GetTokenType().empty());
+    EXPECT_TRUE(response2.GetResult().GetRefreshToken().empty());
+    EXPECT_TRUE(response2.GetResult().GetUserIdentifier().empty());
+    EXPECT_TRUE(response2.GetResult().GetTermAcceptanceToken().empty());
+    EXPECT_TRUE(response2.GetResult().GetTermsOfServiceUrl().empty());
+    EXPECT_TRUE(response2.GetResult().GetTermsOfServiceUrlJson().empty());
+    EXPECT_TRUE(response2.GetResult().GetPrivatePolicyUrl().empty());
+    EXPECT_TRUE(response2.GetResult().GetPrivatePolicyUrlJson().empty());
+  }
+
+  {
+    SCOPED_TRACE("Sign in");
+    AuthenticationClient::SignInUserResponse response3 =
+        SignInFederated(GoogleAuthenticationBody(email, token_.access_token));
+    EXPECT_EQ(olp::http::HttpStatusCode::OK, response3.GetResult().GetStatus());
+    EXPECT_STREQ(kErrorOk.c_str(),
+                 response3.GetResult().GetErrorResponse().message.c_str());
+    EXPECT_FALSE(response3.GetResult().GetAccessToken().empty());
+    EXPECT_FALSE(response3.GetResult().GetTokenType().empty());
+    EXPECT_FALSE(response3.GetResult().GetRefreshToken().empty());
+    EXPECT_FALSE(response3.GetResult().GetUserIdentifier().empty());
+    EXPECT_TRUE(response3.GetResult().GetTermAcceptanceToken().empty());
+    EXPECT_TRUE(response3.GetResult().GetTermsOfServiceUrl().empty());
+    EXPECT_TRUE(response3.GetResult().GetTermsOfServiceUrlJson().empty());
+    EXPECT_TRUE(response3.GetResult().GetPrivatePolicyUrl().empty());
+    EXPECT_TRUE(response3.GetResult().GetPrivatePolicyUrlJson().empty());
+
+    SCOPED_TRACE("Sign out");
+    AuthenticationClient::SignOutUserResponse signout_response =
+        SignOutUser(response3.GetResult().GetAccessToken());
+    EXPECT_TRUE(signout_response.IsSuccessful());
+
+    SCOPED_TRACE("Delete account");
+    AuthenticationTestUtils::DeleteUserResponse response4 =
+        DeleteUser(response3.GetResult().GetAccessToken());
+    EXPECT_EQ(olp::http::HttpStatusCode::NO_CONTENT, response4.status);
+    EXPECT_STREQ(kErrorNoContent.c_str(), response4.error.c_str());
+  }
+
+  {
+    SCOPED_TRACE("Sign in with invalid token");
+    // SignIn with invalid token
+    AuthenticationClient::SignInUserResponse response5 =
+        SignInFederated(GoogleAuthenticationBody(email, "12345"));
+    EXPECT_EQ(olp::http::HttpStatusCode::UNAUTHORIZED,
+              response5.GetResult().GetStatus());
+    EXPECT_TRUE(response5.GetResult().GetAccessToken().empty());
+    EXPECT_TRUE(response5.GetResult().GetTokenType().empty());
+    EXPECT_TRUE(response5.GetResult().GetRefreshToken().empty());
+    EXPECT_TRUE(response5.GetResult().GetUserIdentifier().empty());
+    EXPECT_TRUE(response5.GetResult().GetTermAcceptanceToken().empty());
+    EXPECT_TRUE(response5.GetResult().GetTermsOfServiceUrl().empty());
+    EXPECT_TRUE(response5.GetResult().GetTermsOfServiceUrlJson().empty());
+    EXPECT_TRUE(response5.GetResult().GetPrivatePolicyUrl().empty());
+    EXPECT_TRUE(response5.GetResult().GetPrivatePolicyUrlJson().empty());
+  }
+}
+
+}  // namespace


### PR DESCRIPTION
This API designed to authenticate OLP in situations when AAA service implements
a custom logic for special needs.

Resolves: OLPEDGE-1261

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>