### PR TITLE
Wait for background process termination before exiting

### DIFF
--- a/scripts/linux/nv/gitlab_test_performance.sh
+++ b/scripts/linux/nv/gitlab_test_performance.sh
@@ -102,7 +102,7 @@ ls -la ${cache_location}
 #  3. track the disk IO made by SDK
 #  4. track the CPU load
 
-# Gracefully stop local server
-kill -15 ${SERVER_PID}
-# Waiter for server process to be exited correctly
-wait ${SERVER_PID}
+# Termiante the mock server
+kill -TERM $SERVER_PID
+
+wait


### PR DESCRIPTION
After the mock server recieves a termination signal it might take
some time before all its child processes are terminated. So the job
bash script must wait for all background processes to finish their work.

Relates-To: OLPEDGE-1576

Signed-off-by: Kirill Zhuchkov <kirill.zhuchkov@here.com>