### PR TITLE
Reduce compiler warnings about deprecated methods/classes.

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/TokenEndpoint.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/TokenEndpoint.h
@@ -37,9 +37,6 @@ namespace olp {
 namespace authentication {
 class AutoRefreshingToken;
 
-PORTING_PUSH_WARNINGS()
-PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
-
 /**
  * @brief Corresponds to the token endpoint as specified in the OAuth2.0
  * specification.
@@ -47,6 +44,10 @@ PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
 class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed in 04.2020")
     TokenEndpoint {
  public:
+  // Needed to avoid endless warnings from TokenRequest/TokenResult
+  PORTING_PUSH_WARNINGS()
+  PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
+
   /// Defines the signature used to return the response to the client.
   using TokenResponse = Response<TokenResult>;
   /// Defines the callback that is invoked when the response on
@@ -114,6 +115,8 @@ class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed in 04.2020")
   AutoRefreshingToken RequestAutoRefreshingToken(
       const TokenRequest& token_request = TokenRequest());
 
+  PORTING_POP_WARNINGS()
+
   /**
    * @brief Creates the `TokenEndpoint` instance with the given `settings`
    * parameter.
@@ -128,6 +131,5 @@ class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed in 04.2020")
   std::shared_ptr<Impl> impl_;
 };
 
-PORTING_POP_WARNINGS()
 }  // namespace authentication
 }  // namespace olp

--- a/olp-cpp-sdk-authentication/src/TokenEndpoint.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenEndpoint.cpp
@@ -19,6 +19,9 @@
 
 #include "olp/authentication/TokenEndpoint.h"
 
+PORTING_PUSH_WARNINGS()
+PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
+
 #include "olp/authentication/AuthenticationClient.h"
 #include "olp/authentication/AuthenticationCredentials.h"
 #include "olp/authentication/AutoRefreshingToken.h"
@@ -134,5 +137,6 @@ AutoRefreshingToken TokenEndpoint::RequestAutoRefreshingToken(
   return AutoRefreshingToken(*this, token_request);
 }
 
+PORTING_POP_WARNINGS()
 }  // namespace authentication
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/DataRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/DataRequest.h
@@ -245,8 +245,8 @@ class DATASERVICE_READ_API DataRequest final {
       out << GetDataHandle().get();
     }
     out << "]";
-    if (GetVersion()) {
-      out << "@" << GetVersion().get();
+    if (catalog_version_) {
+      out << "@" << catalog_version_.get();
     }
     if (GetBillingTag()) {
       out << "$" << GetBillingTag().get();

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PartitionsRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PartitionsRequest.h
@@ -220,8 +220,8 @@ class DATASERVICE_READ_API PartitionsRequest final {
   std::string CreateKey(const std::string& layer_id) const {
     std::stringstream out;
     out << layer_id;
-    if (GetVersion()) {
-      out << "@" << GetVersion().get();
+    if (catalog_version_) {
+      out << "@" << catalog_version_.get();
     }
     if (GetBillingTag()) {
       out << "$" << GetBillingTag().get();

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
@@ -123,7 +123,7 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
    * version is specified, the latest version is retrieved.
    *
    * @return A reference to the updated `PrefetchTilesRequest` instance.
-   * 
+   *
    * @deprecated The version is now a part of the VersionedLayerClient
    * constructor.
    */
@@ -202,8 +202,8 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
     std::stringstream out;
     out << layer_id << "[" << GetMinLevel() << "/" << GetMaxLevel() << "]"
         << "(" << GetTileKeys().size() << ")";
-    if (GetVersion()) {
-      out << "@" << GetVersion().get();
+    if (catalog_version_) {
+      out << "@" << catalog_version_.get();
     }
     if (GetBillingTag()) {
       out << "$" << GetBillingTag().get();

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -33,6 +33,11 @@
 #include "repositories/PartitionsRepository.h"
 #include "repositories/PrefetchTilesRepository.h"
 
+// Needed to avoid endless warnings from GetVersion/WithVersion
+#include <olp/core/porting/warning_disable.h>
+PORTING_PUSH_WARNINGS()
+PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
+
 namespace olp {
 namespace dataservice {
 namespace read {
@@ -366,7 +371,6 @@ VersionedLayerClientImpl::PrefetchTiles(PrefetchTilesRequest request) {
                                                           promise);
 }
 
-
 CatalogVersionResponse VersionedLayerClientImpl::GetVersion(
     boost::optional<std::string> billing_tag, const FetchOptions& fetch_options,
     const client::CancellationContext& context) {
@@ -446,9 +450,9 @@ client::CancellableFuture<DataResponse> VersionedLayerClientImpl::GetData(
       });
   return client::CancellableFuture<DataResponse>(std::move(cancel_token),
                                                  std::move(promise));
-
 }
 
+PORTING_POP_WARNINGS()
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
@@ -37,6 +37,11 @@
 #include "olp/dataservice/read/PartitionsRequest.h"
 #include "olp/dataservice/read/TileRequest.h"
 
+// Needed to avoid endless warnings from GetVersion/WithVersion
+#include <olp/core/porting/warning_disable.h>
+PORTING_PUSH_WARNINGS()
+PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
+
 namespace olp {
 namespace dataservice {
 namespace read {
@@ -226,6 +231,7 @@ DataResponse DataRepository::GetVolatileData(
       catalog, layer_id, kVolatileBlobService, request, context, settings);
 }
 
+PORTING_POP_WARNINGS()
 }  // namespace repository
 }  // namespace read
 }  // namespace dataservice

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
@@ -33,6 +33,11 @@
 #include "generated/serializer/JsonSerializer.h"
 // clang-format on
 
+// Needed to avoid endless warnings from GetVersion/WithVersion
+#include <olp/core/porting/warning_disable.h>
+PORTING_PUSH_WARNINGS()
+PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
+
 namespace {
 constexpr auto kLogTag = "PartitionsCacheRepository";
 
@@ -201,6 +206,7 @@ void PartitionsCacheRepository::ClearPartitions(
   }
 }
 
+PORTING_POP_WARNINGS()
 }  // namespace repository
 }  // namespace read
 }  // namespace dataservice

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
@@ -33,6 +33,11 @@
 #include "olp/dataservice/read/PartitionsRequest.h"
 #include "olp/dataservice/read/TileRequest.h"
 
+// Needed to avoid endless warnings from GetVersion/WithVersion
+#include <olp/core/porting/warning_disable.h>
+PORTING_PUSH_WARNINGS()
+PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
+
 namespace olp {
 namespace dataservice {
 namespace read {
@@ -141,7 +146,7 @@ PartitionsResponse PartitionsRepository::GetPartitions(
   PartitionsResponse response;
 
   const auto& partition_ids = request.GetPartitionIds();
-  
+
   if (partition_ids.empty()) {
     auto metadata_api =
         ApiClientLookup::LookupApi(catalog, cancellation_context, "metadata",
@@ -386,6 +391,8 @@ model::Partitions PartitionsRepository::GetTileFromCache(
   }
   return {};
 }
+
+PORTING_POP_WARNINGS()
 }  // namespace repository
 }  // namespace read
 }  // namespace dataservice

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -31,6 +31,11 @@
 #include "PartitionsRepository.h"
 #include "generated/api/QueryApi.h"
 
+// Needed to avoid endless warnings from GetVersion/WithVersion
+#include <olp/core/porting/warning_disable.h>
+PORTING_PUSH_WARNINGS()
+PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
+
 namespace olp {
 namespace dataservice {
 namespace read {
@@ -244,7 +249,8 @@ SubQuadsResponse PrefetchTilesRepository::GetSubQuads(
 
     // add to bulk partitions for cacheing
     partitions.GetMutablePartitions().emplace_back(
-        PartitionsRepository::PartitionFromSubQuad(*subquad, subtile.ToHereTile()));
+        PartitionsRepository::PartitionFromSubQuad(*subquad,
+                                                   subtile.ToHereTile()));
   }
 
   // add to cache
@@ -255,6 +261,7 @@ SubQuadsResponse PrefetchTilesRepository::GetSubQuads(
   return result;
 }
 
+PORTING_POP_WARNINGS()
 }  // namespace repository
 }  // namespace read
 }  // namespace dataservice


### PR DESCRIPTION
As we deprecated some classes that are public but only to be used
internaly there are a lot of deprecated warnings when building the SDK.
This adds pragma compiler flag disables for the places where we actually
use these classes internaly until we can finaly move these classes to private.
Also this commit removes the version usage from the request key creation and
adds again pragma disables to the repositories which are still using the version
setters/getters internaly. This will be changed in the future but until then
we need to lower the warnings count while building.

Resolves: OLPSUP-9858

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>