### PR TITLE
Enable checksum verification during reading data from leveldb.

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DiskCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.cpp
@@ -258,7 +258,9 @@ bool DiskCache::Put(const std::string& key, leveldb::Slice slice) {
 
 boost::optional<std::string> DiskCache::Get(const std::string& key) {
   std::string res;
-  return database_ && database_->Get({}, ToLeveldbSlice(key), &res).ok()
+  leveldb::ReadOptions options;
+  options.verify_checksums = check_crc_;
+  return database_ && database_->Get(options, ToLeveldbSlice(key), &res).ok()
              ? boost::optional<std::string>(std::move(res))
              : boost::none;
 }


### PR DESCRIPTION
Pass the user provided CheckCrc open option, to the leveldb::ReadOptions.

Resolves: OLPEDGE-1660

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>