### PR TITLE
Split declarations and definitions.

### DIFF
--- a/tests/utils/mock-server-client/Client.h
+++ b/tests/utils/mock-server-client/Client.h
@@ -41,80 +41,106 @@ const auto kTimeout = std::chrono::seconds{10};
 
 class Client {
  public:
-  explicit Client(olp::client::OlpClientSettings settings) {
-    http_client_ = olp::client::OlpClientFactory::Create(settings);
-    http_client_->SetBaseUrl(kBaseUrl);
-  }
+  explicit Client(olp::client::OlpClientSettings settings);
 
   void MockResponse(const std::string& method_matcher,
                     const std::string& path_matcher,
-                    const std::string& response_body) {
-    auto expectation = Expectation{};
-    expectation.request.path = path_matcher;
-    expectation.request.method = method_matcher;
-
-    boost::optional<Expectation::ResponseAction> action =
-        Expectation::ResponseAction{};
-    action->body = response_body;
-    expectation.action = action;
-
-    CreateExpectation(expectation);
-  }
+                    const std::string& response_body);
 
   void MockBinaryResponse(const std::string& method_matcher,
                           const std::string& path_matcher,
-                          const std::string& response_body) {
-    auto expectation = Expectation{};
-    expectation.request.path = path_matcher;
-    expectation.request.method = method_matcher;
+                          const std::string& response_body);
 
-    auto binary_response = Expectation::BinaryResponse{};
-    binary_response.base64_string = response_body;
+  Status::Ports Ports() const;
 
-    boost::optional<Expectation::ResponseAction> action =
-        Expectation::ResponseAction{};
-    action->body = binary_response;
-    expectation.action = action;
-
-    CreateExpectation(expectation);
-  }
-
-  std::vector<int32_t> Ports() const {
-    auto response =
-        http_client_->CallApi(kStatusPath, "PUT", {}, {}, {}, nullptr, "",
-                              olp::client::CancellationContext{});
-
-    if (response.status != olp::http::HttpStatusCode::OK) {
-      return {};
-    }
-
-    const auto status = olp::parser::parse<Status>(response.response);
-
-    return status.ports;
-  }
-
-  void Reset() {
-    auto response =
-        http_client_->CallApi(kResetPath, "PUT", {}, {}, {}, nullptr, "",
-                              olp::client::CancellationContext{});
-
-    return;
-  }
+  void Reset();
 
  private:
-  void CreateExpectation(const Expectation& expectation) {
-    const auto data = serialize(expectation);
-    const std::shared_ptr<std::vector<unsigned char>> request_body =
-        std::make_shared<std::vector<unsigned char>>(data.begin(), data.end());
-
-    auto response =
-        http_client_->CallApi(kExpectationPath, "PUT", {}, {}, {}, request_body,
-                              "", olp::client::CancellationContext{});
-
-    return;
-  }
+  void CreateExpectation(const Expectation& expectation);
 
  private:
   std::shared_ptr<olp::client::OlpClient> http_client_;
 };
+
+inline Client::Client(olp::client::OlpClientSettings settings) {
+  http_client_ = olp::client::OlpClientFactory::Create(settings);
+  http_client_->SetBaseUrl(kBaseUrl);
+}
+
+inline void Client::MockResponse(const std::string& method_matcher,
+                                 const std::string& path_matcher,
+                                 const std::string& response_body) {
+  auto expectation = Expectation{};
+  expectation.request.path = path_matcher;
+  expectation.request.method = method_matcher;
+
+  boost::optional<Expectation::ResponseAction> action =
+      Expectation::ResponseAction{};
+  action->body = response_body;
+  expectation.action = action;
+
+  boost::optional<Expectation::ResponseTimes> times =
+      Expectation::ResponseTimes{};
+  times->remaining_times = 1;
+  times->unlimited = false;
+  expectation.times = times;
+
+  CreateExpectation(expectation);
+}
+
+inline void Client::MockBinaryResponse(const std::string& method_matcher,
+                                       const std::string& path_matcher,
+                                       const std::string& response_body) {
+  auto expectation = Expectation{};
+  expectation.request.path = path_matcher;
+  expectation.request.method = method_matcher;
+
+  auto binary_response = Expectation::BinaryResponse{};
+  binary_response.base64_string = response_body;
+
+  boost::optional<Expectation::ResponseAction> action =
+      Expectation::ResponseAction{};
+  action->body = binary_response;
+  expectation.action = action;
+
+  boost::optional<Expectation::ResponseTimes> times =
+      Expectation::ResponseTimes{};
+  times->remaining_times = 1;
+  times->unlimited = false;
+  expectation.times = times;
+
+  CreateExpectation(expectation);
+}
+
+inline Status::Ports Client::Ports() const {
+  auto response = http_client_->CallApi(kStatusPath, "PUT", {}, {}, {}, nullptr,
+                                        "", olp::client::CancellationContext{});
+
+  if (response.status != olp::http::HttpStatusCode::OK) {
+    return {};
+  }
+
+  const auto status = olp::parser::parse<Status>(response.response);
+  return status.ports;
+}
+
+inline void Client::Reset() {
+  auto response = http_client_->CallApi(kResetPath, "PUT", {}, {}, {}, nullptr,
+                                        "", olp::client::CancellationContext{});
+
+  return;
+}
+
+inline void Client::CreateExpectation(const Expectation& expectation) {
+  const auto data = serialize(expectation);
+  const std::shared_ptr<std::vector<unsigned char>> request_body =
+      std::make_shared<std::vector<unsigned char>>(data.begin(), data.end());
+
+  auto response =
+      http_client_->CallApi(kExpectationPath, "PUT", {}, {}, {}, request_body,
+                            "", olp::client::CancellationContext{});
+
+  return;
+}
+
 }  // namespace mockserver

--- a/tests/utils/mock-server-client/Expectation.h
+++ b/tests/utils/mock-server-client/Expectation.h
@@ -48,36 +48,61 @@ struct Expectation {
     std::string base64_string;
   };
 
+  struct ResponseTimes {
+    int64_t remaining_times = 1;
+    bool unlimited = false;
+  };
+
   RequestMatcher request;
   boost::optional<ResponseAction> action = boost::none;
+  boost::optional<ResponseTimes> times = boost::none;
 };
 
 void to_json(const Expectation& x, rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
+             rapidjson::Document::AllocatorType& allocator);
+void to_json(const Expectation::RequestMatcher& x, rapidjson::Value& value,
+             rapidjson::Document::AllocatorType& allocator);
+void to_json(const Expectation::BinaryResponse& x, rapidjson::Value& value,
+             rapidjson::Document::AllocatorType& allocator);
+void to_json(const Expectation::ResponseAction& x, rapidjson::Value& value,
+             rapidjson::Document::AllocatorType& allocator);
+void to_json(const Expectation::ResponseTimes& x, rapidjson::Value& value,
+             rapidjson::Document::AllocatorType& allocator);
+
+std::string serialize(const Expectation& object);
+
+inline void to_json(const Expectation& x, rapidjson::Value& value,
+                    rapidjson::Document::AllocatorType& allocator) {
   value.SetObject();
   olp::serializer::serialize("httpRequest", x.request, value, allocator);
 
   if (x.action != boost::none) {
     olp::serializer::serialize("httpResponse", x.action, value, allocator);
   }
+  if (x.times != boost::none) {
+    olp::serializer::serialize("times", x.times, value, allocator);
+  }
 }
 
-void to_json(const Expectation::RequestMatcher& x, rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
+inline void to_json(const Expectation::RequestMatcher& x,
+                    rapidjson::Value& value,
+                    rapidjson::Document::AllocatorType& allocator) {
   value.SetObject();
   olp::serializer::serialize("path", x.path, value, allocator);
   olp::serializer::serialize("method", x.method, value, allocator);
 }
 
-void to_json(const Expectation::BinaryResponse& x, rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
+inline void to_json(const Expectation::BinaryResponse& x,
+                    rapidjson::Value& value,
+                    rapidjson::Document::AllocatorType& allocator) {
   value.SetObject();
   olp::serializer::serialize("type", x.type, value, allocator);
   olp::serializer::serialize("base64Bytes", x.base64_string, value, allocator);
 }
 
-void to_json(const Expectation::ResponseAction& x, rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
+inline void to_json(const Expectation::ResponseAction& x,
+                    rapidjson::Value& value,
+                    rapidjson::Document::AllocatorType& allocator) {
   value.SetObject();
   olp::serializer::serialize("statusCode", x.status_code, value, allocator);
 
@@ -89,6 +114,15 @@ void to_json(const Expectation::ResponseAction& x, rapidjson::Value& value,
         "body", boost::any_cast<Expectation::BinaryResponse>(x.body), value,
         allocator);
   }
+}
+
+inline void to_json(const Expectation::ResponseTimes& x,
+                    rapidjson::Value& value,
+                    rapidjson::Document::AllocatorType& allocator) {
+  value.SetObject();
+  olp::serializer::serialize("remainingTimes", x.remaining_times, value,
+                             allocator);
+  olp::serializer::serialize("unlimited", x.unlimited, value, allocator);
 }
 
 inline std::string serialize(const Expectation& object) {

--- a/tests/utils/mock-server-client/Status.h
+++ b/tests/utils/mock-server-client/Status.h
@@ -32,9 +32,10 @@ struct Status {
   Ports ports;
 };
 
-void from_json(const rapidjson::Value& value, Status& x){
+void from_json(const rapidjson::Value& value, Status& x);
+
+inline void from_json(const rapidjson::Value& value, Status& x) {
   x.ports = olp::parser::parse<Status::Ports>(value, "ports");
 }
-
 
 }  // namespace mockserver


### PR DESCRIPTION
**Split declarations and definitions.**

This fixes the "already defined" compilation error.
Also improves the code readability a bit, as the code
delcaring classes and structs becames slimer.

Relates-To: OAM-188

Signed-off-by: Kirill Zhuchkov <kirill.zhuchkov@here.com>