### PR TITLE
Update centos build for weekly security test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,9 @@ wv_security_job:
   tags:
   - docker-prod
   image: ${DOCKER_REGISTRY}/${DOCKER_IMAGE_SECURITY}:${DOCKER_IMAGE_SECURITY_VERSION}
+  variables:
+    LD_PRELOAD: "/lib64/libSegFault.so"
+    SEGFAULT_SIGNALS: "all"
   script:
   - $CI_PROJECT_DIR/scripts/linux/weekly/build_centos_debug_wv.sh --centos
   - $CI_PROJECT_DIR/scripts/linux/weekly/security_scanner_upload_wv.sh build/binaries.tar.gz OLP_EDGE_CI@here.com

--- a/scripts/linux/weekly/build_centos_debug_wv.sh
+++ b/scripts/linux/weekly/build_centos_debug_wv.sh
@@ -31,14 +31,14 @@ export BUILD_DIR="$WORKSPACE/$BUILD_DIR_NAME"
 export ARCHIVE_FILE_NAME="binaries.tar.gz"      # artifact name is defined by CI so please do not rename it
 export BUILD_ZIP=1                              # always build artifacts
 
-export CMAKE_CXX_FLAGS="-march=x86-64 -gdwarf-2 -g3 -O0 -fno-builtin"
-export CMAKE_C_FLAGS="-march=x86-64 -gdwarf-2 -g3 -O0 -fno-builtin"
+export CMAKE_CXX_FLAGS="-march=x86-64 -gdwarf-2 -g3 -O0 -fno-builtin -Wall -Wextra -Werror -Wno-deprecated-declarations -Wno-unused-parameter -Wno-unused-function -Wno-attributes"
+export CMAKE_C_FLAGS="-march=x86-64 -gdwarf-2 -g3 -O0 -fno-builtin -Wall -Wextra -Werror -Wno-deprecated-declarations -Wno-unused-parameter -Wno-unused-function -Wno-attributes"
 
 # Add more parameters into CMAKE_PARAM below when needed
 export FLAVOR="Debug"
 export CMAKE_PARAM="-DCMAKE_CXX_FLAGS=\"${CMAKE_CXX_FLAGS}\" -DCMAKE_C_FLAGS=\"${CMAKE_C_FLAGS}\" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=$FLAVOR -DOLP_SDK_BUILD_EXAMPLES=ON"
 export CMAKE_COMMAND="cmake ${CMAKE_PARAM} .."
-export CMAKE_BUILD_ALL_TARGETS="cmake --build . -- -j8"
+export CMAKE_BUILD_ALL_TARGETS="make -j$(nproc)"
 
 # Function :
 build_for_centos() {
@@ -67,8 +67,7 @@ build_for_centos() {
         # Prepare artifacts archive for test job
         # Zip up all the binaries needed to run the tests but need to leave the tar.gz file in build
         # folder as this ensure the CI system archives it automatically
-        tar -czf "${BUILD_DIR_NAME}/$ARCHIVE_FILE_NAME" --exclude='*.git' \
-            "${BUILD_DIR_NAME}/olp-*/*.so"
+        tar -czf "${BUILD_DIR_NAME}/$ARCHIVE_FILE_NAME" --exclude='*.git' --wildcards ${BUILD_DIR_NAME}/olp-*/*.so
         # List files in build archive
         tar -tvf "${BUILD_DIR_NAME}/$ARCHIVE_FILE_NAME"
     fi

--- a/scripts/linux/weekly/security_scanner_upload_wv.sh
+++ b/scripts/linux/weekly/security_scanner_upload_wv.sh
@@ -46,7 +46,7 @@ tar -tvf build/binaries.tar.gz
 
 echo "Packed file: $1. Uploading it..."
 
-curl -f -v -k -H"X-spc-${SECURITY_SCANNER}-username:${SECURITY_API_USER}" -H"X-spc-${SECURITY_SCANNER}-password:${SECURITY_API_PWD}" \
+/usr/local/bin/curl -f -v -k -H"X-spc-${SECURITY_SCANNER}-username:${SECURITY_API_USER}" -H"X-spc-${SECURITY_SCANNER}-password:${SECURITY_API_PWD}" \
 -H"X-spc-${SECURITY_SCANNER}-email:$2" -F"file=@$1" https://${SECURITY_API_URL}/${SECURITY_SCANNER}-ws/analysis/start/454830/version/edge-sdk-cpp-${LATEST_HASH}
 
 echo "File $1 was uploaded to Security Scanner via API"


### PR DESCRIPTION
Add LD_PRELOAD var to centos build.Add missed flags.
Remove not needed flag. Switched from cmake to make.
Make shell using latest curl. Fix archiving.

Relates-TO: OLPEDGE-1725, OLPEDGE-896

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>