### PR TITLE
Refactor prefetch functionality.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
@@ -45,7 +45,8 @@ namespace read {
 class DATASERVICE_READ_API PrefetchTilesRequest final {
  public:
   /**
-   * @brief Gets a vector with the tile keys.
+   * @brief Gets a vector with the tile keys, which is root tiles for min/max
+   * level to prefetch.
    *
    * @return The vector with the tile keys.
    */
@@ -56,7 +57,8 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
   /**
    * @brief Sets the tile keys for the request.
    *
-   * @param tile_keys The vector with the tile keys.
+   * @param tile_keys The vector with the root tile keys for min/max level to
+   * prefetch.
    *
    * @return A reference to the updated `PrefetchTilesRequest` instance.
    */
@@ -69,7 +71,8 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
   /**
    * @brief Sets the tile keys for the request.
    *
-   * @param tile_keys The rvalue reference to the vector with the tile keys.
+   * @param tile_keys The rvalue reference to the vector with the tile keys,
+   * which is root tiles for min/max level to prefetch.
    *
    * @return A reference to the updated `PrefetchTilesRequest` instance.
    */
@@ -80,16 +83,16 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
   }
 
   /**
-   * @brief Gets the minimum tile level.
+   * @brief Gets the minimum tiles level to prefetch.
    *
    * @return The minimum tile level.
    */
   inline unsigned int GetMinLevel() const { return min_level_; }
 
   /**
-   * @brief Sets the minimum tile level for the request.
+   * @brief Sets the minimum tiles level for the request.
    *
-   * @param min_level The minimum tile level.
+   * @param min_level The minimum tiles level to prefetch.
    *
    * @return A reference to the updated `PrefetchTilesRequest` instance.
    */
@@ -98,7 +101,7 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
     return *this;
   }
   /**
-   * @brief Gets the maximum tile level.
+   * @brief Gets the maximum tiles level to prefetch.
    *
    * @return The maximum tile level.
    */
@@ -107,7 +110,7 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
   /**
    * @brief Sets the maximum tile level for the request.
    *
-   * @param max_level The maximum tile level.
+   * @param max_level The maximum tile level to prefetch.
    *
    * @return A reference to the updated `PrefetchTilesRequest` instance.
    */

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
@@ -67,7 +67,7 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
   }
 
   /**
-   * @brief Sets the tile keys for the request.
+   * @brief Sets the vector of the root tile keys for the request.
    *
    * @param tile_keys The rvalue reference to the vector with the root tile keys
    * of the prefetch.

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
@@ -45,8 +45,7 @@ namespace read {
 class DATASERVICE_READ_API PrefetchTilesRequest final {
  public:
   /**
-   * @brief Gets a vector with the tile keys, which is root tiles for min/max
-   * level to prefetch.
+   * @brief Get the vector of the root tile keys.
    *
    * @return The vector with the tile keys.
    */
@@ -55,10 +54,9 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
   }
 
   /**
-   * @brief Sets the tile keys for the request.
+   * @brief Sets the vector of the root tile keys for the request.
    *
-   * @param tile_keys The vector with the root tile keys for min/max level to
-   * prefetch.
+   * @param tile_keys The vector with the root tile keys of the prefetch.
    *
    * @return A reference to the updated `PrefetchTilesRequest` instance.
    */
@@ -71,8 +69,8 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
   /**
    * @brief Sets the tile keys for the request.
    *
-   * @param tile_keys The rvalue reference to the vector with the tile keys,
-   * which is root tiles for min/max level to prefetch.
+   * @param tile_keys The rvalue reference to the vector with the root tile keys
+   * of the prefetch.
    *
    * @return A reference to the updated `PrefetchTilesRequest` instance.
    */
@@ -100,6 +98,7 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
     min_level_ = min_level;
     return *this;
   }
+
   /**
    * @brief Gets the maximum tiles level to prefetch.
    *

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -280,8 +280,8 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    *
    * This method recursively downloads all tile keys from the `minLevel`
    * parameter to the `maxLevel` parameter of the \c PrefetchTilesRequest
-   * object. It helps to reduce the network load by using the prefetched tiles
-   * data from the cache.
+   * object for the given root tiles. It helps to reduce the network load by
+   * using the prefetched tiles data from the cache.
    *
    * @note This method does not guarantee that all tiles are available offline
    * as the cache might overflow, and data might be evicted at any point.
@@ -302,8 +302,8 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    *
    * This method recursively downloads all tile keys from the `minLevel`
    * parameter to the `maxLevel` parameter of the \c PrefetchTilesRequest
-   * object. It helps to reduce the network load by using the prefetched tiles
-   * data from the cache.
+   * object for the given root tiles. It helps to reduce the network load by
+   * using the prefetched tiles data from the cache.
    *
    * @note This method does not guarantee that all tiles are available offline
    * as the cache might overflow, and data might be evicted at any point.

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -278,10 +278,12 @@ class DATASERVICE_READ_API VersionedLayerClient final {
   /**
    * @brief Prefetches a set of tiles asynchronously.
    *
-   * This method recursively downloads all tile keys from the `minLevel`
-   * parameter to the `maxLevel` parameter of the \c PrefetchTilesRequest
-   * object for the given root tiles. It helps to reduce the network load by
-   * using the prefetched tiles data from the cache.
+   * This method recursively downloads all tile keys from the `min_level`
+   * parameter to the `max_level` parameter of the \c PrefetchTilesRequest
+   * object for the given root tiles. If min_level/max_level are the same or
+   * default, only tiles listed in \c PrefetchTilesRequest will be downloaded.
+   * Only tiles will be downloaded which are not already present in the cache,
+   * this helps reduce the network load.
    *
    * @note This method does not guarantee that all tiles are available offline
    * as the cache might overflow, and data might be evicted at any point.
@@ -300,10 +302,12 @@ class DATASERVICE_READ_API VersionedLayerClient final {
   /**
    * @brief Prefetches a set of tiles asynchronously.
    *
-   * This method recursively downloads all tile keys from the `minLevel`
-   * parameter to the `maxLevel` parameter of the \c PrefetchTilesRequest
-   * object for the given root tiles. It helps to reduce the network load by
-   * using the prefetched tiles data from the cache.
+   * This method recursively downloads all tile keys from the `min_level`
+   * parameter to the `max_level` parameter of the \c PrefetchTilesRequest
+   * object for the given root tiles. If min_level/max_level are the same or
+   * default, only tiles listed in \c PrefetchTilesRequest will be downloaded.
+   * Only tiles will be downloaded which are not already present in the cache,
+   * this helps reduce the network load.
    *
    * @note This method does not guarantee that all tiles are available offline
    * as the cache might overflow, and data might be evicted at any point.

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -306,9 +306,8 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
 
           AddTask(settings.task_scheduler, pending_requests,
                   [=](CancellationContext inner_context) {
-                    // Get blob data
-                    // need to be changed to check if data in cache, if not,
-                    // only than load it
+                    // TODO: Get blob data need to be changed to check if data
+                    // in cache, if not, only than load it
                     auto data = repository::DataRepository::GetVersionedData(
                         catalog, layer_id,
                         DataRequest().WithDataHandle(handle).WithBillingTag(

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -136,11 +136,6 @@ void PrefetchTilesRepository::SplitSubtree(
 RootTilesForRequest PrefetchTilesRepository::GetSlicedTilesForRequest(
     const std::vector<geo::TileKey>& tile_keys, unsigned int min,
     unsigned int max) {
-  // adjust min/max values.
-  if (min > max || max >= geo::TileKey().Level()) {
-    // min/max levels are wrong. Reset to dafault case, which is 0/0
-    min = max = 0;
-  }
 
   RootTilesForRequest root_tiles_depth;
   // adjust root tiles to min level
@@ -268,8 +263,10 @@ SubQuadsResponse PrefetchTilesRepository::GetSubQuads(
 
   for (const auto& subquad : subquads) {
     auto subtile = tile.AddedSubHereTile(subquad->GetSubQuadKey());
-    OLP_SDK_LOG_INFO_F(kLogTag, "GetSubQuad key(%s, %" PRId64 ", %" PRId32 ")",
-                       subtile.ToHereTile().c_str(), version, depth);
+    OLP_SDK_LOG_TRACE_F(kLogTag,
+                        "GetSubQuad key(%s, %s | %" PRId64 ", %" PRId32 ")",
+                        subtile.ToHereTile().c_str(),
+                        subquad->GetDataHandle().c_str(), version, depth);
     // Add to result
     result.emplace(subtile, subquad->GetDataHandle());
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -67,10 +67,11 @@ void PrefetchTilesRepository::SplitSubtree(
     const std::uint64_t endTileKey = beginTileKey + childCount;
 
     for (std::uint64_t key = beginTileKey; key < endTileKey; ++key) {
-      auto it = root_tiles_depth.insert({geo::TileKey::FromQuadKey64(key), 4});
+      auto it = root_tiles_depth.insert(
+          {geo::TileKey::FromQuadKey64(key), kMaxQuadTreeIndexDepth});
       // element already exist, update depth with max value(should never hapen)
       if (it.second == false) {
-        it.first->second = 4;
+        it.first->second = kMaxQuadTreeIndexDepth;
       }
     }
     depth -= (kMaxQuadTreeIndexDepth + 1);
@@ -90,13 +91,15 @@ RootTilesForRequest PrefetchTilesRepository::GetSlicedTiles(
     if (max_level == min_level) {
       if (max_level == 0) {  // special case, adjust levels to input tile level
         max_level = tile_key.Level();
-        min_level =
-            (max_level > kMaxQuadTreeIndexDepth) ? (max_level - 4) : (1);
+        min_level = (max_level > kMaxQuadTreeIndexDepth)
+                        ? (max_level - kMaxQuadTreeIndexDepth)
+                        : (1);
       } else {
         // min max values are the same
         // to reduce methadata requests, go 4 levels up
-        min_level =
-            (min_level > kMaxQuadTreeIndexDepth) ? (min_level - 4) : (1);
+        min_level = (min_level > kMaxQuadTreeIndexDepth)
+                        ? (min_level - kMaxQuadTreeIndexDepth)
+                        : (1);
       }
     }
 
@@ -201,7 +204,6 @@ SubQuadsResponse PrefetchTilesRepository::GetSubQuads(
   model::Partitions partitions;
 
   const auto& subquads = quad_tree.GetResult().GetSubQuads();
-  // result.reserve(subquads.size());
   partitions.GetMutablePartitions().reserve(subquads.size());
 
   for (const auto& subquad : subquads) {

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -93,13 +93,13 @@ RootTilesForRequest PrefetchTilesRepository::GetSlicedTiles(
         max_level = tile_key.Level();
         min_level = (max_level > kMaxQuadTreeIndexDepth)
                         ? (max_level - kMaxQuadTreeIndexDepth)
-                        : (1);
+                        : (1u);
       } else {
         // min max values are the same
         // to reduce methadata requests, go 4 levels up
         min_level = (min_level > kMaxQuadTreeIndexDepth)
                         ? (min_level - kMaxQuadTreeIndexDepth)
-                        : (1);
+                        : (1u);
       }
     }
 
@@ -208,7 +208,7 @@ SubQuadsResponse PrefetchTilesRepository::GetSubQuads(
 
   for (const auto& subquad : subquads) {
     auto subtile = tile.AddedSubHereTile(subquad->GetSubQuadKey());
-    OLP_SDK_LOG_TRACE_F(kLogTag,
+    OLP_SDK_LOG_DEBUG_F(kLogTag,
                         "GetSubQuad key(%s, %s | %" PRId64 ", %" PRId32 ")",
                         subtile.ToHereTile().c_str(),
                         subquad->GetDataHandle().c_str(), version, depth);

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
@@ -56,7 +56,7 @@ class PrefetchTilesRepository final {
    * @param minLevel Minimum level of the resultant tile keys.
    * @param maxLevel Maximum level of the resultant tile keys.
    */
-  static RootTilesForRequest GetSlicedTilesForRequest(
+  static RootTilesForRequest GetSlicedTiles(
       const std::vector<geo::TileKey>& tile_keys, unsigned int min,
       unsigned int max);
 
@@ -76,9 +76,6 @@ class PrefetchTilesRepository final {
                                       client::CancellationContext context);
   static void SplitSubtree(RootTilesForRequest& root_tiles_depth,
                            RootTilesForRequest::iterator subtree_to_split);
-  static std::vector<geo::TileKey> GetChildsAt4LevelsDown(
-      const geo::TileKey& tile_key);
-  static std::vector<geo::TileKey> GetChilds(const geo::TileKey& tile_key);
 };
 
 }  // namespace repository

--- a/tests/integration/olp-cpp-sdk-dataservice-read/HttpResponses.h
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/HttpResponses.h
@@ -220,6 +220,9 @@
 #define URL_QUADKEYS_369036 \
   R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/369036/depths/0)"
 
+#define URL_QUADKEYS_92259 \
+  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/92259/depths/4)"
+
 #define URL_QUERY_PARTITION_23618365 \
   R"(https://query.data.api.platform.here.com/query/v1/catalogs/)"+GetTestCatalog()+R"(/layers/hype-test-prefetch/partitions?partition=23618365&version=4)"
 
@@ -267,6 +270,9 @@
 
 #define HTTP_RESPONSE_QUADKEYS_369036 \
   R"jsonString({"subQuads": [{"version":4,"subQuadKey":"1","dataHandle":"data:Embedded Data for 369036"}],"parentQuads": []})jsonString"
+
+#define HTTP_RESPONSE_QUADKEYS_92259 \
+R"jsonString({"subQuads": [{"subQuadKey":"19","version":4,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"},{"subQuadKey":"311","version":4,"dataHandle":"2d696e1f-4145-4bc9-b2b0-7420d1bc78c2"},{"subQuadKey":"316","version":4,"dataHandle":"f9a9fd8e-eb1b-48e5-bfdb-4392b3826443"},{"subQuadKey":"317","version":4,"dataHandle":"e119d20e-c7c6-4563-ae88-8aa5c6ca75c3"},{"subQuadKey":"318","version":4,"dataHandle":"a7a1afdf-db7e-4833-9627-d38bee6e2f81"},{"subQuadKey":"319","version":4,"dataHandle":"9d515348-afce-44e8-bc6f-3693cfbed104"},{"subQuadKey":"79","version":4,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": []})jsonString"
 
 #define HTTP_RESPONSE_BLOB_DATA_PREFETCH_1 \
   R"(--644ff000-704a-4f45-9988-c628602b7064)"

--- a/tests/integration/olp-cpp-sdk-dataservice-read/HttpResponses.h
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/HttpResponses.h
@@ -212,7 +212,7 @@
   R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/23618364/depths/0)"
 
 #define URL_QUADKEYS_1476147 \
-  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/1476147/depths/0)"
+  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/1476147/depths/2)"
 
 #define URL_QUADKEYS_5904591 \
   R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/5904591/depths/1)"

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -1542,7 +1542,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesWithCache) {
 
     auto request = olp::dataservice::read::PrefetchTilesRequest()
                        .WithTileKeys(tile_keys)
-                       .WithMinLevel(10)
+                       .WithMinLevel(11)
                        .WithMaxLevel(12);
 
     auto promise = std::make_shared<std::promise<PrefetchTilesResponse>>();
@@ -1590,7 +1590,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesWithCache) {
     std::future<DataResponse> future = promise->get_future();
 
     auto token = client->GetData(olp::dataservice::read::DataRequest()
-                                     .WithPartitionId("1476147")
+                                     .WithPartitionId("23618366")
                                      .WithFetchOption(CacheOnly),
                                  [promise](DataResponse response) {
                                    promise->set_value(std::move(response));
@@ -1671,7 +1671,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
       olp::geo::TileKey::FromHereTile(kParitionId)};
   auto request = olp::dataservice::read::PrefetchTilesRequest()
                      .WithTileKeys(tile_keys)
-                     .WithMinLevel(10)
+                     .WithMinLevel(11)
                      .WithMaxLevel(12);
 
   auto token = client->PrefetchTiles(


### PR DESCRIPTION
Split functionality to two categories. With default min/max levels prefetch only requested tiles.
With valid levels, which differs prefetch all tiles in subtre from min to max levels.
Create slicing of subtree using depth equal 4.

Resolves:OLPSUP-9847

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>