### PR TITLE
Update VersionedLayerClient example and doxygen.

### DIFF
--- a/examples/Options.h
+++ b/examples/Options.h
@@ -36,6 +36,11 @@ const Option kKeySecretOption{"-s", "--key_secret",
 const Option kCatalogOption{"-c", "--catalog",
                             "Catalog HRN (HERE Resource Name)."};
 
+const Option kCatalogVersionOption{
+    "-v", "--catalog_version",
+    "The version of the catalog from which you wan to "
+    "get data(used in read example, optional)."};
+
 const Option kLayerIdOption{"-l", "--layer_id",
                             "The layer ID inside the catalog where you want to "
                             "publish data to(required for write example)."};

--- a/examples/ReadExample.cpp
+++ b/examples/ReadExample.cpp
@@ -118,7 +118,8 @@ bool HandleDataResponse(
 }
 }  // namespace
 
-int RunExampleRead(const AccessKey& access_key, const std::string& catalog) {
+int RunExampleRead(const AccessKey& access_key, const std::string& catalog,
+                   const boost::optional<int64_t>& catalog_version) {
   // Create a task scheduler instance
   std::shared_ptr<olp::thread::TaskScheduler> task_scheduler =
       olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler(1u);
@@ -174,9 +175,10 @@ int RunExampleRead(const AccessKey& access_key, const std::string& catalog) {
     first_layer_id = HandleCatalogResponse(catalog_response);
   }
 
-  // Create appropriate layer client with HRN, layer name and settings.
+  // Create appropriate layer client with HRN, layer name, version and settings.
   olp::dataservice::read::VersionedLayerClient layer_client(
-      olp::client::HRN(catalog), first_layer_id, client_settings);
+      olp::client::HRN(catalog), first_layer_id, catalog_version,
+      client_settings);
 
   std::string first_partition_id;
   if (!first_layer_id.empty()) {

--- a/examples/ReadExample.h
+++ b/examples/ReadExample.h
@@ -21,12 +21,18 @@
 
 #include "Examples.h"
 
+#include <boost/optional.hpp>
+
 /**
  * @brief Dataservice read example. Authenticate client using access key id and
  * secret. Get catalog and partition metadata, as well as partition data using
  * the HERE Open Location Platform.
  * @param access_key here.access.key.id and here.access.key.secret.
- * @param The HERE Resource Name (HRN) of the catalog from which you want to read data.
+ * @param catalog The HERE Resource Name (HRN) of the catalog from which you
+ * want to read data.
+ * @param catalog_version The desired version of the catalog.
  * @return result of publish data(0 - if succeed)
  */
-int RunExampleRead(const AccessKey& access_key, const std::string& catalog);
+int RunExampleRead(
+    const AccessKey& access_key, const std::string& catalog,
+    const boost::optional<int64_t>& catalog_version = boost::none);

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -76,9 +76,9 @@ class VersionedLayerClientImpl;
  * client_settings.task_scheduler = std::move(task_scheduler);
  * client_settings.network_request_handler = std::move(http_client);
  *
- * VersionedLayerClient client{"hrn:here:data:::your-catalog-hrn", "your-layer-id", client_settings};
+ * VersionedLayerClient client{"hrn:here:data:::your-catalog-hrn", "your-layer-id", "catalog-version", client_settings};
  * auto callback = [](olp::client::ApiResponse<olp::model::Data, olp::client::ApiError> response) {};
- * auto request = DataRequest().WithVersion(100).WithPartitionId("269");
+ * auto request = DataRequest().WithPartitionId("269");
  * auto token = client.GetData(request, callback);
  * @endcode
  *


### PR DESCRIPTION
VersionedLayerClient API is changed, version is specified in constructor
instead of DataRequest now. So the goal of this change is to adapt
example and doxygen to the new API. Added new argument for catalog
version.

Resolves: OLPEDGE-1566

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>