### PR TITLE
Fix compiler warnings

### DIFF
--- a/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
@@ -591,19 +591,13 @@ client::CancellationToken AuthenticationClient::Impl::HandleUserRequest(
           return;
         }
 
-        switch (response_status) {
-          case http::HttpStatusCode::OK: {
-            // Cache the response
-            cache->locked(
-                [credentials,
-                 &response](utils::LruCache<std::string, SignInUserResult>& c) {
-                  return c.InsertOrAssign(credentials.GetKey(), response);
-                });
-          }
-          default:
-            callback(response);
-            break;
+        if (response_status == http::HttpStatusCode::OK) {
+          cache->locked([credentials, &response](
+                            utils::LruCache<std::string, SignInUserResult>& c) {
+            return c.InsertOrAssign(credentials.GetKey(), response);
+          });
         }
+        callback(response);
       });
 
   if (!send_outcome.IsSuccessful()) {

--- a/olp-cpp-sdk-core/src/geo/tiling/TileTreeTraverse.cpp
+++ b/olp-cpp-sdk-core/src/geo/tiling/TileTreeTraverse.cpp
@@ -34,7 +34,7 @@ TileTreeTraverse::NodeContainer TileTreeTraverse::SubNodes(
     const Node& node) const {
   const auto& subdivision = sub_division_scheme_.GetSubdivisionAt(node.Level());
   const unsigned subTileCount = subdivision.Width() * subdivision.Height();
-  const uint16_t subTileMask = ~(~0 << subTileCount);
+  const uint16_t subTileMask = ~(~0u << subTileCount);
 
   return NodeContainer(node, 1, subTileMask);
 }


### PR DESCRIPTION
gcc 5.4 to 7.0 update.
Resolves: OLPEDGE-1638, OLPEDGE-1620.

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>