### PR TITLE
Adapts core/geo files to coding style.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/geo/coordinates/GeoCoordinates.h
+++ b/olp-cpp-sdk-core/include/olp/core/geo/coordinates/GeoCoordinates.h
@@ -25,6 +25,7 @@
 
 namespace olp {
 namespace geo {
+
 /**
  * @brief A geographic location using WGS84 coordinates.
  *
@@ -37,12 +38,13 @@ namespace geo {
 class CORE_API GeoCoordinates {
  public:
   /**
-   * @brief Construct default geo coordinates
+   * @brief Construct default invalid geo coordinates.
    */
   GeoCoordinates();
 
   /**
-   * @brief Construct geo coordinates form latitude and longitude
+   * @brief Construct geo coordinates form latitude and longitude.
+   *
    * @param latitude_radians WGS84 latitude in radians. Valid values are in
    * [-Pi/2, Pi/2] range.
    * @param longitude_radians WGS84 longitude in radians. Valid values are in
@@ -51,7 +53,8 @@ class CORE_API GeoCoordinates {
   GeoCoordinates(double latitude_radians, double longitude_radians);
 
   /**
-   * @brief Construct geo coordinates form latitude and longitude in degrees
+   * @brief Construct geo coordinates form latitude and longitude in degrees.
+   *
    * @param latitude_degrees WGS84 latitude in degrees. Valid values are in
    * [-90, 90] range.
    * @param longitude_degrees WGS84 longitude in degrees. Valid values are in
@@ -63,10 +66,12 @@ class CORE_API GeoCoordinates {
 
   /**
    * @brief Create GeoCoordinates from latitude and longitude in degrees.
+   *
    * @param latitude_degrees WGS84 latitude in degrees. Valid value is in [-90,
    * 90] range.
    * @param longitude_degrees WGS84 longitude in degrees. Valid value is in
    * [-180, 180) range.
+   *
    * @return GeoCoordinate based on specified input.
    * Use normalized() to put values in a valid range.
    */
@@ -75,33 +80,42 @@ class CORE_API GeoCoordinates {
 
   /**
    * @brief Create GeoCoordinates from GeoPoint.
+   *
    * @param geo_point Geo point to convert to.
+   *
    * @return GeoCoordinate based on specified geoPoint.
    */
   static GeoCoordinates FromGeoPoint(const GeoPoint& geo_point);
 
   /**
    * @brief Return geo coordinate as GeoPoint.
+   *
    * @return current coordinate as a GeoPoint.
    */
   GeoPoint ToGeoPoint() const;
 
   /**
    * @brief Return WGS84 latitude in radians.
+   *
    * @return WGS84 latitude in radians.
    */
   double GetLatitude() const;
+
   /**
    * @brief Set latitude in radians.
+   *
    * @param latitude_radians WGS84 latitude in radians. Valid values are in
    * [-Pi/2, Pi/2] range.
    */
   void SetLatitude(double latitude_radians);
+
   /**
    * @brief Return WGS84 longitude in radians.
+   *
    * @return WGS84 longitude in radians.
    */
   double GetLongitude() const;
+
   /**
    * @brief Set longitude in radians.
    * @param longitude_radians WGS84 longitude in radians. Valid values are in
@@ -111,23 +125,29 @@ class CORE_API GeoCoordinates {
 
   /**
    * @brief Return WGS84 latitude in degrees.
+   *
    * @return WGS84 latitude in degrees.
    */
   double GetLatitudeDegrees() const;
 
   /**
    * @brief Set latitude in degrees.
+   *
    * @param latitude_degrees WGS84 latitude in degrees. Valid values are in
    * [-90, 90] range.
    */
   void SetLatitudeDegrees(double latitude_degrees);
+
   /**
    * @brief Return WGS84 longitude in degrees.
+   *
    * @return WGS84 longitude in degrees.
    */
   double GetLongitudeDegrees() const;
+
   /**
    * @brief Set longitude in degrees.
+   *
    * @param longitude_degrees WGS84 longitude in degrees. Valid values are in
    * [-180, 180) range.
    */
@@ -135,30 +155,48 @@ class CORE_API GeoCoordinates {
 
   /**
    * @brief Normalize the latitude and longitude to [-Pi/2, Pi/2], [-Pi, Pi)
-   * range. To that end, longitude wraps around at +/- Pi and latitude is
-   * clamped at +/- Pi/2
+   * range.
+   *
+   * To that end, longitude wraps around at +/- Pi and latitude is clamped at
+   * +/- Pi/2.
    */
   GeoCoordinates Normalized() const;
+
   /**
-   * @brief Overload the bool operator. Return true if the coordinates are valid.
+   * @brief Overload the bool operator.
+   *
+   * Returns true if the coordinates are valid.
+   *
    * @see IsValid
    */
   explicit operator bool() const;
+
   /**
    * @brief Check if the radian values of latitude and longitude are valid
-   * double numbers. The check happens with the help of math::isnan.
+   * double numbers.
+   *
+   * The check happens with the help of math::isnan.
+   *
    * @return true if the result of the check is positive,
    * false if it is negative.
    */
   bool IsValid() const;
 
  private:
-  double latitude_;   ///< Latitude in radians.
-  double longitude_;  ///< Longitude in radians.
+  /// Latitude in radians.
+  double latitude_;
+  /// Longitude in radians.
+  double longitude_;
+  /// Const used to signalize an invalid value latitude or longitude.
   static const double kNaN_;
 };
 
-bool operator==(const GeoCoordinates& lhs, const GeoCoordinates& rhs);
+/**
+ * @brief Compare operator for comparing two coordinates with each other.
+ *
+ * @return true if the two GeoCoordinates are equal, false otherwise.
+ */
+CORE_API bool operator==(const GeoCoordinates& lhs, const GeoCoordinates& rhs);
 
 }  // namespace geo
 }  // namespace olp

--- a/olp-cpp-sdk-core/include/olp/core/geo/coordinates/GeoCoordinates3d.h
+++ b/olp-cpp-sdk-core/include/olp/core/geo/coordinates/GeoCoordinates3d.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,19 +24,23 @@
 
 namespace olp {
 namespace geo {
+
 /**
  * Geodetic coordinates with longitude, latitude and altitude.
  */
 class CORE_API GeoCoordinates3d {
  public:
   /**
-   * Construct invalid geodetic coordinates.
+   * @brief Construct invalid geodetic coordinates.
+   *
    * @post Latitude, longitude and altitude are undefined (NaN).
    */
   GeoCoordinates3d();
 
   /**
-   * Construct geodetic coordinates from latitude, longitude and altitude.
+   * @brief Construct geodetic coordinates from latitude, longitude and
+   * altitude.
+   *
    * @param[in] latitude_radians Latitude in radians.
    * @param[in] longitude_radians Longitude in radians.
    * @param[in] altitude_meters Altitude in meters.
@@ -45,24 +49,29 @@ class CORE_API GeoCoordinates3d {
                    double altitude_meters);
 
   /**
-   * Construct geodetic coordinates from latitude, longitude and altitude.
+   * @brief Construct geodetic coordinates from latitude, longitude and
+   * altitude.
+   *
    * @param[in] latitudeDegrees Latitude in degrees.
    * @param[in] longitudeDegrees Longitude in degrees.
    * @param[in] altitude_meters Altitude in meters.
    * @param[in] degrees Degree tag.
    */
-  GeoCoordinates3d(double latitudeDegrees, double longitudeDegrees,
+  GeoCoordinates3d(double latitude_degrees, double longitude_degrees,
                    double altitude_meters, DegreeType degrees);
 
   /**
-   * Construct geodetic coordinates from 2D coordinates with undefined altitude.
+   * @brief Construct geodetic coordinates from 2D coordinates with undefined
+   * altitude.
+   *
    * @param[in] geo_coordinates 2D geodetic coordinates.
    * @post Altitude is undefined (NaN).
    */
   explicit GeoCoordinates3d(const GeoCoordinates& geo_coordinates);
 
   /**
-   * Construct geodetic coordinates from 2D coordinates and an altitude.
+   * @brief Construct geodetic coordinates from 2D coordinates and an altitude.
+   *
    * @param[in] geo_coordinates 2D geodetic coordinates.
    * @param[in] altitude_meters Altitude in meters.
    */
@@ -70,108 +79,121 @@ class CORE_API GeoCoordinates3d {
                    double altitude_meters);
 
   /**
-   * Create geodetic coordinates from latitude and longitude in degrees.
+   * @brief Create geodetic coordinates from latitude and longitude in degrees.
+   *
    * @param[in] latitude Latitude in degrees.
    * @param[in] longitude Longitude in degrees.
    * @param[in] altitude Altitude in meters.
    * @return Geodetic coordinates.
    */
-  static GeoCoordinates3d FromDegrees(double latitude,
-                                      double longitude,
+  static GeoCoordinates3d FromDegrees(double latitude, double longitude,
                                       double altitude = 0.0);
 
   /**
-   * Create geodetic coordinates from latitude and longitude in radians.
+   * @brief Create geodetic coordinates from latitude and longitude in radians.
+   *
    * @param[in] latitude Latitude in radians.
    * @param[in] longitude Longitude in radians.
    * @param[in] altitude Altitude in meters.
    * @return Geodetic coordinates.
    */
-  static GeoCoordinates3d FromRadians(double latitude,
-                                      double longitude,
+  static GeoCoordinates3d FromRadians(double latitude, double longitude,
                                       double altitude = 0.0);
 
   /**
    * @brief Get latitude and longitude as 2D geodetic coordinates.
+   *
    * @return 2D geodetic coordinates.
    */
   const GeoCoordinates& GetGeoCoordinates() const;
 
   /**
    * @brief Set latitude and longitude from 2D geodetic coordinates.
+   *
    * @param[in] geo_coordinates 2D geodetic coordinates.
    */
   void SetGeoCoordinates(const GeoCoordinates& geo_coordinates);
 
   /**
    * @brief Get latitude.
+   *
    * @return Latitude in radians.
    */
   double GetLatitude() const;
 
   /**
-   * Set latitude.
+   * @brief Set latitude.
+   *
    * @param[in] latitude_radians Latitude in radians.
    */
   void SetLatitude(double latitude_radians);
 
   /**
-   * Get longitude.
+   * @brief Get longitude.
+   *
    * @return Longitude in radians.
    */
   double GetLongitude() const;
 
   /**
-   * Set longitude.
+   * @brief Set longitude.
+   *
    * @param[in] longitude_radians Longitude in radians.
    */
   void SetLongitude(double longitude_radians);
 
   /**
-   * Get latitude in degrees.
+   * @brief Get latitude in degrees.
+   *
    * @return Latitude in degrees.
    */
   double GetLatitudeDegrees() const;
 
   /**
-   * Set latitude in degrees.
+   * @brief Set latitude in degrees.
+   *
    * @param[in] latitude_degrees Latitude in degrees.
    */
   void setLatitudeDegrees(double latitude_degrees);
 
   /**
-   * Get longitude in degrees.
+   * @brief Get longitude in degrees.
    * @return Longitude in degrees.
    */
   double GetLongitudeDegrees() const;
 
   /**
-   * Set longitude in degrees.
+   * @brief Set longitude in degrees.
+   *
    * @param[in] longitude_degrees Longitude in degrees.
    */
   void SetLongitudeDegrees(double longitude_degrees);
 
   /**
-   * Get altitude.
+   * @brief Get altitude.
+   *
    * @return Altitude in meters.
    */
   double GetAltitude() const;
 
   /**
-   * Set altitude.
+   * @brief Set altitude.
+   *
    * @param[in] altitude_meters Altitude in meters.
    */
   void SetAltitude(double altitude_meters);
 
   /**
-   * Check whether coordinates and altitude are valid.
+   * @brief Check whether coordinates and altitude are valid.
+   *
    * @return True if all valid, false if latitude, longitude or altitude is
    * undefined.
    */
   explicit operator bool() const;
 
   /**
-   * Check whether coordinates and altitude are valid.
+   * @brief Check whether coordinates and altitude are valid.
+   *
    * @return True if all valid, false if latitude, longitude or altitude is
    * undefined.
    */

--- a/olp-cpp-sdk-core/include/olp/core/geo/coordinates/GeoPoint.h
+++ b/olp-cpp-sdk-core/include/olp/core/geo/coordinates/GeoPoint.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@
 
 namespace olp {
 namespace geo {
+
 /**
  * @brief A geographic location that uses WGS84 coordinates encoded in
  * a 32-bit unsigned integer.
@@ -57,7 +58,7 @@ class CORE_API GeoPoint {
    * @param[in] yy The Y-coordinate value of the location latitude represented
    * as a 32-bit unsigned integer.
    */
-  GeoPoint(std::uint32_t xx, std::uint32_t yy);
+  GeoPoint(uint32_t xx, uint32_t yy);
 
   /**
    * @brief An absolute world X-coordinate value.
@@ -68,6 +69,7 @@ class CORE_API GeoPoint {
    * `x = (x rad + Pi) * max(uint32_t) / 2*Pi`
    */
   std::uint32_t x;
+
   /**
    * @brief An absolute world Y-coordinate value.
    *
@@ -116,7 +118,7 @@ class CORE_API GeoPoint {
 
 inline GeoPoint::GeoPoint() : x(0), y(0) {}
 
-inline GeoPoint::GeoPoint(std::uint32_t xx, std::uint32_t yy) : x(xx), y(yy) {}
+inline GeoPoint::GeoPoint(uint32_t xx, uint32_t yy) : x(xx), y(yy) {}
 
 inline bool GeoPoint::operator==(const GeoPoint& other) const {
   return x == other.x && y == other.y;

--- a/olp-cpp-sdk-core/include/olp/core/geo/coordinates/GeoRectangle.h
+++ b/olp-cpp-sdk-core/include/olp/core/geo/coordinates/GeoRectangle.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@
 
 namespace olp {
 namespace geo {
+
 /**
  * @brief A rectangular area in WGS84 coordinates
  *
@@ -55,7 +56,7 @@ class CORE_API GeoRectangle {
 
   bool Contains(const GeoCoordinates& point) const;
 
-  bool Overlaps(const GeoRectangle& rect) const;
+  bool Overlaps(const GeoRectangle& rectangle) const;
 
   bool operator==(const GeoRectangle& other) const;
 

--- a/olp-cpp-sdk-core/src/geo/coordinates/GeoCoordinates.cpp
+++ b/olp-cpp-sdk-core/src/geo/coordinates/GeoCoordinates.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,32 +17,32 @@
  * License-Filename: LICENSE
  */
 
-#include <olp/core/geo/coordinates/GeoCoordinates.h>
-#include <olp/core/math/Math.h>
+#include "olp/core/geo/coordinates/GeoCoordinates.h"
+
+#include "olp/core/math/Math.h"
 
 namespace olp {
-
-using namespace math;
-
 namespace geo {
 const double GeoCoordinates::kNaN_ = std::nan("");
 
+namespace {
+constexpr auto kMaxUInt32 = std::numeric_limits<std::uint32_t>::max();
+}  // namespace
+
 GeoCoordinates GeoCoordinates::FromGeoPoint(const GeoPoint& geo_point) {
-  constexpr std::uint32_t maxUInt32 = std::numeric_limits<std::uint32_t>::max();
-  const double uInt32ToRadFactor = math::two_pi / maxUInt32;
-  return GeoCoordinates{geo_point.y * uInt32ToRadFactor - math::half_pi,
-                        geo_point.x * uInt32ToRadFactor - math::pi};
+  const double int_to_rad_factor = math::two_pi / kMaxUInt32;
+  return GeoCoordinates{geo_point.y * int_to_rad_factor - math::half_pi,
+                        geo_point.x * int_to_rad_factor - math::pi};
 }
 
 GeoPoint GeoCoordinates::ToGeoPoint() const {
-  const GeoCoordinates norm = Normalized();
-  constexpr std::uint32_t maxUInt32 = std::numeric_limits<std::uint32_t>::max();
-  const double radToUInt32Factor = maxUInt32 * math::one_over_two_pi;
+  const auto norm = Normalized();
+  const double rad_to_int_factor = kMaxUInt32 * math::one_over_two_pi;
 
   const auto x = static_cast<std::uint32_t>(
-      std::round((norm.longitude_ + pi) * radToUInt32Factor));
+      std::round((norm.longitude_ + math::pi) * rad_to_int_factor));
   const auto y = static_cast<std::uint32_t>(
-      std::round((norm.latitude_ + half_pi) * radToUInt32Factor));
+      std::round((norm.latitude_ + math::half_pi) * rad_to_int_factor));
 
   return {x, y};
 }
@@ -91,8 +91,8 @@ double GeoCoordinates::GetLatitudeDegrees() const {
   return math::Degrees(latitude_);
 }
 
-void GeoCoordinates::SetLatitudeDegrees(double latitudeDegrees) {
-  latitude_ = math::Radians(latitudeDegrees);
+void GeoCoordinates::SetLatitudeDegrees(double latitude_degrees) {
+  latitude_ = math::Radians(latitude_degrees);
 }
 
 double GeoCoordinates::GetLongitudeDegrees() const {
@@ -111,7 +111,6 @@ GeoCoordinates GeoCoordinates::Normalized() const {
   GeoCoordinates norm{*this};
   norm.latitude_ = math::Clamp(norm.latitude_, -math::half_pi, +math::half_pi);
   norm.longitude_ = math::Wrap(norm.longitude_, -math::pi, +math::pi);
-
   return norm;
 }
 

--- a/olp-cpp-sdk-core/src/geo/coordinates/GeoCoordinates3d.cpp
+++ b/olp-cpp-sdk-core/src/geo/coordinates/GeoCoordinates3d.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,14 @@
  * License-Filename: LICENSE
  */
 
-#include <olp/core/geo/coordinates/GeoCoordinates3d.h>
-#include <olp/core/math/Math.h>
+#include "olp/core/geo/coordinates/GeoCoordinates3d.h"
+
+#include "olp/core/math/Math.h"
 
 namespace olp {
 namespace geo {
+
+const double GeoCoordinates3d::kNaN_ = std::numeric_limits<double>::quiet_NaN();
 
 GeoCoordinates3d::GeoCoordinates3d() : geo_coordinates_(), altitude_(kNaN_) {}
 
@@ -31,29 +34,30 @@ GeoCoordinates3d::GeoCoordinates3d(double latitude_radians,
     : geo_coordinates_(latitude_radians, longitude_radians),
       altitude_(altitude_meters) {}
 
-GeoCoordinates3d::GeoCoordinates3d(double latitudeDegrees,
-                                   double longitudeDegrees,
+GeoCoordinates3d::GeoCoordinates3d(double latitude_degrees,
+                                   double longitude_degrees,
                                    double altitude_meters, DegreeType degrees)
-    : geo_coordinates_(latitudeDegrees, longitudeDegrees, degrees),
+    : geo_coordinates_(latitude_degrees, longitude_degrees, degrees),
       altitude_(altitude_meters) {}
 
-GeoCoordinates3d::GeoCoordinates3d(const GeoCoordinates& geoCoords)
-    : geo_coordinates_(geoCoords), altitude_(kNaN_) {}
+GeoCoordinates3d::GeoCoordinates3d(const GeoCoordinates& coordinates)
+    : geo_coordinates_(coordinates), altitude_(kNaN_) {}
 
-GeoCoordinates3d::GeoCoordinates3d(const GeoCoordinates& geoCoordinates,
+GeoCoordinates3d::GeoCoordinates3d(const GeoCoordinates& coordinates,
                                    double altitude_meters)
-    : geo_coordinates_(geoCoordinates), altitude_(altitude_meters) {}
+    : geo_coordinates_(coordinates), altitude_(altitude_meters) {}
 
-GeoCoordinates3d GeoCoordinates3d::FromDegrees(double lat,
-                                               double lon,
-                                               double alt) {
-  return GeoCoordinates3d(math::Radians(lat), math::Radians(lon), alt);
+GeoCoordinates3d GeoCoordinates3d::FromDegrees(double latitude,
+                                               double longitude,
+                                               double altitude) {
+  return GeoCoordinates3d(math::Radians(latitude), math::Radians(longitude),
+                          altitude);
 }
 
-GeoCoordinates3d GeoCoordinates3d::FromRadians(double lat,
-                                               double lon,
-                                               double alt) {
-  return GeoCoordinates3d(lat, lon, alt);
+GeoCoordinates3d GeoCoordinates3d::FromRadians(double latitude,
+                                               double longitude,
+                                               double altitude) {
+  return GeoCoordinates3d(latitude, longitude, altitude);
 }
 
 const GeoCoordinates& GeoCoordinates3d::GetGeoCoordinates() const {
@@ -114,11 +118,9 @@ bool operator!=(const GeoCoordinates3d& lhs, const GeoCoordinates3d& rhs) {
   return !(lhs == rhs);
 }
 
-const double GeoCoordinates3d::kNaN_ = std::numeric_limits<double>::quiet_NaN();
-
 bool GeoCoordinates3d::IsValid() const {
   return !math::isnan(altitude_) && geo_coordinates_.IsValid();
 }
-}  // namespace geo
 
+}  // namespace geo
 }  // namespace olp

--- a/olp-cpp-sdk-core/src/geo/coordinates/GeoRectangle.cpp
+++ b/olp-cpp-sdk-core/src/geo/coordinates/GeoRectangle.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,11 @@
  * License-Filename: LICENSE
  */
 
-#include <olp/core/geo/coordinates/GeoRectangle.h>
+#include "olp/core/geo/coordinates/GeoRectangle.h"
 
 #include <algorithm>
 
-#include <olp/core/math/Math.h>
+#include "olp/core/math/Math.h"
 
 namespace olp {
 namespace geo {
@@ -55,7 +55,9 @@ double GeoRectangle::LatitudeSpan() const {
 
 double GeoRectangle::LongitudeSpan() const {
   double width = north_east_.GetLongitude() - south_west_.GetLongitude();
-  if (width < 0) width += math::two_pi;
+  if (width < 0) {
+    width += math::two_pi;
+  }
 
   return width;
 }
@@ -67,10 +69,14 @@ GeoCoordinates GeoRectangle::Center() const {
   const double west = south_west_.GetLongitude();
   const double east = north_east_.GetLongitude();
 
-  if (west < east) return GeoCoordinates(latitude, (west + east) * 0.5);
+  if (west < east) {
+    return GeoCoordinates(latitude, (west + east) * 0.5);
+  }
 
   double longitude = (math::two_pi + east + west) * 0.5;
-  if (longitude > math::two_pi) longitude -= math::two_pi;
+  if (longitude > math::two_pi) {
+    longitude -= math::two_pi;
+  }
 
   return GeoCoordinates(latitude, longitude);
 }
@@ -83,73 +89,87 @@ bool GeoRectangle::Contains(const GeoCoordinates& point) const {
   const double west = south_west_.GetLongitude();
   const double east = north_east_.GetLongitude();
 
-  if (east > west)
+  if (east > west) {
     return point.GetLongitude() >= west && point.GetLongitude() <= east;
+  }
 
   // this code handles rectangle crossing 180 meridian
   return point.GetLongitude() >= east || point.GetLongitude() <= west;
 }
 
-bool GeoRectangle::Overlaps(const GeoRectangle& rect) const {
-  if (south_west_.GetLatitude() >= rect.north_east_.GetLatitude() ||
-      rect.south_west_.GetLatitude() >= north_east_.GetLatitude())
+bool GeoRectangle::Overlaps(const GeoRectangle& rectangle) const {
+  if (south_west_.GetLatitude() >= rectangle.north_east_.GetLatitude() ||
+      rectangle.south_west_.GetLatitude() >= north_east_.GetLatitude()) {
     return false;
+  }
 
   double west = south_west_.GetLongitude();
   double east = north_east_.GetLongitude();
 
-  if (west >= east) east = west + LatitudeSpan();
+  if (west >= east) {
+    east = west + LatitudeSpan();
+  }
 
-  double rectWest = rect.south_west_.GetLongitude();
-  double rectEast = rect.north_east_.GetLongitude();
+  double rectangle_west = rectangle.south_west_.GetLongitude();
+  double rectangle_east = rectangle.north_east_.GetLongitude();
 
-  if (rectWest >= rectEast) rectEast = rectWest + rect.LatitudeSpan();
+  if (rectangle_west >= rectangle_east) {
+    rectangle_east = rectangle_west + rectangle.LatitudeSpan();
+  }
 
-  return !(west >= rectEast || rectWest >= east);
+  return !(west >= rectangle_east || rectangle_west >= east);
 }
 
 GeoRectangle GeoRectangle::BooleanUnion(const GeoRectangle& other) const {
-  if (IsEmpty()) return other;
+  if (IsEmpty()) {
+    return other;
+  }
 
-  if (other.IsEmpty()) return *this;
+  if (other.IsEmpty()) {
+    return *this;
+  }
 
-  const GeoCoordinates southWest(
+  const GeoCoordinates south_west(
       std::min(south_west_.GetLatitude(), other.south_west_.GetLatitude()),
       std::min(south_west_.GetLongitude(), other.south_west_.GetLongitude()));
 
   // Special handling to cover longitude wrapping
   double longitude1 = north_east_.GetLongitude();
-  if (longitude1 < south_west_.GetLongitude()) longitude1 += math::two_pi;
-
-  double longitude2 = other.north_east_.GetLongitude();
-  if (longitude2 < other.south_west_.GetLongitude()) longitude2 += math::two_pi;
-
-  double maxLongitude = std::max(longitude1, longitude2);
-  if (maxLongitude > math::pi) {
-    const double upperLimit =
-        nextafter(southWest.GetLongitude(), southWest.GetLongitude() - 1.0);
-    maxLongitude = std::min(maxLongitude - math::two_pi, upperLimit);
+  if (longitude1 < south_west_.GetLongitude()) {
+    longitude1 += math::two_pi;
   }
 
-  const GeoCoordinates northEast(
-      std::max(north_east_.GetLatitude(), other.north_east_.GetLatitude()),
-      maxLongitude);
+  double longitude2 = other.north_east_.GetLongitude();
+  if (longitude2 < other.south_west_.GetLongitude()) {
+    longitude2 += math::two_pi;
+  }
 
-  return GeoRectangle(southWest, northEast);
+  double max_longitude = std::max(longitude1, longitude2);
+  if (max_longitude > math::pi) {
+    const double upper_limit =
+        nextafter(south_west.GetLongitude(), south_west.GetLongitude() - 1.0);
+    max_longitude = std::min(max_longitude - math::two_pi, upper_limit);
+  }
+
+  const GeoCoordinates north_east(
+      std::max(north_east_.GetLatitude(), other.north_east_.GetLatitude()),
+      max_longitude);
+
+  return GeoRectangle(south_west, north_east);
 }
 
 GeoRectangle& GeoRectangle::GrowToContain(const GeoCoordinates& point) {
-  double pointLatitude = point.GetLatitude();
-  double pointLongitude = point.GetLongitude();
+  double point_latitude = point.GetLatitude();
+  double point_longitude = point.GetLongitude();
 
-  if (pointLatitude < south_west_.GetLatitude())
-    south_west_.SetLatitude(pointLatitude);
-  if (pointLatitude > north_east_.GetLatitude())
-    north_east_.SetLatitude(pointLatitude);
-  if (pointLongitude < south_west_.GetLongitude())
-    south_west_.SetLongitude(pointLongitude);
-  if (pointLongitude > north_east_.GetLongitude())
-    north_east_.SetLongitude(pointLongitude);
+  if (point_latitude < south_west_.GetLatitude())
+    south_west_.SetLatitude(point_latitude);
+  if (point_latitude > north_east_.GetLatitude())
+    north_east_.SetLatitude(point_latitude);
+  if (point_longitude < south_west_.GetLongitude())
+    south_west_.SetLongitude(point_longitude);
+  if (point_longitude > north_east_.GetLongitude())
+    north_east_.SetLongitude(point_longitude);
 
   return *this;
 }


### PR DESCRIPTION
This commit is the first of a series of coding style adapts
to follow for the olp/geo folder, which is based on a legacy
repository that was merged into this.
This commit adapts GeoCoordinates, GeoCoordinates3d, GeoPoint,
and GeoRectangle to coding style.

Relates-to: OLPEDGE-569

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>