### PR TITLE
Add a cpp client for MockServer

### DIFF
--- a/tests/utils/mock-server-client/Client.h
+++ b/tests/utils/mock-server-client/Client.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <olp/core/client/OlpClient.h>
+#include <olp/core/client/OlpClientFactory.h>
+#include <olp/core/client/OlpClientSettings.h>
+#include <olp/core/generated/parser/JsonParser.h>
+#include "Expectation.h"
+#include "Status.h"
+
+namespace mockserver {
+
+const auto kBaseUrl = "https://localhost:1080";
+const auto kExpectationPath = "/mockserver/expectation";
+const auto kStatusPath = "/mockserver/status";
+const auto kResetPath = "/mockserver/reset";
+const auto kTimeout = std::chrono::seconds{10};
+
+class Client {
+ public:
+  explicit Client(olp::client::OlpClientSettings settings) {
+    http_client_ = olp::client::OlpClientFactory::Create(settings);
+    http_client_->SetBaseUrl(kBaseUrl);
+  }
+
+  void MockResponse(const std::string& method_matcher,
+                    const std::string& path_matcher,
+                    const std::string& response_body) {
+    auto expectation = Expectation{};
+    expectation.request.path = path_matcher;
+    expectation.request.method = method_matcher;
+
+    boost::optional<Expectation::ResponseAction> action =
+        Expectation::ResponseAction{};
+    action->body = response_body;
+    expectation.action = action;
+
+    CreateExpectation(expectation);
+  }
+
+  std::vector<int32_t> Ports() const {
+    auto response =
+        http_client_->CallApi(kStatusPath, "PUT", {}, {}, {}, nullptr, "", {});
+
+    if (response.status != olp::http::HttpStatusCode::OK) {
+      return {};
+    }
+
+    const auto status = olp::parser::parse<Status>(response.response);
+
+    return status.ports;
+  }
+
+  void Reset() {
+    auto response =
+        http_client_->CallApi(kResetPath, "PUT", {}, {}, {}, nullptr, "", {});
+
+    return;
+  }
+
+ private:
+  void CreateExpectation(const Expectation& expectation) {
+    const auto data = serialize(expectation);
+    const std::shared_ptr<std::vector<unsigned char>> request_body =
+        std::make_shared<std::vector<unsigned char>>(data.begin(), data.end());
+
+    auto response = http_client_->CallApi(kExpectationPath, "PUT", {}, {}, {},
+                                          request_body, "", {});
+
+    return;
+  }
+
+ private:
+  std::shared_ptr<olp::client::OlpClient> http_client_;
+};
+}  // namespace mockserver

--- a/tests/utils/mock-server-client/Expectation.h
+++ b/tests/utils/mock-server-client/Expectation.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+
+#include <olp/core/generated/serializer/SerializerWrapper.h>
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+#include <boost/any.hpp>
+#include <boost/optional.hpp>
+
+namespace mockserver {
+
+struct Expectation {
+  struct RequestMatcher {
+    boost::optional<std::string> path = boost::none;
+    boost::optional<std::string> method = boost::none;
+  };
+
+  struct ResponseAction {
+    boost::optional<uint16_t> status_code = boost::none;
+
+    /// Any of BinaryResponse, std::string, boost::any
+    boost::any body;
+  };
+
+  struct BinaryResponse {
+    std::string type = "BINARY";
+    std::vector<std::uint8_t> base64_bytes;
+  };
+
+  RequestMatcher request;
+  boost::optional<ResponseAction> action = boost::none;
+};
+
+void to_json(const Expectation& x, rapidjson::Value& value,
+             rapidjson::Document::AllocatorType& allocator) {
+  value.SetObject();
+  olp::serializer::serialize("httpRequest", x.request, value, allocator);
+
+  if (x.action != boost::none) {
+    olp::serializer::serialize("httpResponse", x.action, value, allocator);
+  }
+}
+
+void to_json(const Expectation::RequestMatcher& x, rapidjson::Value& value,
+             rapidjson::Document::AllocatorType& allocator) {
+  value.SetObject();
+  olp::serializer::serialize("path", x.path, value, allocator);
+  olp::serializer::serialize("method", x.method, value, allocator);
+}
+
+void to_json(const Expectation::BinaryResponse& x, rapidjson::Value& value,
+             rapidjson::Document::AllocatorType& allocator) {
+  value.SetObject();
+  olp::serializer::serialize("type", x.type, value, allocator);
+  olp::serializer::serialize("base64Bytes", x.base64_bytes, value, allocator);
+}
+
+void to_json(const Expectation::ResponseAction& x, rapidjson::Value& value,
+             rapidjson::Document::AllocatorType& allocator) {
+  value.SetObject();
+  olp::serializer::serialize("statusCode", x.status_code, value, allocator);
+
+  if (x.body.type() == typeid(std::string)) {
+    olp::serializer::serialize("body", boost::any_cast<std::string>(x.body),
+                               value, allocator);
+  } else if (x.body.type() == typeid(Expectation::BinaryResponse)) {
+    olp::serializer::serialize(
+        "body", boost::any_cast<Expectation::BinaryResponse>(x.body), value,
+        allocator);
+  }
+}
+
+inline std::string serialize(const Expectation& object) {
+  rapidjson::Document doc;
+  auto& allocator = doc.GetAllocator();
+
+  doc.SetObject();
+  to_json(object, doc, allocator);
+
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  doc.Accept(writer);
+  return buffer.GetString();
+};
+
+}  // namespace mockserver

--- a/tests/utils/mock-server-client/Status.h
+++ b/tests/utils/mock-server-client/Status.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <vector>
+
+#include <rapidjson/document.h>
+#include <olp/core/generated/parser/ParserWrapper.h>
+
+namespace mockserver {
+
+struct Status {
+  using Ports = std::vector<int32_t>;
+
+  Ports ports;
+};
+
+void from_json(const rapidjson::Value& value, Status& x){
+  x.ports = olp::parser::parse<Status::Ports>(value, "ports");
+}
+
+
+}  // namespace mockserver


### PR DESCRIPTION
With the client, we'll be able to mock HTTP responses of various OLP services.

The MockServer CPP client helps to mock such responses directly from `gtest` code

Relates-To: OLPEDGE-1252

Signed-off-by: Kirill Zhuchkov <kirill.zhuchkov@here.com>
