### PR TITLE
Remove trailing whitespaces 👹

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
@@ -387,14 +387,14 @@ class AUTHENTICATION_API AuthenticationClient {
   client::CancellationToken SignInHereUser(
       const AuthenticationCredentials& credentials,
       const UserProperties& properties, const SignInUserCallback& callback);
-  
+
   /**
    * @brief Signs in with a custom request body.
    *
    * This method provides the mechanism to authenticate with the HERE Platform
    * using a custom request body. You should use this method when the HERE
    * Platform authentication backend offers you individual parameters or
-   * endpoint. 
+   * endpoint.
    *
    * @param credentials The `AuthenticationCredentials` instance.
    * @param request_body The request body that will be passed to the oauth


### PR DESCRIPTION
Trailing whitespaces evil.
Don't commit evil into your repo.

Trailing whitespace issues can cause a lot of problems when they get into your repository.
It leads to false diffs which claim lines have been changed when in fact the only
the thing that changed was spacing.

This can make finding what actually changed in a file later on in the development cycle
next to impossible.

Relates-To: OLPEDGE-1595

Signed-off-by: Kirill Zhuchkov <kirill.zhuchkov@here.com>