### PR TITLE
Make CacheWithUpdate option unsuported for VersionedLayerClient.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/FetchOptions.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/FetchOptions.h
@@ -43,6 +43,7 @@ enum FetchOptions {
   /**
    * Returns the requested cached resource if it is found and updates the cache
    * in the background.
+   * @note Do not Use for versioned layer client requests.
    */
   CacheWithUpdate
 };

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -164,9 +164,7 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    *
    * @param data_request The `DataRequest` instance that contains a complete set
    * of request parameters.
-   * @note The `GetLayerId` value of the \c DataRequest object is ignored, and
-   * the parameter from the constructor is used instead. CacheWithUpdate fetch
-   * option is not suported.
+   * @note CacheWithUpdate fetch option is not suported.
    * @param callback The `DataResponseCallback` object that is invoked if
    * the `DataResult` object is available or an error is encountered.
    *
@@ -186,9 +184,7 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    *
    * @param data_request The `DataRequest` instance that contains a complete set
    * of request parameters.
-   * @note The `GetLayerId` value of the \c DataRequest object is ignored, and
-   * the parameter from the constructor is used instead. CacheWithUpdate fetch
-   * option is not suported.
+   * @note CacheWithUpdate fetch option is not suported.
    *
    * @return `CancellableFuture` that contains the `DataResponse` instance
    * or an error. You can also use `CancellableFuture` to cancel this request.
@@ -251,9 +247,7 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    *
    * @param partitions_request The `PartitionsRequest` instance that contains
    * a complete set of request parameters.
-   * @note The `GetLayerId` value of the \c PartitionsRequest object is ignored,
-   * and the parameter from the constructor is used instead. CacheWithUpdate
-   * fetch option is not suported.
+   * @note CacheWithUpdate fetch option is not suported.
    * @param callback The `PartitionsResponseCallback` object that is invoked if
    * the list of partitions is available or an error is encountered.
    *
@@ -272,9 +266,7 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    *
    * @param partitions_request The `PartitionsRequest` instance that contains
    * a complete set of request parameters.
-   * @note The `GetLayerId` value of the \c PartitionsRequest object is ignored,
-   * and the parameter from the constructor is used instead. CacheWithUpdate
-   * fetch option is not suported.
+   * @note CacheWithUpdate fetch option is not suported.
    *
    * @return `CancellableFuture` that contains the `PartitionsResponse` instance
    * with data or an error. You can also use `CancellableFuture` to cancel this
@@ -296,8 +288,6 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    *
    * @param request The `PrefetchTilesRequest` instance that contains
    * a complete set of request parameters.
-   * @note The `GetLayerId` value of the \c PrefetchTilesRequest object is
-   * ignored, and the parameter from the constructor is used instead.
    * @param callback The `PrefetchTilesResponseCallback` object that is invoked
    * if the `PrefetchTilesResult` instance is available or an error is
    * encountered.
@@ -320,8 +310,6 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    *
    * @param request The `PrefetchTilesRequest` instance that contains
    * a complete set of request parameters.
-   * @note The `GetLayerId` value of the \c PrefetchTilesRequest object is
-   * ignored, and the parameter from the constructor is used instead.
    *
    * @return `CancellableFuture` that contains the `PrefetchTilesResponse`
    * instance with data or an error. You can also use `CancellableFuture` to

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -165,7 +165,8 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    * @param data_request The `DataRequest` instance that contains a complete set
    * of request parameters.
    * @note The `GetLayerId` value of the \c DataRequest object is ignored, and
-   * the parameter from the constructor is used instead.
+   * the parameter from the constructor is used instead. CacheWithUpdate fetch
+   * option is not suported.
    * @param callback The `DataResponseCallback` object that is invoked if
    * the `DataResult` object is available or an error is encountered.
    *
@@ -186,7 +187,8 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    * @param data_request The `DataRequest` instance that contains a complete set
    * of request parameters.
    * @note The `GetLayerId` value of the \c DataRequest object is ignored, and
-   * the parameter from the constructor is used instead.
+   * the parameter from the constructor is used instead. CacheWithUpdate fetch
+   * option is not suported.
    *
    * @return `CancellableFuture` that contains the `DataResponse` instance
    * or an error. You can also use `CancellableFuture` to cancel this request.
@@ -209,6 +211,7 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    *
    * @param request The `TileRequest` instance that contains a complete set
    * of request parameters.
+   * @note CacheWithUpdate fetch option is not suported.
    * @param callback The `DataResponseCallback` object that is invoked if
    * the `DataResult` object is available or an error is encountered.
    *
@@ -232,6 +235,7 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    *
    * @param request The `TileRequest` instance that contains a complete set
    * of request parameters.
+   * @note CacheWithUpdate fetch option is not suported.
    *
    * @return `CancellableFuture` that contains the `DataResponse` instance
    * or an error. You can also use `CancellableFuture` to cancel this request.
@@ -248,7 +252,8 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    * @param partitions_request The `PartitionsRequest` instance that contains
    * a complete set of request parameters.
    * @note The `GetLayerId` value of the \c PartitionsRequest object is ignored,
-   * and the parameter from the constructor is used instead.
+   * and the parameter from the constructor is used instead. CacheWithUpdate
+   * fetch option is not suported.
    * @param callback The `PartitionsResponseCallback` object that is invoked if
    * the list of partitions is available or an error is encountered.
    *
@@ -268,7 +273,8 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    * @param partitions_request The `PartitionsRequest` instance that contains
    * a complete set of request parameters.
    * @note The `GetLayerId` value of the \c PartitionsRequest object is ignored,
-   * and the parameter from the constructor is used instead.
+   * and the parameter from the constructor is used instead. CacheWithUpdate
+   * fetch option is not suported.
    *
    * @return `CancellableFuture` that contains the `PartitionsResponse` instance
    * with data or an error. You can also use `CancellableFuture` to cancel this

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -74,6 +74,16 @@ client::CancellationToken VersionedLayerClientImpl::GetPartitions(
                         "VersionedLayerClient constructor to specify version");
   }
 
+  if (request.GetFetchOption() == CacheWithUpdate) {
+    auto task = [](client::CancellationContext) -> PartitionsResponse {
+      return {{client::ErrorCode::InvalidArgument,
+               "CacheWithUpdate option can not be used for versioned "
+               "layer"}};
+    };
+    return AddTask(settings_.task_scheduler, pending_requests_, std::move(task),
+                   std::move(callback));
+  }
+
   auto schedule_get_partitions = [&](PartitionsRequest request,
                                      PartitionsResponseCallback callback) {
     auto catalog = catalog_;
@@ -97,16 +107,6 @@ client::CancellationToken VersionedLayerClientImpl::GetPartitions(
                    std::move(partitions_task), std::move(callback));
   };
 
-  if (request.GetFetchOption() == CacheWithUpdate) {
-    auto task = [=](client::CancellationContext) -> PartitionsResponse {
-      return {{client::ErrorCode::InvalidArgument,
-               "CacheWithUpdate option can not be used for versioned "
-               "layer."}};
-    };
-    return AddTask(settings_.task_scheduler, pending_requests_, std::move(task),
-                   std::move(callback));
-  }
-
   return ScheduleFetch(std::move(schedule_get_partitions), std::move(request),
                        std::move(callback));
 }
@@ -128,6 +128,16 @@ client::CancellationToken VersionedLayerClientImpl::GetData(
     OLP_SDK_LOG_WARNING(kLogTag,
                         "DataRequest::WithVersion() is deprecated. Use "
                         "VersionedLayerClient constructor to specify version");
+  }
+
+  if (request.GetFetchOption() == CacheWithUpdate) {
+    auto task = [](client::CancellationContext) -> DataResponse {
+      return {{client::ErrorCode::InvalidArgument,
+               "CacheWithUpdate option can not be used for versioned "
+               "layer"}};
+    };
+    return AddTask(settings_.task_scheduler, pending_requests_, std::move(task),
+                   std::move(callback));
   }
 
   auto schedule_get_data = [&](DataRequest request,
@@ -156,15 +166,6 @@ client::CancellationToken VersionedLayerClientImpl::GetData(
                    std::move(data_task), std::move(callback));
   };
 
-  if (request.GetFetchOption() == CacheWithUpdate) {
-    auto task = [=](client::CancellationContext) -> DataResponse {
-      return {{client::ErrorCode::InvalidArgument,
-               "CacheWithUpdate option can not be used for versioned "
-               "layer."}};
-    };
-    return AddTask(settings_.task_scheduler, pending_requests_, std::move(task),
-                   std::move(callback));
-  }
   return ScheduleFetch(std::move(schedule_get_data), std::move(request),
                        std::move(callback));
 }
@@ -398,6 +399,16 @@ CatalogVersionResponse VersionedLayerClientImpl::GetVersion(
 
 client::CancellationToken VersionedLayerClientImpl::GetData(
     TileRequest request, DataResponseCallback callback) {
+  if (request.GetFetchOption() == CacheWithUpdate) {
+    auto task = [](client::CancellationContext) -> DataResponse {
+      return {{client::ErrorCode::InvalidArgument,
+               "CacheWithUpdate option can not be used for versioned "
+               "layer"}};
+    };
+    return AddTask(settings_.task_scheduler, pending_requests_, std::move(task),
+                   std::move(callback));
+  }
+
   auto schedule_get_data = [&](TileRequest request,
                                DataResponseCallback callback) {
     auto catalog = catalog_;
@@ -421,16 +432,6 @@ client::CancellationToken VersionedLayerClientImpl::GetData(
     return AddTask(settings.task_scheduler, pending_requests,
                    std::move(data_task), std::move(callback));
   };
-
-  if (request.GetFetchOption() == CacheWithUpdate) {
-    auto task = [=](client::CancellationContext) -> DataResponse {
-      return {{client::ErrorCode::InvalidArgument,
-               "CacheWithUpdate option can not be used for versioned "
-               "layer."}};
-    };
-    return AddTask(settings_.task_scheduler, pending_requests_, std::move(task),
-                   std::move(callback));
-  }
 
   return ScheduleFetch(std::move(schedule_get_data), std::move(request),
                        std::move(callback));

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -98,19 +98,13 @@ client::CancellationToken VersionedLayerClientImpl::GetPartitions(
   };
 
   if (request.GetFetchOption() == CacheWithUpdate) {
-    request.WithFetchOption(FetchOptions::OnlineIfNotFound);
-    return ScheduleFetch(
-        [&](PartitionsRequest, PartitionsResponseCallback callback) {
-          return AddTask(
-              settings_.task_scheduler, pending_requests_,
-              [=](client::CancellationContext) -> PartitionsResponse {
-                return {{client::ErrorCode::InvalidArgument,
-                         "CacheWithUpdate option can not be used for versioned "
-                         "layer."}};
-              },
-              std::move(callback));
-        },
-        std::move(request), std::move(callback));
+    auto task = [=](client::CancellationContext) -> PartitionsResponse {
+      return {{client::ErrorCode::InvalidArgument,
+               "CacheWithUpdate option can not be used for versioned "
+               "layer."}};
+    };
+    return AddTask(settings_.task_scheduler, pending_requests_, std::move(task),
+                   std::move(callback));
   }
 
   return ScheduleFetch(std::move(schedule_get_partitions), std::move(request),
@@ -163,19 +157,13 @@ client::CancellationToken VersionedLayerClientImpl::GetData(
   };
 
   if (request.GetFetchOption() == CacheWithUpdate) {
-    request.WithFetchOption(FetchOptions::OnlineIfNotFound);
-    return ScheduleFetch(
-        [&](DataRequest, DataResponseCallback callback) {
-          return AddTask(
-              settings_.task_scheduler, pending_requests_,
-              [=](client::CancellationContext) -> DataResponse {
-                return {{client::ErrorCode::InvalidArgument,
-                         "CacheWithUpdate option can not be used for versioned "
-                         "layer."}};
-              },
-              std::move(callback));
-        },
-        std::move(request), std::move(callback));
+    auto task = [=](client::CancellationContext) -> DataResponse {
+      return {{client::ErrorCode::InvalidArgument,
+               "CacheWithUpdate option can not be used for versioned "
+               "layer."}};
+    };
+    return AddTask(settings_.task_scheduler, pending_requests_, std::move(task),
+                   std::move(callback));
   }
   return ScheduleFetch(std::move(schedule_get_data), std::move(request),
                        std::move(callback));
@@ -435,19 +423,13 @@ client::CancellationToken VersionedLayerClientImpl::GetData(
   };
 
   if (request.GetFetchOption() == CacheWithUpdate) {
-    request.WithFetchOption(FetchOptions::OnlineIfNotFound);
-    return ScheduleFetch(
-        [&](TileRequest, DataResponseCallback callback) {
-          return AddTask(
-              settings_.task_scheduler, pending_requests_,
-              [=](client::CancellationContext) -> DataResponse {
-                return {{client::ErrorCode::InvalidArgument,
-                         "CacheWithUpdate option can not be used for versioned "
-                         "layer."}};
-              },
-              std::move(callback));
-        },
-        std::move(request), std::move(callback));
+    auto task = [=](client::CancellationContext) -> DataResponse {
+      return {{client::ErrorCode::InvalidArgument,
+               "CacheWithUpdate option can not be used for versioned "
+               "layer."}};
+    };
+    return AddTask(settings_.task_scheduler, pending_requests_, std::move(task),
+                   std::move(callback));
   }
 
   return ScheduleFetch(std::move(schedule_get_data), std::move(request),

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -97,6 +97,22 @@ client::CancellationToken VersionedLayerClientImpl::GetPartitions(
                    std::move(partitions_task), std::move(callback));
   };
 
+  if (request.GetFetchOption() == CacheWithUpdate) {
+    request.WithFetchOption(FetchOptions::OnlineIfNotFound);
+    return ScheduleFetch(
+        [&](PartitionsRequest, PartitionsResponseCallback callback) {
+          return AddTask(
+              settings_.task_scheduler, pending_requests_,
+              [=](client::CancellationContext) -> PartitionsResponse {
+                return {{client::ErrorCode::InvalidArgument,
+                         "CacheWithUpdate option can not be used for versioned "
+                         "layer."}};
+              },
+              std::move(callback));
+        },
+        std::move(request), std::move(callback));
+  }
+
   return ScheduleFetch(std::move(schedule_get_partitions), std::move(request),
                        std::move(callback));
 }
@@ -145,6 +161,22 @@ client::CancellationToken VersionedLayerClientImpl::GetData(
     return AddTask(settings.task_scheduler, pending_requests_,
                    std::move(data_task), std::move(callback));
   };
+
+  if (request.GetFetchOption() == CacheWithUpdate) {
+    request.WithFetchOption(FetchOptions::OnlineIfNotFound);
+    return ScheduleFetch(
+        [&](DataRequest, DataResponseCallback callback) {
+          return AddTask(
+              settings_.task_scheduler, pending_requests_,
+              [=](client::CancellationContext) -> DataResponse {
+                return {{client::ErrorCode::InvalidArgument,
+                         "CacheWithUpdate option can not be used for versioned "
+                         "layer."}};
+              },
+              std::move(callback));
+        },
+        std::move(request), std::move(callback));
+  }
   return ScheduleFetch(std::move(schedule_get_data), std::move(request),
                        std::move(callback));
 }
@@ -401,6 +433,22 @@ client::CancellationToken VersionedLayerClientImpl::GetData(
     return AddTask(settings.task_scheduler, pending_requests,
                    std::move(data_task), std::move(callback));
   };
+
+  if (request.GetFetchOption() == CacheWithUpdate) {
+    request.WithFetchOption(FetchOptions::OnlineIfNotFound);
+    return ScheduleFetch(
+        [&](TileRequest, DataResponseCallback callback) {
+          return AddTask(
+              settings_.task_scheduler, pending_requests_,
+              [=](client::CancellationContext) -> DataResponse {
+                return {{client::ErrorCode::InvalidArgument,
+                         "CacheWithUpdate option can not be used for versioned "
+                         "layer."}};
+              },
+              std::move(callback));
+        },
+        std::move(request), std::move(callback));
+  }
 
   return ScheduleFetch(std::move(schedule_get_data), std::move(request),
                        std::move(callback));

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
@@ -352,13 +352,10 @@ PartitionsResponse PartitionsRepository::QueryPartitionForVersionedTile(
       result.SetPartitions({partitions.GetMutablePartitions().back()});
     }
   }
-
-  if (fetch_option != OnlineOnly) {
     // add partitions to cache
     repository::PartitionsCacheRepository repository(catalog, settings.cache);
     repository.Put(PartitionsRequest().WithVersion(version), partitions,
                    layer_id, boost::none);
-  }
 
   if (result.GetPartitions().size() == 0) {
     return ApiError(ErrorCode::NotFound,

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
@@ -307,7 +307,6 @@ PartitionsResponse PartitionsRepository::QueryPartitionForVersionedTile(
     const client::HRN& catalog, const std::string& layer_id,
     const TileRequest& request, int64_t version,
     client::CancellationContext context, client::OlpClientSettings settings) {
-  auto fetch_option = request.GetFetchOption();
   const auto& tile_key = request.GetTileKey();
   auto tile = tile_key.ToHereTile();
   auto query_api = ApiClientLookup::LookupApi(


### PR DESCRIPTION
Return InvalidArgument for CacheWithUpdate option.
Update tests.

Relates-To: OLPEDGE-1658

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>