### PR TITLE
Expose introspect app API

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
@@ -26,6 +26,7 @@
 #include <string>
 
 #include <olp/authentication/AuthenticationSettings.h>
+#include <olp/authentication/Types.h>
 #include <olp/core/client/ApiResponse.h>
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/http/NetworkProxySettings.h>
@@ -584,6 +585,23 @@ class AUTHENTICATION_API AuthenticationClient {
       const AuthenticationCredentials& credentials,
       const std::string& user_access_token,
       const SignOutUserCallback& callback);
+
+  /**
+   * @brief Retrieves the application associated with the client access token.
+   *
+   * The application does not need permissions to access this endpoint.
+   * It will allow any client access token to retrieve its own information.
+   *
+   * @param access_token A valid access token that is associated with the
+   * application.
+   * @param callback The`IntrospectAppCallback` method that is called when
+   * the client introspect request is completed.
+   *
+   * @return The `CancellationToken` instance that can be used to cancel
+   * the request.
+   */
+  client::CancellationToken IntrospectApp(std::string access_token,
+                                          IntrospectAppCallback callback);
 
   /**
    * @brief Sets the `NetworkProxySettings` instance used by the underlying

--- a/olp-cpp-sdk-authentication/include/olp/authentication/IntrospectAppResult.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/IntrospectAppResult.h
@@ -121,8 +121,6 @@ class AUTHENTICATION_API IntrospectAppResult {
   /**
    * @brief Token endpoint authentication method.
    *
-   * The default value will be "client_secret_jwt".
-   *
    * @return The token endpoint authentication method.
    */
   const std::string& GetTokenEndpointAuthMethod() const {

--- a/olp-cpp-sdk-authentication/include/olp/authentication/Types.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/Types.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <olp/authentication/AuthenticationError.h>
+#include <olp/authentication/IntrospectAppResult.h>
+#include <olp/core/client/ApiError.h>
+#include <olp/core/client/ApiResponse.h>
+
+namespace olp {
+namespace authentication {
+
+/// The response template type.
+template <typename ResultType>
+using Response = client::ApiResponse<ResultType, AuthenticationError>;
+
+/// The callback template type.
+template <typename ResultType>
+using Callback = std::function<void(Response<ResultType>)>;
+
+/// Defines the callback signature when the user request is completed.
+using IntrospectAppResponse = Response<IntrospectAppResult>;
+
+/// Called when the user introspect app request is completed.
+using IntrospectAppCallback = Callback<IntrospectAppResult>;
+
+}  // namespace authentication
+}  // namespace olp

--- a/olp-cpp-sdk-authentication/src/Constants.cpp
+++ b/olp-cpp-sdk-authentication/src/Constants.cpp
@@ -32,5 +32,27 @@ const unsigned int Constants::INVALID_DATA_ERROR_CODE = 400200;
 const char* Constants::ACCESS_TOKEN = "accessToken";
 const char* Constants::EXPIRES_IN = "expiresIn";
 const char* Constants::REFRESH_TOKEN = "refreshToken";
+
+const char* Constants::CLIENT_ID = "clientId";
+const char* Constants::NAME = "name";
+const char* Constants::DESCRIPTION = "description";
+const char* Constants::REDIRECT_URIS = "redirectUris";
+const char* Constants::ALLOWED_SCOPES = "allowedScopes";
+const char* Constants::TOKEN_ENDPOINT_AUTH_METHOD = "tokenEndpointAuthMethod";
+const char* Constants::TOKEN_ENDPOINT_AUTH_METHOD_REASON =
+    "tokenEndpointAuthMethodReason";
+const char* Constants::DOB_REQUIRED = "dobRequired";
+const char* Constants::TOKEN_DURATION = "tokenDuration";
+const char* Constants::REFERRERS = "referrers";
+const char* Constants::STATUS = "status";
+const char* Constants::APP_CODE_ENABLED = "appCodeEnabled";
+const char* Constants::CREATED_TIME = "createdTime";
+const char* Constants::REALM = "realm";
+const char* Constants::TYPE = "type";
+const char* Constants::RESPONSE_TYPES = "responseTypes";
+const char* Constants::TIER = "tier";
+const char* Constants::HRN = "hrn";
+const char* Constants::MESSAGE = "message";
+
 }  // namespace authentication
 }  // namespace olp

--- a/olp-cpp-sdk-authentication/src/Constants.h
+++ b/olp-cpp-sdk-authentication/src/Constants.h
@@ -36,6 +36,27 @@ class Constants {
   static const char* ACCESS_TOKEN;
   static const char* EXPIRES_IN;
   static const char* REFRESH_TOKEN;
+
+  // introspect app strings
+  static const char* CLIENT_ID;
+  static const char* NAME;
+  static const char* DESCRIPTION;
+  static const char* REDIRECT_URIS;
+  static const char* ALLOWED_SCOPES;
+  static const char* TOKEN_ENDPOINT_AUTH_METHOD;
+  static const char* TOKEN_ENDPOINT_AUTH_METHOD_REASON;
+  static const char* DOB_REQUIRED;
+  static const char* TOKEN_DURATION;
+  static const char* REFERRERS;
+  static const char* STATUS;
+  static const char* APP_CODE_ENABLED;
+  static const char* CREATED_TIME;
+  static const char* REALM;
+  static const char* TYPE;
+  static const char* RESPONSE_TYPES;
+  static const char* TIER;
+  static const char* HRN;
+  static const char* MESSAGE;
 };
 
 }  // namespace authentication

--- a/tests/integration/olp-cpp-sdk-authentication/AuthenticationMockedResponses.h
+++ b/tests/integration/olp-cpp-sdk-authentication/AuthenticationMockedResponses.h
@@ -104,3 +104,9 @@ const std::string kResponseErrorFields = R"JSON(
 const std::string kSignupHereUserResponse = R"JSON(
     {"userId": "HERE-5fa10eda-39ff-4cbc-9b0c-5acba4685649"}
     )JSON";
+const std::string kIntrospectAppResponse = R"JSON(
+    {"clientId": "DdcIHVVKuMvTQrdci1FW", "name": "My Third Party App", "description": "This is a longer description of My Third Party App.", "redirectUris": [ "https://www.example.com", "https://qa.example.com" ], "allowedScopes": [ "email", "profile" ], "tokenEndpointAuthMethod": "client_secret_jwt", "tokenEndpointAuthMethodReason": "Here's the reason why client_secret_jwt was not used.", "dobRequired": false, "tokenDuration": 3600, "referrers": [ "localhost", "127.0.0.1", "www.facebook.com/hello/world/" ], "status": "active", "appCodeEnabled": true, "createdTime": 1432216394712, "realm": "HERE", "type": "application", "responseTypes": [ "code" ], "tier": "olp_tier_50k", "hrn": "hrn:here:account::HERE:app/DdcIHVVKuMvTQrdci1FW"}    
+    )JSON";
+const std::string kInvalidAccessTokenResponse = R"JSON(
+    {"errorId":"ERROR-cf976ca6-bf6e-44f7-a9e6-e271766c61fe","httpStatus":401,"errorCode":400601,"message":"Invalid accessToken.","error":"invalid_request","error_description":"errorCode: '400601'. Invalid accessToken."}
+    )JSON";


### PR DESCRIPTION
Added new IntrospectApp method for AuthenticationClient. Now it's
possible to obtain application info like name, description, realm etc.
using access token.
Functional and integration tests added also.

Resolves: OLPEDGE-1489

Signed-off-by: Kostiantyn Zvieriev ext-kostiantyn.zvieriev@here.com