### PR TITLE
Security fix in AuthenticationClient

### DIFF
--- a/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
@@ -615,7 +615,7 @@ client::CancellationToken AuthenticationClient::Impl::SignInFederated(
     AuthenticationClient::SignInUserCallback callback) {
   auto payload =
       std::make_shared<std::vector<unsigned char>>(request_body.size());
-  std::memcpy(payload->data(), request_body.data(), request_body.size());
+  std::memcpy(payload->data(), request_body.data(), payload->size());
   return HandleUserRequest(credentials, kOauthEndpoint, payload, callback);
 }
 


### PR DESCRIPTION
Fixed possible stack overflow while copying data
from string in AuthenticationClient::Impl::SignInFederated

Resolves: OLPEDGE-1716

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>