### PR TITLE
RemoveFromCache API for VersionedLayerClient.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -318,6 +318,15 @@ class DATASERVICE_READ_API VersionedLayerClient final {
   client::CancellableFuture<PrefetchTilesResponse> PrefetchTiles(
       PrefetchTilesRequest request);
 
+  /**
+   * @brief Removes the partition from the mutable disk cache.
+   *
+   * @param partition_id The partition ID that should be removed.
+   *
+   * @return True if partition data is removed successfully; false otherwise.
+   */
+  bool RemoveFromCache(const std::string& partition_id);
+
  private:
   std::unique_ptr<VersionedLayerClientImpl> impl_;
 };

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
@@ -94,6 +94,10 @@ client::CancellableFuture<DataResponse> VersionedLayerClient::GetData(
   return impl_->GetData(std::move(request));
 }
 
+bool VersionedLayerClient::RemoveFromCache(const std::string& partition_id) {
+  return impl_->RemoveFromCache(partition_id);
+}
+
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -81,6 +81,8 @@ class VersionedLayerClientImpl {
   virtual client::CancellableFuture<PrefetchTilesResponse> PrefetchTiles(
       PrefetchTilesRequest request);
 
+  virtual bool RemoveFromCache(const std::string& partition_id);
+
  private:
   CatalogVersionResponse GetVersion(boost::optional<std::string> billing_tag,
                                     const FetchOptions& fetch_options,

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.cpp
@@ -62,12 +62,12 @@ boost::optional<model::Data> DataCacheRepository::Get(
   return std::move(cachedData);
 }
 
-void DataCacheRepository::Clear(const std::string& layer_id,
+bool DataCacheRepository::Clear(const std::string& layer_id,
                                 const std::string& data_handle) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, layer_id, data_handle);
-  OLP_SDK_LOG_TRACE_F(kLogTag, "Clear '%s'", key.c_str());
-  cache_->RemoveKeysWithPrefix(key);
+  OLP_SDK_LOG_INFO_F(kLogTag, "Clear '%s'", key.c_str());
+  return cache_->RemoveKeysWithPrefix(key);
 }
 
 }  // namespace repository

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.h
@@ -46,7 +46,7 @@ class DataCacheRepository final {
   boost::optional<model::Data> Get(const std::string& layer_id,
                                    const std::string& data_handle);
 
-  void Clear(const std::string& layer_id, const std::string& data_handle);
+  bool Clear(const std::string& layer_id, const std::string& data_handle);
 
  private:
   client::HRN hrn_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
@@ -63,6 +63,11 @@ class PartitionsCacheRepository final {
                        const std::vector<std::string>& partitionIds,
                        const std::string& layer_id);
 
+  bool ClearPartitionMetadata(int64_t catalog_version,
+                              const std::string& partition_id,
+                              const std::string& layer_id,
+                              boost::optional<model::Partition>& out_partition);
+
  private:
   client::HRN hrn_;
   std::shared_ptr<cache::KeyValueCache> cache_;

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -344,8 +344,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataFromPartitionAsync) {
   std::future<DataResponse> future = promise->get_future();
   auto partition = GetArgument("dataservice_read_test_partition");
   auto token = client->GetData(
-      olp::dataservice::read::DataRequest()
-          .WithPartitionId(partition),
+      olp::dataservice::read::DataRequest().WithPartitionId(partition),
       [promise](DataResponse response) { promise->set_value(response); });
 
   ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
@@ -380,8 +379,8 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
       catalog, layer, version, *settings_);
 
   auto partition = GetArgument("dataservice_read_test_partition");
-  auto data_request = olp::dataservice::read::DataRequest()
-                          .WithPartitionId(partition);
+  auto data_request =
+      olp::dataservice::read::DataRequest().WithPartitionId(partition);
   auto cancellable_future = client->GetData(std::move(data_request));
 
   auto raw_future = cancellable_future.GetFuture();
@@ -423,8 +422,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataFromPartitionSync) {
 
   auto partition = GetArgument("dataservice_read_test_partition");
   auto token = client->GetData(
-      olp::dataservice::read::DataRequest()
-          .WithPartitionId(partition),
+      olp::dataservice::read::DataRequest().WithPartitionId(partition),
       [&response](DataResponse resp) { response = std::move(resp); });
   ASSERT_TRUE(response.IsSuccessful());
   ASSERT_TRUE(response.GetResult() != nullptr);
@@ -459,8 +457,8 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
   ASSERT_TRUE(client);
 
   auto partition = GetArgument("dataservice_read_test_partition");
-  auto data_request = olp::dataservice::read::DataRequest()
-                          .WithPartitionId(partition);
+  auto data_request =
+      olp::dataservice::read::DataRequest().WithPartitionId(partition);
   auto cancellable_future = client->GetData(std::move(data_request));
 
   auto raw_future = cancellable_future.GetFuture();
@@ -621,8 +619,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataEmptyPartitionsSync) {
 
   auto partition = GetArgument("dataservice_read_test_partition");
   auto token = client->GetData(
-      olp::dataservice::read::DataRequest()
-          .WithPartitionId(partition),
+      olp::dataservice::read::DataRequest().WithPartitionId(partition),
       [&response](DataResponse resp) { response = std::move(resp); });
   ASSERT_FALSE(response.IsSuccessful());
   ASSERT_FALSE(response.GetResult() != nullptr);
@@ -2673,40 +2670,39 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetTileTwoSequentialCalls) {
   auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
       hrn, "testlayer", 4, *settings_);
 
-    EXPECT_CALL(*network_mock_,
-                Send(IsGetRequest(kHttpLookupQuery), _, _, _, _))
-        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                         olp::http::HttpStatusCode::OK),
-                                     kHttpResponseLookupApiQuery));
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(kHttpLookupQuery), _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseLookupApiQuery));
 
-    EXPECT_CALL(*network_mock_,
-                Send(IsGetRequest(kHttpQueryTreeIndex), _, _, _, _))
-        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                         olp::http::HttpStatusCode::OK),
-                                     kHttpSubQuads));
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(kHttpQueryTreeIndex), _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpSubQuads));
 
-    EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
-        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                         olp::http::HttpStatusCode::OK),
-                                     kHttpResponseLookupBlob));
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseLookupBlob));
 
-    EXPECT_CALL(*network_mock_,
-                Send(IsGetRequest(kHttpResponseBlobData_5904591), _, _, _, _))
-        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                         olp::http::HttpStatusCode::OK),
-                                     "someData"));
-    {
-      SCOPED_TRACE("Request data using TileRequest");
-      auto request = olp::dataservice::read::TileRequest().WithTileKey(
-          olp::geo::TileKey::FromHereTile("5904591"));
-      auto data_response = client->GetData(request).GetFuture().get();
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(kHttpResponseBlobData_5904591), _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   "someData"));
+  {
+    SCOPED_TRACE("Request data using TileRequest");
+    auto request = olp::dataservice::read::TileRequest().WithTileKey(
+        olp::geo::TileKey::FromHereTile("5904591"));
+    auto data_response = client->GetData(request).GetFuture().get();
 
-      ASSERT_TRUE(data_response.IsSuccessful())
-          << ApiErrorToString(data_response.GetError());
-      ASSERT_LT(0, data_response.GetResult()->size());
-      std::string data_string(data_response.GetResult()->begin(),
-                              data_response.GetResult()->end());
-      ASSERT_EQ("someData", data_string);
+    ASSERT_TRUE(data_response.IsSuccessful())
+        << ApiErrorToString(data_response.GetError());
+    ASSERT_LT(0, data_response.GetResult()->size());
+    std::string data_string(data_response.GetResult()->begin(),
+                            data_response.GetResult()->end());
+    ASSERT_EQ("someData", data_string);
   }
   {
     SCOPED_TRACE("Neighboring tile, same subquad, check metadata cached");
@@ -2738,6 +2734,64 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetTileTwoSequentialCalls) {
                             data_response.GetResult()->end());
     ASSERT_EQ("someOtherData", data_string);
   }
+}
+
+TEST_F(DataserviceReadVersionedLayerClientTest, RemoveFromCache) {
+  EXPECT_CALL(*network_mock_, Send(_, _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseLookupQuery))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponsePartition_269))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseLookupBlob))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   kHttpResponseBlobData_269));
+
+  auto catalog = olp::client::HRN::FromString(
+      GetArgument("dataservice_read_test_catalog"));
+  auto layer = GetArgument("dataservice_read_test_layer");
+  auto version = std::stoi(GetArgument("dataservice_read_test_layer_version"));
+
+  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+      catalog, layer, version, *settings_);
+  ASSERT_TRUE(client);
+
+  // load and cache some data
+  auto promise = std::make_shared<std::promise<DataResponse>>();
+  auto future = promise->get_future();
+  auto partition = GetArgument("dataservice_read_test_partition");
+  auto data_request =
+      olp::dataservice::read::DataRequest().WithPartitionId(partition);
+  auto token = client->GetData(data_request, [promise](DataResponse response) {
+    promise->set_value(response);
+  });
+
+  ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
+  DataResponse response = future.get();
+
+  ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
+  ASSERT_NE(response.GetResult(), nullptr);
+  ASSERT_NE(response.GetResult()->size(), 0u);
+
+  // remove the data from cache
+  ASSERT_TRUE(client->RemoveFromCache(partition));
+
+  // check the data is not available in cache
+  promise = std::make_shared<std::promise<DataResponse>>();
+  future = promise->get_future();
+  data_request.WithFetchOption(CacheOnly);
+  token = client->GetData(data_request, [promise](DataResponse response) {
+    promise->set_value(response);
+  });
+
+  ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
+  response = future.get();
+
+  ASSERT_FALSE(response.IsSuccessful());
 }
 
 }  // namespace


### PR DESCRIPTION
Added new RemoveFromCache method. It's now possible to clear all cache
data for specific partition.
Added integration test for the new functionality.

Resolves: OLPEDGE-1567

Signed-off-by: Kostiantyn Zvieriev ext-kostiantyn.zvieriev@here.com