### PR TITLE
Add custom headers for network.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/http/Network.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/Network.h
@@ -81,6 +81,11 @@ class CORE_API Network {
    * @param[in] id The unique RequestId of the request to be cancelled.
    */
   virtual void Cancel(RequestId id) = 0;
+
+  /**
+   * @brief Set default headers.
+   */
+  virtual void SetDefaultHeaders(Headers headers);
 };
 
 /**

--- a/olp-cpp-sdk-core/include/olp/core/http/NetworkUtils.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/NetworkUtils.h
@@ -21,6 +21,8 @@
 
 #include <string>
 
+#include <olp/core/http/NetworkTypes.h>
+
 namespace olp {
 namespace http {
 /**
@@ -37,6 +39,8 @@ class NetworkUtils {
                                         size_t offset = 0);
   static size_t CaseInsensitiveFind(const std::string& str1,
                                     const std::string& str2, size_t offset = 0);
+
+  static std::string ExtractUserAgent(Headers& headers);
 
 };  // class NetworkUtils
 

--- a/olp-cpp-sdk-core/src/http/Network.cpp
+++ b/olp-cpp-sdk-core/src/http/Network.cpp
@@ -34,6 +34,8 @@
 namespace olp {
 namespace http {
 
+void Network::SetDefaultHeaders(Headers) {}
+
 CORE_API std::shared_ptr<Network> CreateDefaultNetwork(
     size_t max_requests_count) {
   CORE_UNUSED(max_requests_count);

--- a/olp-cpp-sdk-core/src/http/NetworkUtils.cpp
+++ b/olp-cpp-sdk-core/src/http/NetworkUtils.cpp
@@ -19,7 +19,9 @@
 
 #include "olp/core/http/NetworkUtils.h"
 
-#include <string>
+#include <algorithm>
+
+#include "olp/core/http/NetworkConstants.h"
 
 namespace olp {
 namespace http {
@@ -69,6 +71,24 @@ size_t NetworkUtils::CaseInsensitiveFind(const std::string& str1,
     }
   }
   return std::string::npos;
+}
+
+std::string NetworkUtils::ExtractUserAgent(Headers& headers) {
+  std::string user_agent;
+
+  auto user_agent_it =
+      std::find_if(headers.begin(), headers.end(),
+                   [](const Header& header_pair) {
+                     return NetworkUtils::CaseInsensitiveCompare(
+                         header_pair.first, kUserAgentHeader);
+                   });
+
+  if (user_agent_it != headers.end()) {
+    user_agent = std::move((*user_agent_it).second);
+    headers.erase(user_agent_it);
+  }
+
+  return user_agent;  
 }
 
 std::string HttpErrorToString(int error) {

--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.h
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.h
@@ -88,6 +88,11 @@ class NetworkCurl : public olp::http::Network,
    */
   void Cancel(RequestId id) override;
 
+  /**
+   * @brief Implementation of SetDefaultHeaders method from Network abstract class.
+   */
+  void SetDefaultHeaders(Headers headers) override;
+
  private:
   /**
    * @brief Context of each individual network request.
@@ -336,6 +341,9 @@ class NetworkCurl : public olp::http::Network,
 
   /// Stores value if `curl_global_init()` was successful on construction.
   bool curl_initialized_;
+
+  Headers default_headers_;
+  std::string user_agent_;
 };
 
 }  // namespace http

--- a/olp-cpp-sdk-core/tests/http/NetworkUtils.cpp
+++ b/olp-cpp-sdk-core/tests/http/NetworkUtils.cpp
@@ -79,6 +79,30 @@ TEST(NetworkUtilsTest, CaseInsensitiveFind) {
   EXPECT_EQ(std::string::npos, NetworkUtils::CaseInsensitiveFind("", ""));
 }
 
+TEST(NetworkUtilsTest, ExtractUserAgentTest) {
+  {
+    SCOPED_TRACE("User agent is present and extracted");
+    Headers headers;
+    headers.emplace_back(Header("user-Agent", "agent smith"));
+    headers.emplace_back(Header("other-header", "header"));
+    std::string user_agent = NetworkUtils::ExtractUserAgent(headers);
+    EXPECT_EQ(user_agent, "agent smith");
+    EXPECT_EQ(headers.size(), 1);
+    EXPECT_EQ(headers[0].first, "other-header");
+    EXPECT_EQ(headers[0].second, "header");
+  }
+  {
+    SCOPED_TRACE("User agent is missing and nothing happens");
+    Headers headers;
+    headers.emplace_back(Header("other-header", "header"));
+    std::string user_agent = NetworkUtils::ExtractUserAgent(headers);
+    EXPECT_EQ(user_agent, "");
+    EXPECT_EQ(headers.size(), 1);
+    EXPECT_EQ(headers[0].first, "other-header");
+    EXPECT_EQ(headers[0].second, "header");
+  }
+}
+
 TEST(NetworkUtilsTest, HttpErrorToString) {
   EXPECT_EQ("Unknown Error", HttpErrorToString(1));
   EXPECT_EQ("Continue", HttpErrorToString(100));


### PR DESCRIPTION
User can set headers that will be added for each request made by network.
Additionally, it concatenates the user agents set to network and passed with
request.

Relates-To: OLPEDGE-1669