### PR TITLE
Add support for X-Correlation-Id

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/HttpResponse.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/HttpResponse.h
@@ -59,7 +59,7 @@ class CORE_API HttpResponse {
    * @param headers Response headers.
    */
   HttpResponse(int status, std::stringstream&& response,
-               http::HeadersType&& headers)
+               http::Headers&& headers)
       : status(status),
         response(std::move(response)),
         headers(std::move(headers)) {}
@@ -94,7 +94,7 @@ class CORE_API HttpResponse {
   /**
    * @brief HTTP headers.
    */
-  http::HeadersType headers;
+  http::Headers headers;
 };
 
 inline void HttpResponse::GetResponse(std::vector<unsigned char>& output) {

--- a/olp-cpp-sdk-core/include/olp/core/http/NetworkRequest.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/NetworkRequest.h
@@ -58,7 +58,7 @@ class CORE_API NetworkRequest final {
    * @brief Get all HTTP headers.
    * @return vector of HTTP headers.
    */
-  const HeadersType& GetHeaders() const;
+  const Headers& GetHeaders() const;
 
   /**
    * @brief Add extra HTTP header.
@@ -126,7 +126,7 @@ class CORE_API NetworkRequest final {
   /// Request URL.
   std::string url_;
   /// HTTP headers.
-  HeadersType headers_;
+  Headers headers_;
   /// Body of HTTP request.
   RequestBodyType body_;
   /// Network settings for this request.

--- a/olp-cpp-sdk-core/include/olp/core/http/NetworkTypes.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/NetworkTypes.h
@@ -132,12 +132,12 @@ CORE_API std::string ErrorCodeToString(ErrorCode code);
 /**
  * @brief Type alias for HTTP header.
  */
-using HeaderPair = std::pair<std::string, std::string>;
+using Header = std::pair<std::string, std::string>;
 
 /**
  * @brief Type alias for vector of HTTP headers.
  */
-using HeadersType = std::vector<HeaderPair>;
+using Headers = std::vector<Header>;
 
 }  // namespace http
 }  // namespace olp

--- a/olp-cpp-sdk-core/include/olp/core/http/NetworkTypes.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/NetworkTypes.h
@@ -130,9 +130,14 @@ class SendOutcome final {
 CORE_API std::string ErrorCodeToString(ErrorCode code);
 
 /**
- * @brief Type alias for HTTP headers.
+ * @brief Type alias for HTTP header.
  */
-using HeadersType = std::vector<std::pair<std::string, std::string>>;
+using HeaderPair = std::pair<std::string, std::string>;
+
+/**
+ * @brief Type alias for vector of HTTP headers.
+ */
+using HeadersType = std::vector<HeaderPair>;
 
 }  // namespace http
 }  // namespace olp

--- a/olp-cpp-sdk-core/src/client/OlpClient.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClient.cpp
@@ -130,7 +130,7 @@ HttpResponse SendRequest(const http::NetworkRequest& request,
   Condition condition{};
   auto response_body = std::make_shared<std::stringstream>();
   http::SendOutcome outcome{http::ErrorCode::CANCELLED_ERROR};
-  http::HeadersType headers;
+  http::Headers headers;
 
   context.ExecuteOrCancelled(
       [&]() {

--- a/olp-cpp-sdk-core/src/http/NetworkRequest.cpp
+++ b/olp-cpp-sdk-core/src/http/NetworkRequest.cpp
@@ -23,7 +23,7 @@ namespace http {
 
 NetworkRequest::NetworkRequest(std::string url) : url_{std::move(url)} {}
 
-const HeadersType& NetworkRequest::GetHeaders() const { return headers_; }
+const Headers& NetworkRequest::GetHeaders() const { return headers_; }
 
 const std::string& NetworkRequest::GetUrl() const { return url_; }
 

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/StreamApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/StreamApi.cpp
@@ -39,11 +39,11 @@
 namespace {
 constexpr auto kLogTag = "read::StreamApi";
 
-void HandleCorrelationId(const olp::http::HeadersType& headers,
+void HandleCorrelationId(const olp::http::Headers& headers,
                          std::string& x_correlation_id) {
   auto it =
       std::find_if(std::begin(headers), std::end(headers),
-                   [&](const olp::http::HeaderPair& header) {
+                   [&](const olp::http::Header& header) {
                      return (header.first.compare("X-Correlation-Id") == 0);
                    });
   if (it != headers.end()) {

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/StreamApi.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/StreamApi.h
@@ -256,6 +256,9 @@ class StreamApi {
       const boost::optional<std::string>& mode,
       const client::CancellationContext& context, const std::string& endpoint,
       std::string& x_correlation_id);
+
+  static bool HandleCorrelationId(const http::HeadersType& headers,
+                                  std::string& x_correlation_id);
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/StreamApi.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/StreamApi.h
@@ -256,9 +256,6 @@ class StreamApi {
       const boost::optional<std::string>& mode,
       const client::CancellationContext& context, const std::string& endpoint,
       std::string& x_correlation_id);
-
-  static bool HandleCorrelationId(const http::HeadersType& headers,
-                                  std::string& x_correlation_id);
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/tests/StreamApiTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/StreamApiTest.cpp
@@ -82,8 +82,8 @@ const std::string kLayerId{"test-layer"};
 const std::string kSerialMode{"serial"};
 const std::string kParallelMode{"parallel"};
 const std::string kCorrelationId{"test-correlation-id"};
-const std::pair<std::string, std::string> kCorrelationIdHeader{
-    "X-Correlation-Id", kCorrelationId};
+const olp::http::HeaderPair kCorrelationIdHeader{"X-Correlation-Id",
+                                                 kCorrelationId};
 
 constexpr auto kUrlSubscribeNoQueryParams =
     R"(https://some.base.url/stream/v2/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2/layers/test-layer/subscribe)";

--- a/olp-cpp-sdk-dataservice-read/tests/StreamApiTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/StreamApiTest.cpp
@@ -173,7 +173,7 @@ TEST_F(StreamApiTest, Subscribe) {
                      _, _, _, _))
         .WillOnce(ReturnHttpResponse(
             http::NetworkResponse().WithStatus(http::HttpStatusCode::CREATED),
-            kHttpResponseSubscribeSucceeds));
+            kHttpResponseSubscribeSucceeds, {kCorrelationIdHeader}));
 
     ConsumerProperties subscription_properties{
         ConsumerOption("field_string", "abc"),
@@ -193,6 +193,7 @@ TEST_F(StreamApiTest, Subscribe) {
     EXPECT_EQ(subscribe_response.GetResult().GetNodeBaseURL(), kNodeBaseUrl);
     EXPECT_EQ(subscribe_response.GetResult().GetSubscriptionId(),
               kSubscriptionId);
+    EXPECT_EQ(x_correlation_id, kCorrelationId);
 
     Mock::VerifyAndClearExpectations(network_mock_.get());
   }
@@ -203,7 +204,7 @@ TEST_F(StreamApiTest, Subscribe) {
                 Send(IsPostRequest(kUrlSubscribeNoQueryParams), _, _, _, _))
         .WillOnce(ReturnHttpResponse(
             http::NetworkResponse().WithStatus(http::HttpStatusCode::FORBIDDEN),
-            kHttpResponseSubscribeFails));
+            kHttpResponseSubscribeFails, {kCorrelationIdHeader}));
 
     olp_client_.SetBaseUrl(kBaseUrl);
     std::string x_correlation_id;
@@ -232,7 +233,7 @@ TEST_F(StreamApiTest, ConsumeData) {
                      _, _, _, _))
         .WillOnce(ReturnHttpResponse(
             http::NetworkResponse().WithStatus(http::HttpStatusCode::OK),
-            kHttpResponseConsumeDataSucceeds));
+            kHttpResponseConsumeDataSucceeds, {kCorrelationIdHeader}));
 
     olp_client_.SetBaseUrl(kNodeBaseUrl);
     std::string x_correlation_id = kCorrelationId;
@@ -244,6 +245,7 @@ TEST_F(StreamApiTest, ConsumeData) {
     EXPECT_TRUE(consume_data_response.IsSuccessful())
         << ApiErrorToString(consume_data_response.GetError());
     EXPECT_EQ(consume_data_response.GetResult().GetMessages().size(), 2);
+    EXPECT_EQ(x_correlation_id, kCorrelationId);
 
     Mock::VerifyAndClearExpectations(network_mock_.get());
   }
@@ -256,7 +258,7 @@ TEST_F(StreamApiTest, ConsumeData) {
                      _, _, _, _))
         .WillOnce(ReturnHttpResponse(
             http::NetworkResponse().WithStatus(http::HttpStatusCode::OK),
-            kHttpResponseConsumeDataSucceeds));
+            kHttpResponseConsumeDataSucceeds, {kCorrelationIdHeader}));
 
     olp_client_.SetBaseUrl(kNodeBaseUrl);
     std::string x_correlation_id = kCorrelationId;
@@ -268,6 +270,7 @@ TEST_F(StreamApiTest, ConsumeData) {
     EXPECT_TRUE(consume_data_response.IsSuccessful())
         << ApiErrorToString(consume_data_response.GetError());
     EXPECT_EQ(consume_data_response.GetResult().GetMessages().size(), 2);
+    EXPECT_EQ(x_correlation_id, kCorrelationId);
 
     Mock::VerifyAndClearExpectations(network_mock_.get());
   }
@@ -295,6 +298,7 @@ TEST_F(StreamApiTest, ConsumeData) {
     EXPECT_EQ(consume_data_response.GetError().GetMessage(),
               kHttpResponseConsumeDataFails);
     EXPECT_EQ(consume_data_response.GetResult().GetMessages().size(), 0);
+    EXPECT_EQ(x_correlation_id, kCorrelationId);
 
     Mock::VerifyAndClearExpectations(network_mock_.get());
   }
@@ -312,7 +316,8 @@ TEST_F(StreamApiTest, CommitOffsets) {
                            BodyEq(kHttpRequestBodyWithStreamOffsets)),
                      _, _, _, _))
         .WillOnce(ReturnHttpResponse(
-            http::NetworkResponse().WithStatus(http::HttpStatusCode::OK), ""));
+            http::NetworkResponse().WithStatus(http::HttpStatusCode::OK), "",
+            {kCorrelationIdHeader}));
 
     olp_client_.SetBaseUrl(kNodeBaseUrl);
     std::string x_correlation_id = kCorrelationId;
@@ -324,6 +329,7 @@ TEST_F(StreamApiTest, CommitOffsets) {
     EXPECT_TRUE(commit_offsets_response.IsSuccessful())
         << ApiErrorToString(commit_offsets_response.GetError());
     EXPECT_EQ(commit_offsets_response.GetResult(), http::HttpStatusCode::OK);
+    EXPECT_EQ(x_correlation_id, kCorrelationId);
 
     Mock::VerifyAndClearExpectations(network_mock_.get());
   }
@@ -336,7 +342,8 @@ TEST_F(StreamApiTest, CommitOffsets) {
                            BodyEq(kHttpRequestBodyWithStreamOffsets)),
                      _, _, _, _))
         .WillOnce(ReturnHttpResponse(
-            http::NetworkResponse().WithStatus(http::HttpStatusCode::OK), ""));
+            http::NetworkResponse().WithStatus(http::HttpStatusCode::OK), "",
+            {kCorrelationIdHeader}));
 
     olp_client_.SetBaseUrl(kNodeBaseUrl);
     std::string x_correlation_id = kCorrelationId;
@@ -348,6 +355,7 @@ TEST_F(StreamApiTest, CommitOffsets) {
     EXPECT_TRUE(commit_offsets_response.IsSuccessful())
         << ApiErrorToString(commit_offsets_response.GetError());
     EXPECT_EQ(commit_offsets_response.GetResult(), http::HttpStatusCode::OK);
+    EXPECT_EQ(x_correlation_id, kCorrelationId);
 
     Mock::VerifyAndClearExpectations(network_mock_.get());
   }
@@ -361,7 +369,7 @@ TEST_F(StreamApiTest, CommitOffsets) {
                      _, _, _, _))
         .WillOnce(ReturnHttpResponse(
             http::NetworkResponse().WithStatus(http::HttpStatusCode::CONFLICT),
-            kHttpResponseCommitOffsetsFails));
+            kHttpResponseCommitOffsetsFails, {kCorrelationIdHeader}));
 
     olp_client_.SetBaseUrl(kNodeBaseUrl);
     std::string x_correlation_id = kCorrelationId;
@@ -375,6 +383,7 @@ TEST_F(StreamApiTest, CommitOffsets) {
               http::HttpStatusCode::CONFLICT);
     EXPECT_EQ(commit_offsets_response.GetError().GetMessage(),
               kHttpResponseCommitOffsetsFails);
+    EXPECT_EQ(x_correlation_id, kCorrelationId);
 
     Mock::VerifyAndClearExpectations(network_mock_.get());
   }
@@ -392,7 +401,8 @@ TEST_F(StreamApiTest, SeekToOffset) {
                            BodyEq(kHttpRequestBodyWithStreamOffsets)),
                      _, _, _, _))
         .WillOnce(ReturnHttpResponse(
-            http::NetworkResponse().WithStatus(http::HttpStatusCode::OK), ""));
+            http::NetworkResponse().WithStatus(http::HttpStatusCode::OK), "",
+            {kCorrelationIdHeader}));
 
     olp_client_.SetBaseUrl(kNodeBaseUrl);
     std::string x_correlation_id = kCorrelationId;
@@ -404,6 +414,7 @@ TEST_F(StreamApiTest, SeekToOffset) {
     EXPECT_TRUE(seek_to_offset_response.IsSuccessful())
         << ApiErrorToString(seek_to_offset_response.GetError());
     EXPECT_EQ(seek_to_offset_response.GetResult(), http::HttpStatusCode::OK);
+    EXPECT_EQ(x_correlation_id, kCorrelationId);
 
     Mock::VerifyAndClearExpectations(network_mock_.get());
   }
@@ -416,7 +427,8 @@ TEST_F(StreamApiTest, SeekToOffset) {
                            BodyEq(kHttpRequestBodyWithStreamOffsets)),
                      _, _, _, _))
         .WillOnce(ReturnHttpResponse(
-            http::NetworkResponse().WithStatus(http::HttpStatusCode::OK), ""));
+            http::NetworkResponse().WithStatus(http::HttpStatusCode::OK), "",
+            {kCorrelationIdHeader}));
 
     olp_client_.SetBaseUrl(kNodeBaseUrl);
     std::string x_correlation_id = kCorrelationId;
@@ -428,6 +440,7 @@ TEST_F(StreamApiTest, SeekToOffset) {
     EXPECT_TRUE(commit_offsets_response.IsSuccessful())
         << ApiErrorToString(commit_offsets_response.GetError());
     EXPECT_EQ(commit_offsets_response.GetResult(), http::HttpStatusCode::OK);
+    EXPECT_EQ(x_correlation_id, kCorrelationId);
 
     Mock::VerifyAndClearExpectations(network_mock_.get());
   }
@@ -441,7 +454,8 @@ TEST_F(StreamApiTest, SeekToOffset) {
                      _, _, _, _))
         .WillOnce(ReturnHttpResponse(http::NetworkResponse().WithStatus(
                                          http::HttpStatusCode::BAD_REQUEST),
-                                     kHttpResponseSeekToOffsetFails));
+                                     kHttpResponseSeekToOffsetFails,
+                                     {kCorrelationIdHeader}));
 
     olp_client_.SetBaseUrl(kNodeBaseUrl);
     std::string x_correlation_id = kCorrelationId;

--- a/olp-cpp-sdk-dataservice-read/tests/StreamApiTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/StreamApiTest.cpp
@@ -82,7 +82,7 @@ const std::string kLayerId{"test-layer"};
 const std::string kSerialMode{"serial"};
 const std::string kParallelMode{"parallel"};
 const std::string kCorrelationId{"test-correlation-id"};
-const olp::http::HeaderPair kCorrelationIdHeader{"X-Correlation-Id",
+const olp::http::Header kCorrelationIdHeader{"X-Correlation-Id",
                                                  kCorrelationId};
 
 constexpr auto kUrlSubscribeNoQueryParams =

--- a/tests/common/mocks/NetworkMock.cpp
+++ b/tests/common/mocks/NetworkMock.cpp
@@ -103,7 +103,8 @@ GenerateNetworkMockActions(std::shared_ptr<std::promise<void>> pre_signal,
 ///
 
 NetworkCallback ReturnHttpResponse(olp::http::NetworkResponse response,
-                                   const std::string& response_body) {
+                                   const std::string& response_body,
+                                   const http::HeadersType& headers) {
   return [=](olp::http::NetworkRequest request,
              olp::http::Network::Payload payload,
              olp::http::Network::Callback callback,
@@ -111,9 +112,13 @@ NetworkCallback ReturnHttpResponse(olp::http::NetworkResponse response,
              olp::http::Network::DataCallback data_callback)
              -> olp::http::SendOutcome {
     std::thread([=]() {
+      for (const auto& header : headers) {
+        header_callback(header.first, header.second);
+      }
       *payload << response_body;
       callback(response);
-    }).detach();
+    })
+        .detach();
 
     constexpr auto unused_request_id = 5;
     return olp::http::SendOutcome(unused_request_id);

--- a/tests/common/mocks/NetworkMock.cpp
+++ b/tests/common/mocks/NetworkMock.cpp
@@ -104,7 +104,7 @@ GenerateNetworkMockActions(std::shared_ptr<std::promise<void>> pre_signal,
 
 NetworkCallback ReturnHttpResponse(olp::http::NetworkResponse response,
                                    const std::string& response_body,
-                                   const http::HeadersType& headers) {
+                                   const http::Headers& headers) {
   return [=](olp::http::NetworkRequest request,
              olp::http::Network::Payload payload,
              olp::http::Network::Callback callback,

--- a/tests/common/mocks/NetworkMock.h
+++ b/tests/common/mocks/NetworkMock.h
@@ -91,7 +91,7 @@ GenerateNetworkMockActions(std::shared_ptr<std::promise<void>> pre_signal,
 
 NetworkCallback ReturnHttpResponse(olp::http::NetworkResponse response,
                                    const std::string& response_body,
-                                   const http::HeadersType& headers = {});
+                                   const http::Headers& headers = {});
 
 }  // namespace common
 }  // namespace tests

--- a/tests/common/mocks/NetworkMock.h
+++ b/tests/common/mocks/NetworkMock.h
@@ -90,7 +90,8 @@ GenerateNetworkMockActions(std::shared_ptr<std::promise<void>> pre_signal,
 ///
 
 NetworkCallback ReturnHttpResponse(olp::http::NetworkResponse response,
-                                   const std::string& response_body);
+                                   const std::string& response_body,
+                                   const http::HeadersType& headers = {});
 
 }  // namespace common
 }  // namespace tests


### PR DESCRIPTION
Get x-corelation-id from http responce  headers.
Modify mock network to return headers.

Relates-To: OLPEDGE-1355

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>