### PR TITLE
Add pretty Gitlab reports for FV tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,14 +38,13 @@ build_test_linux_fv:
     variables:
       - $FULLY
   artifacts:
+    reports:
+      junit:
+      - reports/*.xml
     when: always
     paths:
       - reports
     expire_in: 1 year
-    # reports:
-    # https://gitlab.com/gitlab-org/gitlab-ce/issues/17081
-    # Check this issue status in Gitlab 12.4 (Oct 2019)
-    #   junit: "reports/*.xml"
 
 build_test_nv:
   stage: build


### PR DESCRIPTION
This Gitlab feature was enabled on Gitlab Server recently.
https://docs.gitlab.com/12.7/ee/ci/junit_test_reports.html#viewing-junit-test-reports-on-gitlab

Relates-To: OLPEDGE-1467

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>