### PR TITLE
Add MockBinaryResponse method.

### DIFF
--- a/tests/utils/mock-server-client/Expectation.h
+++ b/tests/utils/mock-server-client/Expectation.h
@@ -45,7 +45,7 @@ struct Expectation {
 
   struct BinaryResponse {
     std::string type = "BINARY";
-    std::vector<std::uint8_t> base64_bytes;
+    std::string base64_string;
   };
 
   RequestMatcher request;
@@ -73,7 +73,7 @@ void to_json(const Expectation::BinaryResponse& x, rapidjson::Value& value,
              rapidjson::Document::AllocatorType& allocator) {
   value.SetObject();
   olp::serializer::serialize("type", x.type, value, allocator);
-  olp::serializer::serialize("base64Bytes", x.base64_bytes, value, allocator);
+  olp::serializer::serialize("base64Bytes", x.base64_string, value, allocator);
 }
 
 void to_json(const Expectation::ResponseAction& x, rapidjson::Value& value,


### PR DESCRIPTION
The method can be used for mocking binary responses.

Fix "ambiguous call" compialtion errors.

Relates-To: OAM-188

Signed-off-by: Kirill Zhuchkov <kirill.zhuchkov@here.com>