### PR TITLE
RemoveFromCache by TileKey for VersionedLayerClient

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -331,6 +331,15 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    */
   bool RemoveFromCache(const std::string& partition_id);
 
+  /**
+   * @brief Removes the tile from the mutable disk cache.
+   *
+   * @param tile The tile key that should be removed.
+   *
+   * @return True if tile data is removed successfully; false otherwise.
+   */
+  bool RemoveFromCache(const geo::TileKey& tile);
+
  private:
   std::unique_ptr<VersionedLayerClientImpl> impl_;
 };

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
@@ -98,6 +98,11 @@ bool VersionedLayerClient::RemoveFromCache(const std::string& partition_id) {
   return impl_->RemoveFromCache(partition_id);
 }
 
+bool VersionedLayerClient::RemoveFromCache(const geo::TileKey& tile) {
+  return impl_->RemoveFromCache(tile);
+}
+
+
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -498,6 +498,11 @@ bool VersionedLayerClientImpl::RemoveFromCache(
   return data_repository.Clear(layer_id_, partition.get().GetDataHandle());
 }
 
+bool VersionedLayerClientImpl::RemoveFromCache(const geo::TileKey& tile) {
+  auto partition_id = tile.ToHereTile();
+  return RemoveFromCache(partition_id);
+}
+
 PORTING_POP_WARNINGS()
 }  // namespace read
 }  // namespace dataservice

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -83,6 +83,8 @@ class VersionedLayerClientImpl {
 
   virtual bool RemoveFromCache(const std::string& partition_id);
 
+  virtual bool RemoveFromCache(const geo::TileKey& tile);
+
  private:
   CatalogVersionResponse GetVersion(boost::optional<std::string> billing_tag,
                                     const FetchOptions& fetch_options,


### PR DESCRIPTION
Overloading RemoveFromCache() method with TileKey input. Its reusing
previous method implementation, so added integration and unit tests are
similar.

Resolves: OLPEDGE-1567

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>