### PR TITLE
Fix the flaky condition.

### DIFF
--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVersionedLayerClientTest.cpp
@@ -146,15 +146,6 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, StartBatch) {
           .get();
   EXPECT_SUCCESS(complete_batch_response);
 
-  get_batch_response =
-      versioned_client->GetBatch(response.GetResult()).GetFuture().get();
-
-  EXPECT_SUCCESS(get_batch_response);
-  ASSERT_EQ(response.GetResult().GetId().value(),
-            get_batch_response.GetResult().GetId().value());
-  ASSERT_EQ("submitted",
-            get_batch_response.GetResult().GetDetails()->GetState());
-
   for (int i = 0; i < 100; ++i) {
     get_batch_response =
         versioned_client->GetBatch(response.GetResult()).GetFuture().get();


### PR DESCRIPTION
Fix the flaky condition in DataserviceWriteVersionedLayerClientTest.StartBatch test.

Resolves: OLPEDGE-1653

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>