### PR TITLE
Fix some code style rules checked by clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,34 @@
+---
+Language: Cpp
 BasedOnStyle: Google
+
+AccessModifierOffset: -1
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+BinPackParameters: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit: 80
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+DerivePointerAlignment: true
+IndentCaseLabels: true
+IndentWidth: 2
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+PenaltyBreakComment: 300
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceInEmptyParentheses: false
+SpacesInAngles: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false


### PR DESCRIPTION
Due to some difference in clang-format versions, some
sorting and breaking is off.
To avoid this, fix default values in .clang-format file
so that we do not have any surprises.

Relates-To: OLPEDGE-1465

Signed-off-by: Kirill Zhuchkov <kirill.zhuchkov@here.com>