### PR TITLE
Refactor prefetch functionality.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -278,10 +278,13 @@ class DATASERVICE_READ_API VersionedLayerClient final {
   /**
    * @brief Prefetches a set of tiles asynchronously.
    *
-   * This method recursively downloads all tile keys from the `minLevel`
-   * parameter to the `maxLevel` parameter of the \c PrefetchTilesRequest
-   * object. It helps to reduce the network load by using the prefetched tiles
-   * data from the cache.
+   * This method requests data for tile keys in parameter of the \c
+   * PrefetchTilesRequest. Also requested and cached methadata for tile keys
+   * from the `minLevel` parameter to the `maxLevel` parameter of the \c
+   * PrefetchTilesRequest object, min/max levels should be not wider range
+   * than 4. If range exceeds 4, used max value 4, levels are calculated based
+   * on current levels of requested tiles. It helps to reduce the network load
+   * by using the prefetched tiles data from the cache.
    *
    * @note This method does not guarantee that all tiles are available offline
    * as the cache might overflow, and data might be evicted at any point.
@@ -300,13 +303,17 @@ class DATASERVICE_READ_API VersionedLayerClient final {
   /**
    * @brief Prefetches a set of tiles asynchronously.
    *
-   * This method recursively downloads all tile keys from the `minLevel`
-   * parameter to the `maxLevel` parameter of the \c PrefetchTilesRequest
-   * object. It helps to reduce the network load by using the prefetched tiles
-   * data from the cache.
+   * This method requests data for tile keys in parameter of the \c
+   * PrefetchTilesRequest. Also requested and cached methadata for tile keys
+   * from the `minLevel` parameter to the `maxLevel` parameter of the \c
+   * PrefetchTilesRequest object, min/max levels should be not wider range
+   * than 4. If range exceeds 4, used max value 4, levels are calculated based
+   * on current levels of requested tiles. It helps to reduce the network load
+   * by using the prefetched tiles data from the cache.
    *
-   * @note This method does not guarantee that all tiles are available offline
-   * as the cache might overflow, and data might be evicted at any point.
+   * @note This method does not guarantee that all tiles methadata are available
+   * offline as the cache might overflow, and data might be evicted at any
+   * point.
    *
    * @param request The `PrefetchTilesRequest` instance that contains
    * a complete set of request parameters.

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -66,16 +66,16 @@ class PartitionsRepository {
       client::CancellationContext context,
       const client::OlpClientSettings& settings);
 
+  static model::Partitions GetTileFromCache(
+      const client::HRN& catalog, const std::string& layer_id,
+      const TileRequest& request, int64_t version,
+      const client::OlpClientSettings& settings);
+
  protected:
   static PartitionsResponse QueryPartitionForVersionedTile(
       const client::HRN& catalog, const std::string& layer_id,
       const TileRequest& request, int64_t version,
       client::CancellationContext context, client::OlpClientSettings settings);
-
-  static model::Partitions GetTileFromCache(
-      const client::HRN& catalog, const std::string& layer_id,
-      const TileRequest& request, int64_t version,
-      const client::OlpClientSettings& settings);
 
  private:
   static PartitionsResponse GetPartitions(

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
@@ -40,10 +40,12 @@ namespace repository {
 
 using TileKeyAndDepth = std::pair<geo::TileKey, int32_t>;
 using SubQuadsRequest = std::map<std::string, TileKeyAndDepth>;
-using SubQuadsResult = std::vector<std::pair<geo::TileKey, std::string>>;
+using SubQuadsResult = std::map<geo::TileKey, std::string>;
 using SubQuadsResponse = client::ApiResponse<SubQuadsResult, client::ApiError>;
-using SubTilesResult = SubQuadsResult;
-using SubTilesResponse = client::ApiResponse<SubTilesResult, client::ApiError>;
+struct TilesResult {
+  std::map<geo::TileKey, std::string> found_tiles;
+  std::vector<geo::TileKey> tile_keys;
+};
 
 class PrefetchTilesRepository final {
  public:
@@ -61,7 +63,7 @@ class PrefetchTilesRepository final {
       const std::vector<geo::TileKey>& tile_keys, unsigned int min_level,
       unsigned int max_level);
 
-  static SubTilesResponse GetSubTiles(
+  static SubQuadsResponse GetSubTiles(
       const client::HRN& catalog, const std::string& layer_id,
       const PrefetchTilesRequest& request, const SubQuadsRequest& sub_quads,
       client::CancellationContext context,
@@ -73,6 +75,10 @@ class PrefetchTilesRepository final {
                                       geo::TileKey tile, int32_t depth,
                                       const client::OlpClientSettings& settings,
                                       client::CancellationContext context);
+  static TilesResult GetSubQuadsFromCache(
+      const client::HRN& catalog, const std::string& layer_id,
+      const PrefetchTilesRequest& request, client::CancellationContext context,
+      int64_t version, const client::OlpClientSettings& settings);
 
  private:
   static SubQuadsRequest EffectiveTileKeys(const geo::TileKey& tile_key,

--- a/tests/integration/olp-cpp-sdk-dataservice-read/HttpResponses.h
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/HttpResponses.h
@@ -212,7 +212,7 @@
   R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/23618364/depths/0)"
 
 #define URL_QUADKEYS_1476147 \
-  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/1476147/depths/0)"
+  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/1476147/depths/2)"
 
 #define URL_QUADKEYS_5904591 \
   R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/5904591/depths/1)"
@@ -260,7 +260,7 @@
   R"jsonString({"subQuads": [{"version":4,"subQuadKey":"1","dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"}],"parentQuads": []})jsonString"
 
 #define HTTP_RESPONSE_QUADKEYS_1476147 \
-  R"jsonString({"subQuads": [{"version":4,"subQuadKey":"1","dataHandle":"f9a9fd8e-eb1b-48e5-bfdb-4392b3826443"}],"parentQuads": [{"version":4,"partition":"1476147","dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"}]})jsonString"
+  R"jsonString({"subQuads": [{"subQuadKey":"1","version":4,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"},{"subQuadKey":"23","version":4,"dataHandle":"2d696e1f-4145-4bc9-b2b0-7420d1bc78c2"},{"subQuadKey":"28","version":4,"dataHandle":"f9a9fd8e-eb1b-48e5-bfdb-4392b3826443"},{"subQuadKey":"29","version":4,"dataHandle":"e119d20e-c7c6-4563-ae88-8aa5c6ca75c3"},{"subQuadKey":"30","version":4,"dataHandle":"a7a1afdf-db7e-4833-9627-d38bee6e2f81"},{"subQuadKey":"31","version":4,"dataHandle":"9d515348-afce-44e8-bc6f-3693cfbed104"},{"subQuadKey":"7","version":4,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": []})jsonString"
 
 #define HTTP_RESPONSE_QUADKEYS_5904591 \
   R"jsonString({"subQuads": [{"version":4,"subQuadKey":"4","dataHandle":"f9a9fd8e-eb1b-48e5-bfdb-4392b3826443"},{"version":4,"subQuadKey":"5","dataHandle":"e119d20e-c7c6-4563-ae88-8aa5c6ca75c3"},{"version":4,"subQuadKey":"6","dataHandle":"a7a1afdf-db7e-4833-9627-d38bee6e2f81"},{"version":4,"subQuadKey":"7","dataHandle":"9d515348-afce-44e8-bc6f-3693cfbed104"},{"version":4,"subQuadKey":"1","dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": [{"version":4,"partition":"1476147","dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"}]})jsonString"


### PR DESCRIPTION
Check requested tiles handles in cache.
Add only one quad for requested tile, even if levels widht are more than 4.
Request data only for requested tiles.
Update tests.

Resolves:OLPSUP-9847
