### PR TITLE
Temporary disable functional versioned layer publish tests

### DIFF
--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVersionedLayerClientTest.cpp
@@ -119,7 +119,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, StartBatchInvalid) {
   ASSERT_FALSE(cancel_batch_response.IsSuccessful());
 }
 
-TEST_F(DataserviceWriteVersionedLayerClientTest, StartBatch) {
+TEST_F(DataserviceWriteVersionedLayerClientTest, DISABLED_StartBatch) {
   auto versioned_client = CreateVersionedLayerClient();
   auto response = versioned_client
                       ->StartBatch(StartBatchRequest().WithLayers(
@@ -265,7 +265,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, CancelAllBatch) {
   ASSERT_FALSE(response.IsSuccessful());
 }
 
-TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatch) {
+TEST_F(DataserviceWriteVersionedLayerClientTest, DISABLED_PublishToBatch) {
   auto versioned_client = CreateVersionedLayerClient();
   auto response = versioned_client
                       ->StartBatch(StartBatchRequest().WithLayers(
@@ -328,7 +328,8 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatch) {
             get_batch_response.GetResult().GetDetails()->GetState());
 }
 
-TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatchDeleteClient) {
+TEST_F(DataserviceWriteVersionedLayerClientTest,
+       DISABLED_PublishToBatchDeleteClient) {
   auto versioned_client = CreateVersionedLayerClient();
   auto response = versioned_client
                       ->StartBatch(StartBatchRequest().WithLayers(
@@ -410,7 +411,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatchDeleteClient) {
             get_batch_response.GetResult().GetDetails()->GetState());
 }
 
-TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatchMulti) {
+TEST_F(DataserviceWriteVersionedLayerClientTest, DISABLED_PublishToBatchMulti) {
   auto versioned_client = CreateVersionedLayerClient();
   auto response = versioned_client
                       ->StartBatch(StartBatchRequest().WithLayers(


### PR DESCRIPTION
Temporary disable functional versioned layer publish tests due
to bug in OLP.

Resolves: OLPEDGE-1614

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>