### PR TITLE
Add support for a list of partitions to GetPartition API

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PartitionsRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PartitionsRequest.h
@@ -43,8 +43,8 @@ class DATASERVICE_READ_API PartitionsRequest final {
 
   /**
    * @brief Sets the list of partitions.
-   * 
-   * When set to boost::none, the GetPartitions method will download the whole
+   *
+   * When the list is empty, the GetPartitions method will download the whole
    * layer metadata. Additionally, a single request supports up to 100
    * partitions.
    *
@@ -52,8 +52,7 @@ class DATASERVICE_READ_API PartitionsRequest final {
    *
    * @return A reference to the updated `PartitionsRequest` instance.
    */
-  inline PartitionsRequest& WithPartitionIds(
-      boost::optional<PartitionIds> partition_ids) {
+  inline PartitionsRequest& WithPartitionIds(PartitionIds partition_ids) {
     partition_ids_ = std::move(partition_ids);
     return *this;
   }
@@ -61,11 +60,9 @@ class DATASERVICE_READ_API PartitionsRequest final {
   /**
    * @brief Gets the list of the partitions.
    *
-   * @return The optional vector of strings that represent partitions.
+   * @return The vector of strings that represent partitions.
    */
-  inline const boost::optional<PartitionIds>& GetPartitionIds() const {
-    return partition_ids_;
-  }
+  inline const PartitionIds& GetPartitionIds() const { return partition_ids_; }
 
   /**
    * @brief Sets the catalog metadata version.
@@ -189,7 +186,7 @@ class DATASERVICE_READ_API PartitionsRequest final {
   }
 
  private:
-  boost::optional<PartitionIds> partition_ids_;
+  PartitionIds partition_ids_;
   boost::optional<int64_t> catalog_version_;
   boost::optional<std::string> billing_tag_;
   FetchOptions fetch_option_{OnlineIfNotFound};

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
@@ -44,10 +44,10 @@ class PartitionsCacheRepository final {
 
   void Put(const PartitionsRequest& request,
            const model::Partitions& partitions, const std::string& layer_id,
-           const boost::optional<time_t>& expiry, bool allLayer = false);
+           const boost::optional<time_t>& expiry, bool layer_metadata = false);
 
   model::Partitions Get(const PartitionsRequest& request,
-                        const std::vector<std::string>& partitionIds,
+                        const std::vector<std::string>& partition_ids,
                         const std::string& layer_id);
 
   boost::optional<model::Partitions> Get(const PartitionsRequest& request,


### PR DESCRIPTION
When the user specifies the list of partitions the query API is used instead of
metadata API. This brings the user functionality to access partitions
metadata of individual partitions.
The implementation checks the cache if the number of requested partitions is
less then the number of partitions found in the cache, the check fails and SDK
performs the online request.

Resolves: OLPEDGE-1017

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>