### PR TITLE
Fix codecoverage precision,exclude examples

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 coverage:
   range: 60..100
-  round: down
+  round: nearest
   precision: 1
   status:
     project:
@@ -40,4 +40,8 @@ ignore:
   - olp-cpp-sdk-dataservice-write/src/FlushEventListener.h
   - olp-cpp-sdk-dataservice-write/src/FlushMetrics.h
   - tests
-  - testutils
+  - scripts
+  - examples
+  - docs
+  - external
+


### PR DESCRIPTION
Due to unstable work on CodeCov tool and precission
issues we need to exclude more folders from scanner:
  - scripts
  - examples
  - docs
  - external

Relates-TO: OLPEDGE-1657

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>