### PR TITLE
Fix crash in OlpClient.

### DIFF
--- a/tests/common/mocks/NetworkMock.h
+++ b/tests/common/mocks/NetworkMock.h
@@ -59,6 +59,10 @@ class NetworkMock : public olp::http::Network {
 struct MockedResponseInformation {
   int status;        /// HTTP status code for response.
   const char* data;  /// Body of HTTP response.
+  http::Headers headers;
+  MockedResponseInformation(int status, const char* data,
+                            http::Headers&& headers = {})
+      : status(status), data(data), headers(std::move(headers)) {}
 };
 
 /**


### PR DESCRIPTION
Using deleted stack headers variable.
Add checking atomic interest_flag to indicate if request was canceled.

Relates-To: OLPEDGE-1605

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>