### PR TITLE
New AuthenticationClient constructor.

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <string>
 
+#include <olp/authentication/AuthenticationSettings.h>
 #include <olp/core/client/ApiResponse.h>
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/http/NetworkProxySettings.h>
@@ -54,9 +55,6 @@ class TaskScheduler;
  * @brief The authentication namespace
  */
 namespace authentication {
-
-static const std::string kHereAccountProductionUrl =
-    "https://account.api.here.com";
 
 /**
  * @brief An API class of the C++ client that provides
@@ -269,6 +267,14 @@ class AUTHENTICATION_API AuthenticationClient {
   AuthenticationClient(
       const std::string& authentication_server_url = kHereAccountProductionUrl,
       size_t token_cache_limit = 100u);
+
+  /**
+   * @brief Creates the `AuthenticationClient` instance.
+   *
+   * @param settings The authentication settings that can be used to configure
+   * the `AuthenticationClient` instance.
+   */
+  explicit AuthenticationClient(AuthenticationSettings settings);
 
   /**
    * @brief A default destructor.

--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationSettings.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationSettings.h
@@ -37,8 +37,8 @@ class TaskScheduler;
 
 namespace authentication {
 /// The default token endpoint url.
-static constexpr auto kHereAccountProductionTokenEndpointUrl =
-    "https://account.api.here.com/oauth2/token";
+static constexpr auto kHereAccountProductionUrl =
+    "https://account.api.here.com";
 
 /**
  * @brief Configures the `TokenEndpoint` instance.
@@ -51,13 +51,13 @@ struct AUTHENTICATION_API AuthenticationSettings {
    *
    * To remove any existing proxy settings, set to boost::none.
    */
-  boost::optional<http::NetworkProxySettings> network_proxy_settings;
+  boost::optional<http::NetworkProxySettings> network_proxy_settings{};
 
   /**
    * @brief The network instance that is used to internally operate with the OLP
    * services.
    */
-  std::shared_ptr<http::Network> network_request_handler = nullptr;
+  std::shared_ptr<http::Network> network_request_handler{nullptr};
 
   /**
    * @brief The `TaskScheduler` class that is used to manage
@@ -65,15 +65,18 @@ struct AUTHENTICATION_API AuthenticationSettings {
    *
    * If nullptr, all request calls are performed synchronously.
    */
-  std::shared_ptr<thread::TaskScheduler> task_scheduler;
+  std::shared_ptr<thread::TaskScheduler> task_scheduler{nullptr};
 
   /**
    * @brief The server URL of the token endpoint.
-   *
-   * @note Only standard OAuth2 Token URLs (those ending in `oauth2/token`) are
-   * supported.
    */
-  std::string token_endpoint_url{kHereAccountProductionTokenEndpointUrl};
+  std::string token_endpoint_url{kHereAccountProductionUrl};
+
+  /**
+   * @brief The maximum number of tokens that can be stored in LRU
+   * in-memory cache.
+   */
+  size_t token_cache_limit{100u};
 };
 
 }  // namespace authentication


### PR DESCRIPTION
This is a part of authentication refactoring. Added new
AuthenticationClient constructor using AuthenticationSewttings to
setup network and task scheduler.

Our goal is to remove setters, users should switch to this
constructor, we aim for decoupling this from the TokenEndpoint in
the near future.

Resolves: OLPEDGE-1262

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>