### PR TITLE
Fix iifinite loop in PrefetchTiles. Add tests with wrong levels for PrefetchTiles.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -69,6 +69,11 @@ SubQuadsRequest PrefetchTilesRepository::EffectiveTileKeys(
   SubQuadsRequest ret;
   auto current_level = tile_key.Level();
 
+  // min/max values was not set. Use default wide range.
+  if (max_level == 0 && min_level == 0) {
+    max_level = geo::TileKey().Level();
+  }
+
   auto AddParents = [&]() {
     auto tile{tile_key.Parent()};
     while (tile.Level() >= min_level && tile.IsValid()) {

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -71,15 +71,16 @@ SubQuadsRequest PrefetchTilesRepository::EffectiveTileKeys(
 
   auto AddParents = [&]() {
     auto tile{tile_key.Parent()};
-    while (tile.Level() >= min_level) {
+    while (tile.Level() >= min_level && tile.IsValid()) {
       if (tile.Level() <= max_level)
         ret[tile.ToHereTile()] = std::make_pair(tile, 0);
       tile = tile.Parent();
     }
   };
 
-  auto AddChildren = [&](const geo::TileKey& tile) {
-    auto child_tiles = EffectiveTileKeys(tile, min_level, max_level, false);
+  auto AddChildren = [&](const geo::TileKey& tile, unsigned int min,
+                         unsigned int max) {
+    auto child_tiles = EffectiveTileKeys(tile, min, max, false);
     for (auto tile : child_tiles) {
       // check if child already exist, if so, use the greater depth
       auto old_child = ret.find(tile.first);
@@ -99,7 +100,7 @@ SubQuadsRequest PrefetchTilesRepository::EffectiveTileKeys(
     // from there
     auto children = GetChildAtLevel(tile_key, min_level);
     for (auto child : children) {
-      AddChildren(child);
+      AddChildren(child, min_level, max_level);
     }
   } else {
     // tile is within min and max
@@ -111,13 +112,14 @@ SubQuadsRequest PrefetchTilesRepository::EffectiveTileKeys(
     if (max_level - current_level <= kMaxQuadTreeIndexDepth) {
       ret[tile_key_str] = std::make_pair(tile_key, max_level - current_level);
     } else {
-      // Backend only takes MAX_QUAD_TREE_INDEX_DEPTH at a time, so we have to
+      // Backend only takes kMaxQuadTreeIndexDepth at a time, so we have to
       // manually calculate all the tiles that should included
       ret[tile_key_str] = std::make_pair(tile_key, kMaxQuadTreeIndexDepth);
       auto children =
           GetChildAtLevel(tile_key, current_level + kMaxQuadTreeIndexDepth + 1);
       for (auto child : children) {
-        AddChildren(child);
+        AddChildren(child, current_level,
+                    current_level + kMaxQuadTreeIndexDepth);
       }
     }
   }
@@ -127,6 +129,9 @@ SubQuadsRequest PrefetchTilesRepository::EffectiveTileKeys(
 
 std::vector<geo::TileKey> PrefetchTilesRepository::GetChildAtLevel(
     const geo::TileKey& tile_key, unsigned int min_level) {
+  if (!tile_key.IsValid()) {
+    return {};
+  }
   if (tile_key.Level() >= min_level) {
     return {tile_key};
   }

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
@@ -280,8 +280,8 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchWrongLevels) {
     std::vector<olp::geo::TileKey> tile_keys = {
         olp::geo::TileKey::FromHereTile(kTileId)};
 
-    SCOPED_TRACE("min/max levels are 0");
     {
+      SCOPED_TRACE("min/max levels are 0");
       auto request = olp::dataservice::read::PrefetchTilesRequest()
                          .WithTileKeys(tile_keys)
                          .WithMinLevel(0)
@@ -307,8 +307,8 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchWrongLevels) {
       ASSERT_EQ(10u, result.size());
     }
 
-    SCOPED_TRACE(" min level greater than max level");
     {
+      SCOPED_TRACE(" min level greater than max level");
       auto request = olp::dataservice::read::PrefetchTilesRequest()
                          .WithTileKeys(tile_keys)
                          .WithMinLevel(-1)
@@ -326,8 +326,8 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchWrongLevels) {
       EXPECT_FALSE(response.IsSuccessful());
       ASSERT_TRUE(response.GetResult().empty());
     }
-    SCOPED_TRACE(" min/max levels are very wide range");
     {
+      SCOPED_TRACE(" min/max levels are very wide range");
       auto request = olp::dataservice::read::PrefetchTilesRequest()
                          .WithTileKeys(tile_keys)
                          .WithMinLevel(0)

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
@@ -280,7 +280,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchWrongLevels) {
     std::vector<olp::geo::TileKey> tile_keys = {
         olp::geo::TileKey::FromHereTile(kTileId)};
 
-    // min/max levels are 0
+    SCOPED_TRACE("min/max levels are 0");
     {
       auto request = olp::dataservice::read::PrefetchTilesRequest()
                          .WithTileKeys(tile_keys)
@@ -296,10 +296,18 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchWrongLevels) {
 
       ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
       PrefetchTilesResponse response = future.get();
-      EXPECT_FALSE(response.IsSuccessful());
-      ASSERT_TRUE(response.GetResult().empty());
+      EXPECT_SUCCESS(response);
+      const auto& result = response.GetResult();
+
+      for (auto tile_result : result) {
+        EXPECT_SUCCESS(*tile_result);
+        ASSERT_TRUE(tile_result->tile_key_.IsValid());
+      }
+
+      ASSERT_EQ(10u, result.size());
     }
-    // min level greater than max level
+
+    SCOPED_TRACE(" min level greater than max level");
     {
       auto request = olp::dataservice::read::PrefetchTilesRequest()
                          .WithTileKeys(tile_keys)
@@ -318,7 +326,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchWrongLevels) {
       EXPECT_FALSE(response.IsSuccessful());
       ASSERT_TRUE(response.GetResult().empty());
     }
-    // max level is very big
+    SCOPED_TRACE(" min/max levels are very wide range");
     {
       auto request = olp::dataservice::read::PrefetchTilesRequest()
                          .WithTileKeys(tile_keys)

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
@@ -263,6 +263,90 @@ TEST_F(DataserviceReadVersionedLayerClientTest, Prefetch) {
   }
 }
 
+TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchWrongLevels) {
+  const auto catalog =
+      olp::client::HRN::FromString(CustomParameters::getArgument(
+          "dataservice_read_test_versioned_prefetch_catalog"));
+  const auto kLayerId = CustomParameters::getArgument(
+      "dataservice_read_test_versioned_prefetch_layer");
+  const auto kTileId = CustomParameters::getArgument(
+      "dataservice_read_test_versioned_prefetch_tile");
+
+  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+      catalog, kLayerId, *settings_);
+
+  {
+    SCOPED_TRACE("Prefetch tiles online and store them in memory cache");
+    std::vector<olp::geo::TileKey> tile_keys = {
+        olp::geo::TileKey::FromHereTile(kTileId)};
+
+    // min/max levels are 0
+    {
+      auto request = olp::dataservice::read::PrefetchTilesRequest()
+                         .WithTileKeys(tile_keys)
+                         .WithMinLevel(0)
+                         .WithMaxLevel(0);
+
+      std::promise<PrefetchTilesResponse> promise;
+      std::future<PrefetchTilesResponse> future = promise.get_future();
+      auto token = client->PrefetchTiles(
+          request, [&promise](PrefetchTilesResponse response) {
+            promise.set_value(std::move(response));
+          });
+
+      ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
+      PrefetchTilesResponse response = future.get();
+      EXPECT_FALSE(response.IsSuccessful());
+      ASSERT_TRUE(response.GetResult().empty());
+    }
+    // min level greater than max level
+    {
+      auto request = olp::dataservice::read::PrefetchTilesRequest()
+                         .WithTileKeys(tile_keys)
+                         .WithMinLevel(-1)
+                         .WithMaxLevel(0);
+
+      std::promise<PrefetchTilesResponse> promise;
+      std::future<PrefetchTilesResponse> future = promise.get_future();
+      auto token = client->PrefetchTiles(
+          request, [&promise](PrefetchTilesResponse response) {
+            promise.set_value(std::move(response));
+          });
+
+      ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
+      PrefetchTilesResponse response = future.get();
+      EXPECT_FALSE(response.IsSuccessful());
+      ASSERT_TRUE(response.GetResult().empty());
+    }
+    // max level is very big
+    {
+      auto request = olp::dataservice::read::PrefetchTilesRequest()
+                         .WithTileKeys(tile_keys)
+                         .WithMinLevel(0)
+                         .WithMaxLevel(-1);
+
+      std::promise<PrefetchTilesResponse> promise;
+      std::future<PrefetchTilesResponse> future = promise.get_future();
+      auto token = client->PrefetchTiles(
+          request, [&promise](PrefetchTilesResponse response) {
+            promise.set_value(std::move(response));
+          });
+
+      ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
+      PrefetchTilesResponse response = future.get();
+      EXPECT_SUCCESS(response);
+      const auto& result = response.GetResult();
+
+      for (auto tile_result : result) {
+        EXPECT_SUCCESS(*tile_result);
+        ASSERT_TRUE(tile_result->tile_key_.IsValid());
+      }
+
+      ASSERT_EQ(10u, result.size());
+    }
+  }
+}
+
 TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchWithCancellableFuture) {
   const auto catalog =
       olp::client::HRN::FromString(CustomParameters::getArgument(

--- a/tests/integration/olp-cpp-sdk-dataservice-read/HttpResponses.h
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/HttpResponses.h
@@ -220,6 +220,9 @@
 #define URL_QUADKEYS_369036 \
   R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/369036/depths/0)"
 
+#define URL_QUADKEYS_1 \
+  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/1/depths/0)"
+
 #define URL_QUERY_PARTITION_23618365 \
   R"(https://query.data.api.platform.here.com/query/v1/catalogs/)"+GetTestCatalog()+R"(/layers/hype-test-prefetch/partitions?partition=23618365&version=4)"
 

--- a/tests/integration/olp-cpp-sdk-dataservice-read/HttpResponses.h
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/HttpResponses.h
@@ -220,9 +220,6 @@
 #define URL_QUADKEYS_369036 \
   R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/369036/depths/0)"
 
-#define URL_QUADKEYS_1 \
-  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/1/depths/0)"
-
 #define URL_QUERY_PARTITION_23618365 \
   R"(https://query.data.api.platform.here.com/query/v1/catalogs/)"+GetTestCatalog()+R"(/layers/hype-test-prefetch/partitions?partition=23618365&version=4)"
 
@@ -264,9 +261,6 @@
 
 #define HTTP_RESPONSE_QUADKEYS_1476147 \
   R"jsonString({"subQuads": [{"version":4,"subQuadKey":"1","dataHandle":"f9a9fd8e-eb1b-48e5-bfdb-4392b3826443"}],"parentQuads": [{"version":4,"partition":"1476147","dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"}]})jsonString"
-
-#define HTTP_RESPONSE_QUADKEYS_1 \
-  R"jsonString({"subQuads": [],"parentQuads": []})jsonString"
 
 #define HTTP_RESPONSE_QUADKEYS_5904591 \
   R"jsonString({"subQuads": [{"version":4,"subQuadKey":"4","dataHandle":"f9a9fd8e-eb1b-48e5-bfdb-4392b3826443"},{"version":4,"subQuadKey":"5","dataHandle":"e119d20e-c7c6-4563-ae88-8aa5c6ca75c3"},{"version":4,"subQuadKey":"6","dataHandle":"a7a1afdf-db7e-4833-9627-d38bee6e2f81"},{"version":4,"subQuadKey":"7","dataHandle":"9d515348-afce-44e8-bc6f-3693cfbed104"},{"version":4,"subQuadKey":"1","dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": [{"version":4,"partition":"1476147","dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"}]})jsonString"

--- a/tests/integration/olp-cpp-sdk-dataservice-read/HttpResponses.h
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/HttpResponses.h
@@ -265,6 +265,9 @@
 #define HTTP_RESPONSE_QUADKEYS_1476147 \
   R"jsonString({"subQuads": [{"version":4,"subQuadKey":"1","dataHandle":"f9a9fd8e-eb1b-48e5-bfdb-4392b3826443"}],"parentQuads": [{"version":4,"partition":"1476147","dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"}]})jsonString"
 
+#define HTTP_RESPONSE_QUADKEYS_1 \
+  R"jsonString({"subQuads": [],"parentQuads": []})jsonString"
+
 #define HTTP_RESPONSE_QUADKEYS_5904591 \
   R"jsonString({"subQuads": [{"version":4,"subQuadKey":"4","dataHandle":"f9a9fd8e-eb1b-48e5-bfdb-4392b3826443"},{"version":4,"subQuadKey":"5","dataHandle":"e119d20e-c7c6-4563-ae88-8aa5c6ca75c3"},{"version":4,"subQuadKey":"6","dataHandle":"a7a1afdf-db7e-4833-9627-d38bee6e2f81"},{"version":4,"subQuadKey":"7","dataHandle":"9d515348-afce-44e8-bc6f-3693cfbed104"},{"version":4,"subQuadKey":"1","dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": [{"version":4,"partition":"1476147","dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"}]})jsonString"
 

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -216,7 +216,7 @@ class DataserviceReadVersionedLayerClientTest : public ::testing::Test {
         .WillByDefault(
             ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                    olp::http::HttpStatusCode::OK),
-                               HTTP_RESPONSE_QUADKEYS_5904591));
+                               HTTP_RESPONSE_QUADKEYS_1));
 
     ON_CALL(*network_mock_,
             Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_1), _, _, _, _))
@@ -1614,8 +1614,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesWithCache) {
   }
 }
 
-TEST_F(DataserviceReadVersionedLayerClientTest,
-       PrefetchTilesWithCancellableFutureWrongLevels) {
+TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesWrongLevels) {
   olp::client::HRN catalog(GetTestCatalog());
   constexpr auto kLayerId = "hype-test-prefetch";
 
@@ -1636,15 +1635,10 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
 
   ASSERT_NE(raw_future.wait_for(kWaitTimeout), std::future_status::timeout);
   PrefetchTilesResponse response = raw_future.get();
-  ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
-  ASSERT_FALSE(response.GetResult().empty());
-
-  const auto& result = response.GetResult();
-  for (auto tile_result : result) {
-    ASSERT_TRUE(tile_result->IsSuccessful())
-        << tile_result->GetError().GetMessage();
-    ASSERT_TRUE(tile_result->tile_key_.IsValid());
-  }
+  ASSERT_FALSE(response.IsSuccessful());
+  ASSERT_EQ(olp::client::ErrorCode::InvalidArgument,
+            response.GetError().GetErrorCode());
+  ASSERT_TRUE(response.GetResult().empty());
 }
 
 TEST_F(DataserviceReadVersionedLayerClientTest,


### PR DESCRIPTION
Add tests for PrefetchTiles with different min/max levels. 
Fix infinite recursion by adding checks for valid TileKey value. 
Reduce min/max level to current level, current level+depth(depth is 4).

Relates-To: OLPEDGE-1624

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>