### PR TITLE
Add custom headers for network.

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -218,6 +218,8 @@ set(OLP_SDK_CLIENT_SOURCES
 )
 
 set(OLP_SDK_HTTP_SOURCES
+    ./src/http/DefaultNetwork.cpp
+    ./src/http/DefaultNetwork.h
     ./src/http/Network.cpp
     ./src/http/NetworkProxySettings.cpp
     ./src/http/NetworkRequest.cpp

--- a/olp-cpp-sdk-core/include/olp/core/http/Network.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/Network.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,12 +81,23 @@ class CORE_API Network {
    * @param[in] id The unique RequestId of the request to be cancelled.
    */
   virtual void Cancel(RequestId id) = 0;
+
+  /**
+   * @brief Sets default network headers.
+   *
+   * Default headers are applied to each request passed to the `Send` method.
+   * User agents are concatenated.
+   *
+   * @param headers The default headers.
+   */
+  virtual void SetDefaultHeaders(Headers headers) {}
 };
 
 /**
  * @brief Create default Network implementation.
  */
-CORE_API std::shared_ptr<Network> CreateDefaultNetwork(size_t max_requests_count);
+CORE_API std::shared_ptr<Network> CreateDefaultNetwork(
+    size_t max_requests_count);
 
 }  // namespace http
 }  // namespace olp

--- a/olp-cpp-sdk-core/include/olp/core/http/NetworkRequest.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/NetworkRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,13 +55,20 @@ class CORE_API NetworkRequest final {
   explicit NetworkRequest(std::string url);
 
   /**
-   * @brief Get all HTTP headers.
-   * @return vector of HTTP headers.
+   * @brief Gets all HTTP headers.
+   * @return The vector of the HTTP headers.
    */
   const Headers& GetHeaders() const;
+  
+  /**
+   * @brief Gets the mutable reference to the HTTP headers.
+   *
+   * @return The mutable reference to vector of HTTP headers.
+   */
+  Headers& GetMutableHeaders();
 
   /**
-   * @brief Add extra HTTP header.
+   * @brief Adds an extra HTTP header.
    * @param[in] name Header name.
    * @param[in] value Header value.
    * @return reference to *this.

--- a/olp-cpp-sdk-core/include/olp/core/http/NetworkUtils.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/NetworkUtils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@
 
 #include <string>
 
+#include <olp/core/http/NetworkTypes.h>
+
 namespace olp {
 namespace http {
 /**
@@ -38,6 +40,16 @@ class NetworkUtils {
   static size_t CaseInsensitiveFind(const std::string& str1,
                                     const std::string& str2, size_t offset = 0);
 
+  /**
+   * @brief Extract the user agent from the headers.
+   *
+   * User agent is removed from the headers.
+   *
+   * @param headers The input headers.
+   *
+   * @return The user agent or an empty string if there is no user agent.
+   */
+  static std::string ExtractUserAgent(Headers& headers);
 };  // class NetworkUtils
 
 std::string HttpErrorToString(int error);

--- a/olp-cpp-sdk-core/src/client/OlpClientSettingsFactory.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClientSettingsFactory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/olp-cpp-sdk-core/src/http/DefaultNetwork.cpp
+++ b/olp-cpp-sdk-core/src/http/DefaultNetwork.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <algorithm>
+
+#include "DefaultNetwork.h"
+#include "olp/core/http/NetworkConstants.h"
+#include "olp/core/http/NetworkUtils.h"
+
+namespace olp {
+namespace http {
+DefaultNetwork::DefaultNetwork(std::shared_ptr<Network> network)
+    : network_{std::move(network)} {}
+
+DefaultNetwork::~DefaultNetwork() = default;
+
+SendOutcome DefaultNetwork::Send(NetworkRequest request, Payload payload,
+                                 Callback callback,
+                                 HeaderCallback header_callback,
+                                 DataCallback data_callback) {
+  {
+    auto& request_headers = request.GetMutableHeaders();
+
+    std::unique_lock<std::mutex> lock(default_headers_mutex_);
+    AppendUserAgent(request_headers);
+    AppendDefaultHeaders(request_headers);
+  }
+
+  return network_->Send(std::move(request), std::move(payload),
+                        std::move(callback), std::move(header_callback),
+                        std::move(data_callback));
+}
+
+void DefaultNetwork::Cancel(RequestId id) { network_->Cancel(id); }
+
+void DefaultNetwork::SetDefaultHeaders(Headers headers) {
+  std::unique_lock<std::mutex> lock(default_headers_mutex_);
+  default_headers_ = std::move(headers);
+  user_agent_ = NetworkUtils::ExtractUserAgent(default_headers_);
+}
+
+void DefaultNetwork::AppendUserAgent(Headers& request_headers) const {
+  if (user_agent_.empty()) {
+    return;
+  }
+  auto user_agent_it =
+      std::find_if(std::begin(request_headers), std::end(request_headers),
+                   [](const Header& header) {
+                     return NetworkUtils::CaseInsensitiveCompare(
+                         header.first, kUserAgentHeader);
+                   });
+
+  if (user_agent_it != std::end(request_headers)) {
+    user_agent_it->second.append(" ").append(user_agent_);
+  } else {
+    request_headers.emplace_back(kUserAgentHeader, user_agent_);
+  }
+}
+
+void DefaultNetwork::AppendDefaultHeaders(Headers& request_headers) const {
+  request_headers.insert(request_headers.end(), default_headers_.begin(),
+                         default_headers_.end());
+}
+
+}  // namespace http
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/http/DefaultNetwork.h
+++ b/olp-cpp-sdk-core/src/http/DefaultNetwork.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <mutex>
+
+#include <olp/core/CoreApi.h>
+#include <olp/core/http/Network.h>
+
+namespace olp {
+namespace http {
+
+/**
+ * @brief The default network class.
+ *
+ * Designed to provide default headers functionality on top of other `Network`
+ * instances.
+ */
+class DefaultNetwork final : public Network {
+ public:
+  /**
+   * @brief Creates the `DefaultNetwork` instance.
+   *
+   * @param network The `Network` instance that is used to handle `Send` and
+   * `Cancel` methods.
+   */
+  explicit DefaultNetwork(std::shared_ptr<Network> network);
+  ~DefaultNetwork() override;
+
+  /// Implements the `Send` method of the `Network` class.
+  SendOutcome Send(NetworkRequest request, Payload payload, Callback callback,
+                   HeaderCallback header_callback = nullptr,
+                   DataCallback data_callback = nullptr) override;
+
+  /// Implements the `Cancel` method of the `Network` class.
+  void Cancel(RequestId id) override;
+
+  /// Implements the `SetDefaultHeaders` method of the `Network` class.
+  void SetDefaultHeaders(Headers headers) override;
+
+ private:
+  void AppendUserAgent(Headers& request_headers) const;
+  void AppendDefaultHeaders(Headers& request_headers) const;
+
+  std::shared_ptr<Network> network_;
+  std::mutex default_headers_mutex_;
+  Headers default_headers_;
+  std::string user_agent_;
+};
+
+}  // namespace http
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/http/Network.cpp
+++ b/olp-cpp-sdk-core/src/http/Network.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 
 #include "olp/core/http/Network.h"
 
+#include "http/DefaultNetwork.h"
 #include "olp/core/utils/WarningWorkarounds.h"
 
 #ifdef OLP_SDK_NETWORK_HAS_CURL
@@ -34,8 +35,8 @@
 namespace olp {
 namespace http {
 
-CORE_API std::shared_ptr<Network> CreateDefaultNetwork(
-    size_t max_requests_count) {
+namespace {
+std::shared_ptr<Network> CreateDefaultNetworkImpl(size_t max_requests_count) {
   CORE_UNUSED(max_requests_count);
 #ifdef OLP_SDK_NETWORK_HAS_CURL
   return std::make_shared<NetworkCurl>(max_requests_count);
@@ -48,6 +49,16 @@ CORE_API std::shared_ptr<Network> CreateDefaultNetwork(
 #else
   static_assert(false, "No default network implementation provided");
 #endif
+}
+}  // namespace
+
+CORE_API std::shared_ptr<Network> CreateDefaultNetwork(
+    size_t max_requests_count) {
+  auto network = CreateDefaultNetworkImpl(max_requests_count);
+  if (network) {
+    return std::make_shared<DefaultNetwork>(network);
+  }
+  return nullptr;
 }
 
 }  // namespace http

--- a/olp-cpp-sdk-core/src/http/NetworkRequest.cpp
+++ b/olp-cpp-sdk-core/src/http/NetworkRequest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ namespace http {
 NetworkRequest::NetworkRequest(std::string url) : url_{std::move(url)} {}
 
 const Headers& NetworkRequest::GetHeaders() const { return headers_; }
+
+Headers& NetworkRequest::GetMutableHeaders() { return headers_; }
 
 const std::string& NetworkRequest::GetUrl() const { return url_; }
 

--- a/olp-cpp-sdk-core/src/http/NetworkUtils.cpp
+++ b/olp-cpp-sdk-core/src/http/NetworkUtils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@
 
 #include "olp/core/http/NetworkUtils.h"
 
-#include <string>
+#include <algorithm>
+
+#include "olp/core/http/NetworkConstants.h"
 
 namespace olp {
 namespace http {
@@ -70,6 +72,25 @@ size_t NetworkUtils::CaseInsensitiveFind(const std::string& str1,
   }
   return std::string::npos;
 }
+
+std::string NetworkUtils::ExtractUserAgent(Headers& headers) {
+  std::string user_agent;
+
+  auto user_agent_it =
+      std::find_if(headers.begin(), headers.end(),
+                   [](const Header& header_pair) {
+                     return NetworkUtils::CaseInsensitiveCompare(
+                         header_pair.first, kUserAgentHeader);
+                   });
+
+  if (user_agent_it != headers.end()) {
+    user_agent = std::move((*user_agent_it).second);
+    headers.erase(user_agent_it);
+  }
+
+  return user_agent;  
+}
+
 
 std::string HttpErrorToString(int error) {
   switch (error) {

--- a/olp-cpp-sdk-core/tests/http/NetworkUtils.cpp
+++ b/olp-cpp-sdk-core/tests/http/NetworkUtils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,28 @@ TEST(NetworkUtilsTest, CaseInsensitiveFind) {
   EXPECT_EQ(std::string::npos,
             NetworkUtils::CaseInsensitiveFind("", "SomeStr"));
   EXPECT_EQ(std::string::npos, NetworkUtils::CaseInsensitiveFind("", ""));
+}
+
+TEST(NetworkUtilsTest, ExtractUserAgentTest) {
+  {
+    SCOPED_TRACE("User agent is present and extracted");
+    Headers headers = {{"user-Agent", "agent smith"},
+                       {"other-header", "header"}};
+    std::string user_agent = NetworkUtils::ExtractUserAgent(headers);
+    EXPECT_EQ(user_agent, "agent smith");
+    EXPECT_EQ(headers.size(), 1);
+    EXPECT_EQ(headers[0].first, "other-header");
+    EXPECT_EQ(headers[0].second, "header");
+  }
+  {
+    SCOPED_TRACE("User agent is missing and nothing happens");
+    Headers headers = {{"other-header", "header"}};
+    std::string user_agent = NetworkUtils::ExtractUserAgent(headers);
+    EXPECT_EQ(user_agent, "");
+    EXPECT_EQ(headers.size(), 1);
+    EXPECT_EQ(headers[0].first, "other-header");
+    EXPECT_EQ(headers[0].second, "header");
+  }
 }
 
 TEST(NetworkUtilsTest, HttpErrorToString) {

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 HERE Europe B.V.
+# Copyright (C) 2019-2020 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ set(OLP_SDK_INTEGRATIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
     ./olp-cpp-sdk-dataservice-write/StreamLayerClientTest.cpp
     ./olp-cpp-sdk-dataservice-write/VolatileLayerClientTest.cpp
+    ./olp-cpp-sdk-core/DefaultNetworkTest.cpp
 )
 
 if (ANDROID OR IOS)
@@ -63,6 +64,11 @@ if (ANDROID OR IOS)
 
     endif()
 
+    target_include_directories(${OLP_SDK_INTEGRATION_TESTS_LIB}
+        PRIVATE
+            ${CMAKE_SOURCE_DIR}/../../olp-cpp-sdk-core/src
+    )
+
 else()
     add_executable(olp-cpp-sdk-integration-tests ${OLP_SDK_INTEGRATIONAL_TESTS_SOURCES})
     target_link_libraries(olp-cpp-sdk-integration-tests
@@ -74,5 +80,10 @@ else()
             olp-cpp-sdk-dataservice-read
             olp-cpp-sdk-dataservice-write
             olp-cpp-sdk-tests-common
+    )
+
+    target_include_directories(olp-cpp-sdk-integration-tests
+        PRIVATE
+            ${CMAKE_SOURCE_DIR}/../../olp-cpp-sdk-core/src
     )
 endif()

--- a/tests/integration/olp-cpp-sdk-core/DefaultNetworkTest.cpp
+++ b/tests/integration/olp-cpp-sdk-core/DefaultNetworkTest.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gmock/gmock.h>
+
+#include <matchers/NetworkUrlMatchers.h>
+#include <mocks/NetworkMock.h>
+
+#include "http/DefaultNetwork.h"
+
+namespace {
+
+using namespace testing;
+using namespace olp::http;
+using namespace olp::tests::common;
+
+const char* kTestUrl = "test_url";
+
+TEST(DefaultNetworkTest, Send) {
+  auto network_mock = std::make_shared<NetworkMock>();
+  auto default_network_adapter = std::make_shared<DefaultNetwork>(network_mock);
+
+  {
+    SCOPED_TRACE("Direct Send call");
+
+    auto request =
+        NetworkRequest(kTestUrl).WithVerb(NetworkRequest::HttpVerb::GET);
+
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(kTestUrl), _, _, _, _))
+        .WillOnce(Return(SendOutcome(1)));
+
+    default_network_adapter->Send(request, nullptr, nullptr);
+
+    Mock::VerifyAndClearExpectations(network_mock.get());
+  }
+
+  {
+    SCOPED_TRACE("Default headers only");
+
+    auto request =
+        NetworkRequest(kTestUrl).WithVerb(NetworkRequest::HttpVerb::GET);
+
+    Header default_header("default-header", "default-value");
+    Headers headers = {default_header};
+
+    auto request_matcher =
+        AllOf(IsGetRequest(kTestUrl), HeadersContain(default_header));
+
+    EXPECT_CALL(*network_mock, Send(request_matcher, _, _, _, _))
+        .WillOnce(Return(SendOutcome(1)));
+
+    default_network_adapter->SetDefaultHeaders(headers);
+
+    default_network_adapter->Send(request, nullptr, nullptr);
+
+    Mock::VerifyAndClearExpectations(network_mock.get());
+  }
+
+  {
+    SCOPED_TRACE("Default headers appended");
+
+    Header request_header("request-header", "request-value");
+
+    auto request = NetworkRequest(kTestUrl)
+                       .WithVerb(NetworkRequest::HttpVerb::GET)
+                       .WithHeader(request_header.first, request_header.second);
+
+    Header default_header("default-header", "default-value");
+    Header default_user_agent("user-agent", "default_user_agent");
+    Headers headers = {default_header, default_user_agent};
+
+    Header expected_user_agent(kUserAgentHeader, "default_user_agent");
+
+    auto request_matcher = AllOf(
+        IsGetRequest(kTestUrl), HeadersContain(request_header),
+        HeadersContain(default_header), HeadersContain(expected_user_agent));
+
+    EXPECT_CALL(*network_mock, Send(request_matcher, _, _, _, _))
+        .WillOnce(Return(SendOutcome(1)));
+
+    default_network_adapter->SetDefaultHeaders(headers);
+
+    default_network_adapter->Send(request, nullptr, nullptr);
+
+    Mock::VerifyAndClearExpectations(network_mock.get());
+  }
+  {
+    SCOPED_TRACE("User agents concatenated");
+
+    Header request_header("request-header", "request-value");
+    Header request_user_agent("user-agent", "requested_user_agent");
+
+    auto request =
+        NetworkRequest(kTestUrl)
+            .WithVerb(NetworkRequest::HttpVerb::GET)
+            .WithHeader(request_header.first, request_header.second)
+            .WithHeader(request_user_agent.first, request_user_agent.second);
+
+    Header default_header("default-header", "default-value");
+    Header default_user_agent("user-agent", "default_user_agent");
+    Headers headers = {default_header, default_user_agent};
+
+    Header expected_user_agent("user-agent",
+                               "requested_user_agent default_user_agent");
+
+    auto request_matcher = AllOf(
+        IsGetRequest(kTestUrl), HeadersContain(request_header),
+        HeadersContain(default_header), HeadersContain(expected_user_agent));
+
+    EXPECT_CALL(*network_mock, Send(request_matcher, _, _, _, _))
+        .WillOnce(Return(SendOutcome(1)));
+
+    default_network_adapter->SetDefaultHeaders(headers);
+
+    default_network_adapter->Send(request, nullptr, nullptr);
+
+    Mock::VerifyAndClearExpectations(network_mock.get());
+  }
+}
+
+}  // namespace


### PR DESCRIPTION
User can set default headers that will be added for each request made by
network. Additionally, it concatenates the user agents set with default headers
and user agents passed with network request.

Relates-To: OLPEDGE-1669

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>