### PR TITLE
Fix a crash in the NetworkCurl

### DIFF
--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
@@ -908,7 +908,6 @@ void NetworkCurl::CompleteMessage(CURL* handle, CURLcode result) {
       return;
     }
 
-    lock.unlock();
     std::string error("Success");
     int status;
     if ((result == CURLE_OK) || (result == CURLE_HTTP_RETURNED_ERROR)) {
@@ -955,7 +954,6 @@ void NetworkCurl::CompleteMessage(CURL* handle, CURLcode result) {
                                        << handles_[index].id << ", url=" << url
                                        << " err=(" << status << ") " << error);
         handles_[index].count = 0;
-        lock.lock();
         events_.emplace_back(EventInfo::Type::SEND_EVENT, &handles_[index]);
         return;
       }
@@ -968,7 +966,7 @@ void NetworkCurl::CompleteMessage(CURL* handle, CURLcode result) {
                         .WithRequestId(handles_[index].id)
                         .WithStatus(status)
                         .WithError(error);
-    ReleaseHandle(&handles_[index]);
+    ReleaseHandleUnlocked(&handles_[index]);
     callback(response);
   } else {
     OLP_SDK_LOG_WARNING(kLogTag, "Complete message to unknown request");
@@ -1078,6 +1076,7 @@ void NetworkCurl::Run() {
               lock.lock();
             }
             curl_multi_remove_handle(curl_, handles_[handle_index].handle);
+            ReleaseHandleUnlocked(&handles_[handle_index]);
           } else {
             OLP_SDK_LOG_ERROR(
                 kLogTag,


### PR DESCRIPTION
Crash happens when the curl handle is duplicated in different request handles,
and then used concurrently with curl_slist_append/curl_slist_free_all.

Keep the mutex lock longer.
Add missing handle release.

OLPEDGE-1687

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>