### PR TITLE
Enable compiler warnings

### DIFF
--- a/olp-cpp-sdk-core/src/client/OlpClient.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClient.cpp
@@ -328,7 +328,7 @@ CancellationToken OlpClient::CallApi(
     const std::string& path, const std::string& method,
     const OlpClient::ParametersType& query_params,
     const OlpClient::ParametersType& header_params,
-    const OlpClient::ParametersType& form_params,
+    const OlpClient::ParametersType& /*form_params*/,
     const OlpClient::RequestBodyType& post_body,
     const std::string& content_type,
     const NetworkAsyncCallback& callback) const {
@@ -368,7 +368,7 @@ CancellationToken OlpClient::CallApi(
 HttpResponse OlpClient::CallApi(std::string path, std::string method,
                                 OlpClient::ParametersType query_params,
                                 OlpClient::ParametersType header_params,
-                                OlpClient::ParametersType forms_params,
+                                OlpClient::ParametersType /*forms_params*/,
                                 OlpClient::RequestBodyType post_body,
                                 std::string content_type,
                                 CancellationContext context) const {

--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.h
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,7 +118,6 @@ class NetworkCurl : public olp::http::Network,
     bool in_use{};
     bool range_out{};
     bool cancelled{};
-    bool get_statistics{};
     bool skip_content{};
     char error_text[CURL_ERROR_SIZE]{};
   };

--- a/olp-cpp-sdk-core/src/thread/ThreadPoolTaskScheduler.cpp
+++ b/olp-cpp-sdk-core/src/thread/ThreadPoolTaskScheduler.cpp
@@ -43,16 +43,13 @@ constexpr auto kLogTag = "ThreadPoolTaskScheduler";
 
 void SetCurrentThreadName(const std::string& thread_name) {
   // Currently only supported for pthread users
+  CORE_UNUSED(thread_name);
 
 #if defined(PORTING_PLATFORM_MAC)
   // Note that in Mac based systems the pthread_setname_np takes 1 argument
   // only.
   pthread_setname_np(thread_name.c_str());
-#elif defined(PORTING_PLATFORM_WINDOWS) || defined(PORTING_PLATFORM_EMSCRIPTEN)
-  // Unused
-  CORE_UNUSED(thread_name);
-#else  // Linux, Android, QNX
-#if defined(OLP_SDK_HAVE_PTHREAD_SETNAME_NP)
+#elif defined(OLP_SDK_HAVE_PTHREAD_SETNAME_NP) // Linux, Android, QNX
   // QNX allows 100 but Linux only 16 so select min value and apply for both.
   // If maximum length is exceeded on some systems, e.g. Linux, the name is not
   // set at all. So better truncate it to have at least the minimum set.
@@ -60,7 +57,6 @@ void SetCurrentThreadName(const std::string& thread_name) {
   std::string truncated_name = thread_name.substr(0, kMaxThreadNameLength - 1);
   pthread_setname_np(pthread_self(), truncated_name.c_str());
 #endif  // OLP_SDK_HAVE_PTHREAD_SETNAME_NP
-#endif  // PORTING_PLATFORM_MAC
 }
 
 }  // namespace

--- a/olp-cpp-sdk-core/tests/cache/InMemoryCacheTest.cpp
+++ b/olp-cpp-sdk-core/tests/cache/InMemoryCacheTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -335,10 +335,10 @@ TEST(InMemoryCacheTest, CustomCost) {
   auto oversized_model = "value: " + oversized;
 
   struct MyCacheCost {
-    std::size_t operator()(const ItemTuple& s) const { return 2; }
+    std::size_t operator()(const ItemTuple&) const { return 2; }
   };
 
-  auto cost_func = [](const ItemTuple& tuple) { return 2; };
+  auto cost_func = [](const ItemTuple&) { return 2; };
 
   olp::cache::InMemoryCache cache(1, MyCacheCost());
 

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -326,7 +326,7 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
                     flag->exchange(true);
                     return EmptyResponse(PrefetchTileNoError());
                   },
-                  [=](EmptyResponse result) {
+                  [=](EmptyResponse /*result*/) {
                     if (!flag->load()) {
                       // If above task was cancelled we might need to set
                       // promise else below task will wait forever

--- a/olp-cpp-sdk-dataservice-read/tests/ApiClientLookupTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/ApiClientLookupTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,11 +134,11 @@ TEST(ApiClientLookupTest, LookupApi) {
     client::CancellationContext context;
     EXPECT_CALL(*network, Send(IsGetRequest(lookup_url), _, _, _, _))
         .Times(1)
-        .WillOnce([=](olp::http::NetworkRequest request,
-                      olp::http::Network::Payload payload,
-                      olp::http::Network::Callback callback,
-                      olp::http::Network::HeaderCallback header_callback,
-                      olp::http::Network::DataCallback data_callback)
+        .WillOnce([=](olp::http::NetworkRequest /*request*/,
+                      olp::http::Network::Payload /*payload*/,
+                      olp::http::Network::Callback /*callback*/,
+                      olp::http::Network::HeaderCallback /*header_callback*/,
+                      olp::http::Network::DataCallback /*data_callback*/)
                       -> olp::http::SendOutcome {
           return olp::http::SendOutcome(olp::http::ErrorCode::CANCELLED_ERROR);
         });
@@ -157,11 +157,11 @@ TEST(ApiClientLookupTest, LookupApi) {
     client::CancellationContext context;
     EXPECT_CALL(*network, Send(IsGetRequest(lookup_url), _, _, _, _))
         .Times(1)
-        .WillOnce([=](olp::http::NetworkRequest request,
-                      olp::http::Network::Payload payload,
-                      olp::http::Network::Callback callback,
-                      olp::http::Network::HeaderCallback header_callback,
-                      olp::http::Network::DataCallback data_callback)
+        .WillOnce([=](olp::http::NetworkRequest /*request*/,
+                      olp::http::Network::Payload /*payload*/,
+                      olp::http::Network::Callback /*callback*/,
+                      olp::http::Network::HeaderCallback /*header_callback*/,
+                      olp::http::Network::DataCallback /*data_callback*/)
                       -> olp::http::SendOutcome {
           // note no network response thread spawns
           constexpr auto unused_request_id = 12;
@@ -183,21 +183,21 @@ TEST(ApiClientLookupTest, LookupApi) {
     client::CancellationContext context;
     EXPECT_CALL(*network, Send(IsGetRequest(lookup_url), _, _, _, _))
         .Times(1)
-        .WillOnce(
-            [=, &context](olp::http::NetworkRequest request,
-                          olp::http::Network::Payload payload,
-                          olp::http::Network::Callback callback,
-                          olp::http::Network::HeaderCallback header_callback,
-                          olp::http::Network::DataCallback data_callback)
-                -> olp::http::SendOutcome {
-              // spawn a 'user' response of cancelling
-              std::thread([&context]() { context.CancelOperation(); }).detach();
+        .WillOnce([=, &context](
+                      olp::http::NetworkRequest /*request*/,
+                      olp::http::Network::Payload /*payload*/,
+                      olp::http::Network::Callback /*callback*/,
+                      olp::http::Network::HeaderCallback /*header_callback*/,
+                      olp::http::Network::DataCallback /*data_callback*/)
+                      -> olp::http::SendOutcome {
+          // spawn a 'user' response of cancelling
+          std::thread([&context]() { context.CancelOperation(); }).detach();
 
-              // note no network response thread spawns
+          // note no network response thread spawns
 
-              constexpr auto unused_request_id = 12;
-              return olp::http::SendOutcome(unused_request_id);
-            });
+          constexpr auto unused_request_id = 12;
+          return olp::http::SendOutcome(unused_request_id);
+        });
     EXPECT_CALL(*network, Cancel(_)).Times(1).WillOnce(Return());
 
     auto response = ApiClientLookup::LookupApi(

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -371,11 +371,11 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
     client::CancellationContext context;
     EXPECT_CALL(*network, Send(IsGetRequest(kOlpSdkUrlLookupQuery), _, _, _, _))
         .Times(1)
-        .WillOnce([=](olp::http::NetworkRequest request,
-                      olp::http::Network::Payload payload,
-                      olp::http::Network::Callback callback,
-                      olp::http::Network::HeaderCallback header_callback,
-                      olp::http::Network::DataCallback data_callback)
+        .WillOnce([=](olp::http::NetworkRequest /*request*/,
+                      olp::http::Network::Payload /*payload*/,
+                      olp::http::Network::Callback /*callback*/,
+                      olp::http::Network::HeaderCallback /*header_callback*/,
+                      olp::http::Network::DataCallback /*data_callback*/)
                       -> olp::http::SendOutcome {
           return olp::http::SendOutcome(olp::http::ErrorCode::CANCELLED_ERROR);
         });
@@ -399,11 +399,11 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
     EXPECT_CALL(*network,
                 Send(IsGetRequest(kOlpSdkUrlPartitionById), _, _, _, _))
         .Times(1)
-        .WillOnce([=](olp::http::NetworkRequest request,
-                      olp::http::Network::Payload payload,
-                      olp::http::Network::Callback callback,
-                      olp::http::Network::HeaderCallback header_callback,
-                      olp::http::Network::DataCallback data_callback)
+        .WillOnce([=](olp::http::NetworkRequest /*request*/,
+                      olp::http::Network::Payload /*payload*/,
+                      olp::http::Network::Callback /*callback*/,
+                      olp::http::Network::HeaderCallback /*header_callback*/,
+                      olp::http::Network::DataCallback /*data_callback*/)
                       -> olp::http::SendOutcome {
           return olp::http::SendOutcome(olp::http::ErrorCode::CANCELLED_ERROR);
         });
@@ -425,11 +425,11 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
     client::CancellationContext context;
     EXPECT_CALL(*network, Send(IsGetRequest(kOlpSdkUrlLookupQuery), _, _, _, _))
         .Times(1)
-        .WillOnce([=](olp::http::NetworkRequest request,
-                      olp::http::Network::Payload payload,
-                      olp::http::Network::Callback callback,
-                      olp::http::Network::HeaderCallback header_callback,
-                      olp::http::Network::DataCallback data_callback)
+        .WillOnce([=](olp::http::NetworkRequest /*request*/,
+                      olp::http::Network::Payload /*payload*/,
+                      olp::http::Network::Callback /*callback*/,
+                      olp::http::Network::HeaderCallback /*header_callback*/,
+                      olp::http::Network::DataCallback /*data_callback*/)
                       -> olp::http::SendOutcome {
           // note no network response thread spawns
           constexpr auto unused_request_id = 12;
@@ -456,11 +456,11 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
     EXPECT_CALL(*network,
                 Send(IsGetRequest(kOlpSdkUrlPartitionById), _, _, _, _))
         .Times(1)
-        .WillOnce([=](olp::http::NetworkRequest request,
-                      olp::http::Network::Payload payload,
-                      olp::http::Network::Callback callback,
-                      olp::http::Network::HeaderCallback header_callback,
-                      olp::http::Network::DataCallback data_callback)
+        .WillOnce([=](olp::http::NetworkRequest /*request*/,
+                      olp::http::Network::Payload /*payload*/,
+                      olp::http::Network::Callback /*callback*/,
+                      olp::http::Network::HeaderCallback /*header_callback*/,
+                      olp::http::Network::DataCallback /*data_callback*/)
                       -> olp::http::SendOutcome {
           // note no network response thread spawns
           constexpr auto unused_request_id = 12;
@@ -485,21 +485,21 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
     client::CancellationContext context;
     EXPECT_CALL(*network, Send(IsGetRequest(kOlpSdkUrlLookupQuery), _, _, _, _))
         .Times(1)
-        .WillOnce(
-            [=, &context](olp::http::NetworkRequest request,
-                          olp::http::Network::Payload payload,
-                          olp::http::Network::Callback callback,
-                          olp::http::Network::HeaderCallback header_callback,
-                          olp::http::Network::DataCallback data_callback)
-                -> olp::http::SendOutcome {
-              // spawn a 'user' response of cancelling
-              std::thread([&context]() { context.CancelOperation(); }).detach();
+        .WillOnce([=, &context](
+                      olp::http::NetworkRequest /*request*/,
+                      olp::http::Network::Payload /*payload*/,
+                      olp::http::Network::Callback /*callback*/,
+                      olp::http::Network::HeaderCallback /*header_callback*/,
+                      olp::http::Network::DataCallback /*data_callback*/)
+                      -> olp::http::SendOutcome {
+          // spawn a 'user' response of cancelling
+          std::thread([&context]() { context.CancelOperation(); }).detach();
 
-              // note no network response thread spawns
+          // note no network response thread spawns
 
-              constexpr auto unused_request_id = 12;
-              return olp::http::SendOutcome(unused_request_id);
-            });
+          constexpr auto unused_request_id = 12;
+          return olp::http::SendOutcome(unused_request_id);
+        });
     EXPECT_CALL(*network, Cancel(_)).Times(1).WillOnce(Return());
 
     auto response = repository::PartitionsRepository::GetPartitionById(
@@ -520,21 +520,21 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
     EXPECT_CALL(*network,
                 Send(IsGetRequest(kOlpSdkUrlPartitionById), _, _, _, _))
         .Times(1)
-        .WillOnce(
-            [=, &context](olp::http::NetworkRequest request,
-                          olp::http::Network::Payload payload,
-                          olp::http::Network::Callback callback,
-                          olp::http::Network::HeaderCallback header_callback,
-                          olp::http::Network::DataCallback data_callback)
-                -> olp::http::SendOutcome {
-              // spawn a 'user' response of cancelling
-              std::thread([&context]() { context.CancelOperation(); }).detach();
+        .WillOnce([=, &context](
+                      olp::http::NetworkRequest /*request*/,
+                      olp::http::Network::Payload /*payload*/,
+                      olp::http::Network::Callback /*callback*/,
+                      olp::http::Network::HeaderCallback /*header_callback*/,
+                      olp::http::Network::DataCallback /*data_callback*/)
+                      -> olp::http::SendOutcome {
+          // spawn a 'user' response of cancelling
+          std::thread([&context]() { context.CancelOperation(); }).detach();
 
-              // note no network response thread spawns
+          // note no network response thread spawns
 
-              constexpr auto unused_request_id = 12;
-              return olp::http::SendOutcome(unused_request_id);
-            });
+          constexpr auto unused_request_id = 12;
+          return olp::http::SendOutcome(unused_request_id);
+        });
     EXPECT_CALL(*network, Cancel(_)).Times(1).WillOnce(Return());
 
     auto response = repository::PartitionsRepository::GetPartitionById(

--- a/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,8 +82,8 @@ TEST(VersionedLayerClientTest, RemoveFromCachePartition) {
   settings.cache = cache_mock;
 
   // successfull mock cache calls
-  auto found_cache_response = [](const std::string& key,
-                                 const olp::cache::Decoder& encoder) {
+  auto found_cache_response = [](const std::string& /*key*/,
+                                 const olp::cache::Decoder& /*encoder*/) {
     auto partition = model::Partition();
     partition.SetPartition(kPartitionId);
     partition.SetDataHandle(kBlobDataHandle);
@@ -144,8 +144,8 @@ TEST(VersionedLayerClientTest, RemoveFromCacheTileKey) {
   settings.cache = cache_mock;
 
   // successfull mock cache calls
-  auto found_cache_response = [](const std::string& key,
-                                 const olp::cache::Decoder& encoder) {
+  auto found_cache_response = [](const std::string& /*key*/,
+                                 const olp::cache::Decoder& /*encoder*/) {
     auto partition = model::Partition();
     partition.SetPartition(kPartitionId);
     partition.SetDataHandle(kBlobDataHandle);

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/generated/model/Index.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/generated/model/Index.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,7 +122,6 @@ class DATASERVICE_WRITE_API IntIndexValue final : public IndexValue {
   int64_t intValue_{0};
 
  public:
-  IntIndexValue() = default;
   virtual ~IntIndexValue() = default;
   IntIndexValue(int64_t intValue, IndexType type) : IndexValue(type) {
     intValue_ = std::move(intValue);
@@ -140,7 +139,6 @@ class DATASERVICE_WRITE_API StringIndexValue final : public IndexValue {
   std::string stringValue_;
 
  public:
-  StringIndexValue() = default;
   virtual ~StringIndexValue() = default;
   StringIndexValue(std::string stringValue, IndexType type) : IndexValue(type) {
     stringValue_ = std::move(stringValue);
@@ -158,7 +156,6 @@ class DATASERVICE_WRITE_API TimeWindowIndexValue final : public IndexValue {
   int64_t timeWindowValue_{0};
 
  public:
-  TimeWindowIndexValue() = default;
   virtual ~TimeWindowIndexValue() = default;
   TimeWindowIndexValue(int64_t timeWindowValue, IndexType type)
       : IndexValue(type) {
@@ -177,7 +174,6 @@ class DATASERVICE_WRITE_API HereTileIndexValue final : public IndexValue {
   int64_t hereTileValue_{0};
 
  public:
-  HereTileIndexValue() = default;
   HereTileIndexValue(int64_t hereTileValue, IndexType type) : IndexValue(type) {
     hereTileValue_ = std::move(hereTileValue);
   }

--- a/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -150,7 +150,7 @@ void IndexLayerClientImpl::CancelAll() { tokenList_.CancelAll(); }
 void IndexLayerClientImpl::CancelPendingRequests() { CancelAll(); }
 
 CancellationToken IndexLayerClientImpl::InitCatalogModel(
-    const model::PublishIndexRequest& request,
+    const model::PublishIndexRequest& /*request*/,
     const InitCatalogModelCallback& callback) {
   if (!catalog_model_.GetId().empty()) {
     callback(boost::none);

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -269,7 +269,7 @@ olp::client::CancellationToken StreamLayerClientImpl::Flush(
         callback(responses);
         return EmptyFlushApiResponse{};
       },
-      [=](EmptyFlushApiResponse response) {
+      [=](EmptyFlushApiResponse /*response*/) {
         // we don't need to notify user 2 times, cause we already invoke a
         // callback in the execution function:
         if (!exec_started->load()) {

--- a/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -692,7 +692,7 @@ std::string VersionedLayerClientImpl::FindContentTypeForLayerId(
 }
 
 void VersionedLayerClientImpl::UploadBlob(
-    std::string publication_id,
+    std::string /*publication_id*/,
     std::shared_ptr<model::PublishPartition> partition, std::string data_handle,
     std::string layer_id,
     std::shared_ptr<client::CancellationContext> cancel_context,

--- a/olp-cpp-sdk-dataservice-write/tests/ApiClientLookupTest.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/ApiClientLookupTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -231,11 +231,11 @@ TEST_P(ApiClientLookupTest, LookupApiClientSync) {
     EXPECT_CALL(*network_,
                 Send(IsGetRequest(GetLookupApiRequestUrl()), _, _, _, _))
         .Times(1)
-        .WillOnce([=](olp::http::NetworkRequest request,
-                      olp::http::Network::Payload payload,
-                      olp::http::Network::Callback callback,
-                      olp::http::Network::HeaderCallback header_callback,
-                      olp::http::Network::DataCallback data_callback)
+        .WillOnce([=](olp::http::NetworkRequest /*request*/,
+                      olp::http::Network::Payload /*payload*/,
+                      olp::http::Network::Callback /*callback*/,
+                      olp::http::Network::HeaderCallback /*header_callback*/,
+                      olp::http::Network::DataCallback /*data_callback*/)
                       -> olp::http::SendOutcome {
           // note no network_ response thread spawns
           constexpr auto kUnusedRequestId = 42;
@@ -257,11 +257,11 @@ TEST_P(ApiClientLookupTest, LookupApiClientSync) {
     EXPECT_CALL(*network_,
                 Send(IsGetRequest(GetLookupApiRequestUrl()), _, _, _, _))
         .Times(1)
-        .WillOnce([=](olp::http::NetworkRequest request,
-                      olp::http::Network::Payload payload,
-                      olp::http::Network::Callback callback,
-                      olp::http::Network::HeaderCallback header_callback,
-                      olp::http::Network::DataCallback data_callback)
+        .WillOnce([=](olp::http::NetworkRequest /*request*/,
+                      olp::http::Network::Payload /*payload*/,
+                      olp::http::Network::Callback /*callback*/,
+                      olp::http::Network::HeaderCallback /*header_callback*/,
+                      olp::http::Network::DataCallback /*data_callback*/)
                       -> olp::http::SendOutcome {
           return olp::http::SendOutcome(olp::http::ErrorCode::CANCELLED_ERROR);
         });
@@ -281,14 +281,15 @@ TEST_P(ApiClientLookupTest, LookupApiClientSync) {
     EXPECT_CALL(*network_,
                 Send(IsGetRequest(GetLookupApiRequestUrl()), _, _, _, _))
         .Times(1)
-        .WillOnce([=](olp::http::NetworkRequest request,
-                      olp::http::Network::Payload payload,
-                      olp::http::Network::Callback callback,
-                      olp::http::Network::HeaderCallback header_callback,
-                      olp::http::Network::DataCallback data_callback) mutable
+        .WillOnce([=](olp::http::NetworkRequest /*request*/,
+                      olp::http::Network::Payload /*payload*/,
+                      olp::http::Network::Callback /*callback*/,
+                      olp::http::Network::HeaderCallback /*header_callback*/,
+                      olp::http::Network::DataCallback /*data_callback*/) mutable
                   -> olp::http::SendOutcome {
-          std::thread([context]() mutable { context.CancelOperation(); })
-              .detach();
+          std::thread([context]() mutable {
+            context.CancelOperation();
+          }).detach();
           constexpr auto kUnusedRequestId = 42;
           return olp::http::SendOutcome(kUnusedRequestId);
         });

--- a/olp-cpp-sdk-dataservice-write/tests/StreamLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/StreamLayerClientImplTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -731,7 +731,7 @@ TEST_F(StreamLayerClientImplTest, QueueAndFlush) {
   ON_CALL(*client, PublishDataTask(_, _))
       .WillByDefault(
           [](model::PublishDataRequest request,
-             client::CancellationContext context) -> PublishDataResponse {
+             client::CancellationContext /*context*/) -> PublishDataResponse {
             PublishDataResult result;
             result.SetTraceID(request.GetTraceId().get());
             return PublishDataResponse{result};

--- a/scripts/linux/psv/build_psv.sh
+++ b/scripts/linux/psv/build_psv.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright (C) 2019 HERE Europe B.V.
+# Copyright (C) 2019-2020 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ ulimit -c unlimited
 mkdir -p build
 cd build
 cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-    -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -Wno-deprecated-declarations -Wno-unused-parameter -Wno-unused-function -Wno-attributes" \
+    -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -Wno-deprecated-declarations" \
     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
     -DOLP_SDK_BUILD_EXAMPLES=ON \
     -DBUILD_SHARED_LIBS=ON \

--- a/scripts/linux/weekly/build_centos_debug_wv.sh
+++ b/scripts/linux/weekly/build_centos_debug_wv.sh
@@ -31,8 +31,8 @@ export BUILD_DIR="$WORKSPACE/$BUILD_DIR_NAME"
 export ARCHIVE_FILE_NAME="binaries.tar.gz"      # artifact name is defined by CI so please do not rename it
 export BUILD_ZIP=1                              # always build artifacts
 
-export CMAKE_CXX_FLAGS="-march=x86-64 -gdwarf-2 -g3 -O0 -fno-builtin -Wall -Wextra -Werror -Wno-deprecated-declarations -Wno-unused-parameter -Wno-unused-function -Wno-attributes"
-export CMAKE_C_FLAGS="-march=x86-64 -gdwarf-2 -g3 -O0 -fno-builtin -Wall -Wextra -Werror -Wno-deprecated-declarations -Wno-unused-parameter -Wno-unused-function -Wno-attributes"
+export CMAKE_CXX_FLAGS="-march=x86-64 -gdwarf-2 -g3 -O0 -fno-builtin -Wall -Wextra -Werror -Wno-deprecated-declarations"
+export CMAKE_C_FLAGS="-march=x86-64 -gdwarf-2 -g3 -O0 -fno-builtin -Wall -Wextra -Werror -Wno-deprecated-declarations"
 
 # Add more parameters into CMAKE_PARAM below when needed
 export FLAVOR="Debug"

--- a/tests/common/mocks/NetworkMock.cpp
+++ b/tests/common/mocks/NetworkMock.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ GenerateNetworkMockActions(std::shared_ptr<std::promise<void>> pre_signal,
        post_signal, callback_placeholder](
           NetworkRequest request, Network::Payload payload,
           Network::Callback callback, Network::HeaderCallback header_callback,
-          Network::DataCallback data_callback) -> olp::http::SendOutcome {
+          Network::DataCallback /*data_callback*/) -> olp::http::SendOutcome {
     *callback_placeholder = callback;
 
     auto mocked_network_block = [request, pre_signal, wait_for_signal,
@@ -89,7 +89,7 @@ GenerateNetworkMockActions(std::shared_ptr<std::promise<void>> pre_signal,
   };
 
   auto mocked_cancel = [completed,
-                        callback_placeholder](olp::http::RequestId id) {
+                        callback_placeholder](olp::http::RequestId /*id*/) {
     if (!completed->exchange(true)) {
       auto cancel_code = static_cast<int>(ErrorCode::CANCELLED_ERROR);
       (*callback_placeholder)(
@@ -108,11 +108,11 @@ GenerateNetworkMockActions(std::shared_ptr<std::promise<void>> pre_signal,
 NetworkCallback ReturnHttpResponse(olp::http::NetworkResponse response,
                                    const std::string& response_body,
                                    const http::Headers& headers) {
-  return [=](olp::http::NetworkRequest request,
+  return [=](olp::http::NetworkRequest /*request*/,
              olp::http::Network::Payload payload,
              olp::http::Network::Callback callback,
              olp::http::Network::HeaderCallback header_callback,
-             olp::http::Network::DataCallback data_callback)
+             olp::http::Network::DataCallback /*data_callback*/)
              -> olp::http::SendOutcome {
     std::thread([=]() {
       for (const auto& header : headers) {

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -181,7 +181,6 @@ class AuthenticationClientTest : public AuthenticationCommonTestFixture {
 
   IntrospectAppResponse IntrospectApp(const std::string& access_token,
                                       std::time_t& now,
-                                      unsigned int expires_in = kLimitExpiry,
                                       bool do_cancel = false) {
     std::shared_ptr<IntrospectAppResponse> response;
     unsigned int retry = 0u;
@@ -673,7 +672,7 @@ TEST_F(AuthenticationClientTest, IntrospectApp) {
   EXPECT_EQ(olp::http::HttpStatusCode::OK, result.GetStatus());
 
   auto token = result.GetAccessToken();
-  auto introspect_response = IntrospectApp(token, now, kExpiryTime);
+  auto introspect_response = IntrospectApp(token, now);
   auto introspect_result = introspect_response.GetResult();
 
   EXPECT_TRUE(introspect_response.IsSuccessful());
@@ -692,7 +691,7 @@ TEST_F(AuthenticationClientTest, IntrospectAppInvalidAccessToken) {
   AuthenticationCredentials credentials(id_, secret_);
 
   std::time_t now;
-  auto response = IntrospectApp(kAccessToken, now, kExpiryTime);
+  auto response = IntrospectApp(kAccessToken, now);
   auto result = response.GetResult();
 
   EXPECT_FALSE(response.IsSuccessful());

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
@@ -475,8 +475,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetPartitionsForInvalidLayer) {
         return future.GetFuture().get();
       });
 
-  ASSERT_FALSE(partitions_response.IsSuccessful())
-      << ErrorMessage(partitions_response.GetError());
+  ASSERT_FALSE(partitions_response.IsSuccessful());
   ASSERT_EQ(olp::client::ErrorCode::BadRequest,
             partitions_response.GetError().GetErrorCode());
 }

--- a/tests/functional/utils/Utils.h
+++ b/tests/functional/utils/Utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,15 +25,11 @@
 
 namespace {
 
-std::string ErrorMessage(const olp::client::ApiError& error) {
-  std::ostringstream result_stream;
-  result_stream << "ERROR: code: " << static_cast<int>(error.GetErrorCode())
-                << ", status: " << error.GetHttpStatusCode()
-                << ", message: " << error.GetMessage();
-  return result_stream.str();
-}
-
-#define EXPECT_SUCCESS(response) \
-  EXPECT_TRUE((response).IsSuccessful()) << ErrorMessage((response).GetError());
+#define EXPECT_SUCCESS(response)                                   \
+  EXPECT_TRUE((response).IsSuccessful())                           \
+      << "ERROR: code: "                                           \
+      << static_cast<int>((response).GetError().GetErrorCode())    \
+      << ", status: " << (response).GetError().GetHttpStatusCode() \
+      << ", message: " << (response).GetError().GetMessage();
 
 }  // namespace

--- a/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -176,25 +176,26 @@ class AuthenticationClientTest : public ::testing::Test {
 
     EXPECT_CALL(*network_, Send(_, _, _, _, _))
         .Times(2)  // First is GetTimeFromServer(). Second is actual SignIn.
-        .WillRepeatedly([&](olp::http::NetworkRequest request,
-                            olp::http::Network::Payload payload,
-                            olp::http::Network::Callback callback,
-                            olp::http::Network::HeaderCallback header_callback,
-                            olp::http::Network::DataCallback data_callback) {
-          olp::http::RequestId request_id(5);
-          if (payload) {
-            *payload << data;
-          }
-          callback(olp::http::NetworkResponse()
-                       .WithRequestId(request_id)
-                       .WithStatus(http));
-          if (data_callback) {
-            auto raw = const_cast<char*>(data.c_str());
-            data_callback(reinterpret_cast<uint8_t*>(raw), 0, data.size());
-          }
+        .WillRepeatedly(
+            [&](olp::http::NetworkRequest /*request*/,
+                olp::http::Network::Payload payload,
+                olp::http::Network::Callback callback,
+                olp::http::Network::HeaderCallback /*header_callback*/,
+                olp::http::Network::DataCallback data_callback) {
+              olp::http::RequestId request_id(5);
+              if (payload) {
+                *payload << data;
+              }
+              callback(olp::http::NetworkResponse()
+                           .WithRequestId(request_id)
+                           .WithStatus(http));
+              if (data_callback) {
+                auto raw = const_cast<char*>(data.c_str());
+                data_callback(reinterpret_cast<uint8_t*>(raw), 0, data.size());
+              }
 
-          return olp::http::SendOutcome(request_id);
-        });
+              return olp::http::SendOutcome(request_id);
+            });
 
     client_->SignInClient(
         credentials, {},
@@ -226,10 +227,10 @@ TEST_F(AuthenticationClientTest, SignInClientScope) {
   std::promise<AuthenticationClient::SignInClientResponse> request;
   auto request_future = request.get_future();
   EXPECT_CALL(*network_, Send(_, _, _, _, _))
-      .WillOnce([&](olp::http::NetworkRequest request,
+      .WillOnce([&](olp::http::NetworkRequest /*request*/,
                     olp::http::Network::Payload payload,
                     olp::http::Network::Callback callback,
-                    olp::http::Network::HeaderCallback header_callback,
+                    olp::http::Network::HeaderCallback /*header_callback*/,
                     olp::http::Network::DataCallback data_callback) {
         olp::http::RequestId request_id(5);
         if (payload) {
@@ -248,10 +249,10 @@ TEST_F(AuthenticationClientTest, SignInClientScope) {
       });
 
   EXPECT_CALL(*network_, Send(IsGetRequest(kTimestampUrl), _, _, _, _))
-      .WillOnce([&](olp::http::NetworkRequest request,
+      .WillOnce([&](olp::http::NetworkRequest /*request*/,
                     olp::http::Network::Payload payload,
                     olp::http::Network::Callback callback,
-                    olp::http::Network::HeaderCallback header_callback,
+                    olp::http::Network::HeaderCallback /*header_callback*/,
                     olp::http::Network::DataCallback data_callback) {
         olp::http::RequestId request_id(5);
         if (payload) {
@@ -297,10 +298,10 @@ TEST_F(AuthenticationClientTest, SignInClientData) {
 
   EXPECT_CALL(*network_, Send(_, _, _, _, _))
       .Times(2)
-      .WillOnce([&](olp::http::NetworkRequest request,
+      .WillOnce([&](olp::http::NetworkRequest /*request*/,
                     olp::http::Network::Payload payload,
                     olp::http::Network::Callback callback,
-                    olp::http::Network::HeaderCallback header_callback,
+                    olp::http::Network::HeaderCallback /*header_callback*/,
                     olp::http::Network::DataCallback data_callback) {
         olp::http::RequestId request_id(5);
         if (payload) {
@@ -317,11 +318,11 @@ TEST_F(AuthenticationClientTest, SignInClientData) {
 
         return olp::http::SendOutcome(request_id);
       })
-      .WillOnce([&](olp::http::NetworkRequest request,
-                    olp::http::Network::Payload payload,
+      .WillOnce([&](olp::http::NetworkRequest /*request*/,
+                    olp::http::Network::Payload /*payload*/,
                     olp::http::Network::Callback callback,
-                    olp::http::Network::HeaderCallback header_callback,
-                    olp::http::Network::DataCallback data_callback) {
+                    olp::http::Network::HeaderCallback /*header_callback*/,
+                    olp::http::Network::DataCallback /*data_callback*/) {
         olp::http::RequestId request_id(6);
         callback(olp::http::NetworkResponse()
                      .WithRequestId(request_id)
@@ -332,26 +333,27 @@ TEST_F(AuthenticationClientTest, SignInClientData) {
       });
   EXPECT_CALL(*network_, Send(IsGetRequest(kTimestampUrl), _, _, _, _))
       .Times(2)
-      .WillRepeatedly([&](olp::http::NetworkRequest request,
-                          olp::http::Network::Payload payload,
-                          olp::http::Network::Callback callback,
-                          olp::http::Network::HeaderCallback header_callback,
-                          olp::http::Network::DataCallback data_callback) {
-        olp::http::RequestId request_id(5);
-        if (payload) {
-          *payload << kResponseTime;
-        }
-        callback(olp::http::NetworkResponse()
-                     .WithRequestId(request_id)
-                     .WithStatus(olp::http::HttpStatusCode::OK));
-        if (data_callback) {
-          auto raw = const_cast<char*>(kResponseTime.c_str());
-          data_callback(reinterpret_cast<uint8_t*>(raw), 0,
-                        kResponseTime.size());
-        }
+      .WillRepeatedly(
+          [&](olp::http::NetworkRequest /*request*/,
+              olp::http::Network::Payload payload,
+              olp::http::Network::Callback callback,
+              olp::http::Network::HeaderCallback /*header_callback*/,
+              olp::http::Network::DataCallback data_callback) {
+            olp::http::RequestId request_id(5);
+            if (payload) {
+              *payload << kResponseTime;
+            }
+            callback(olp::http::NetworkResponse()
+                         .WithRequestId(request_id)
+                         .WithStatus(olp::http::HttpStatusCode::OK));
+            if (data_callback) {
+              auto raw = const_cast<char*>(kResponseTime.c_str());
+              data_callback(reinterpret_cast<uint8_t*>(raw), 0,
+                            kResponseTime.size());
+            }
 
-        return olp::http::SendOutcome(request_id);
-      });
+            return olp::http::SendOutcome(request_id);
+          });
 
   std::time_t now = std::time(nullptr);
   client_->SignInClient(
@@ -396,10 +398,10 @@ TEST_F(AuthenticationClientTest, SignInClientData) {
 TEST_F(AuthenticationClientTest, SignUpHereUserData) {
   EXPECT_CALL(*network_, Send(_, _, _, _, _))
       .Times(1)
-      .WillOnce([&](olp::http::NetworkRequest request,
+      .WillOnce([&](olp::http::NetworkRequest /*request*/,
                     olp::http::Network::Payload payload,
                     olp::http::Network::Callback callback,
-                    olp::http::Network::HeaderCallback header_callback,
+                    olp::http::Network::HeaderCallback /*header_callback*/,
                     olp::http::Network::DataCallback data_callback) {
         olp::http::RequestId request_id(5);
         if (payload) {
@@ -435,10 +437,10 @@ TEST_F(AuthenticationClientTest, SignInUserDataFirstTime) {
 
   EXPECT_CALL(*network_, Send(_, _, _, _, _))
       .Times(1)
-      .WillOnce([&](olp::http::NetworkRequest request,
+      .WillOnce([&](olp::http::NetworkRequest /*request*/,
                     olp::http::Network::Payload payload,
                     olp::http::Network::Callback callback,
-                    olp::http::Network::HeaderCallback header_callback,
+                    olp::http::Network::HeaderCallback /*header_callback*/,
                     olp::http::Network::DataCallback data_callback) {
         olp::http::RequestId request_id(5);
         if (payload) {
@@ -489,10 +491,10 @@ TEST_F(AuthenticationClientTest, AcceptTermsData) {
 
   EXPECT_CALL(*network_, Send(_, _, _, _, _))
       .Times(1)
-      .WillOnce([&](olp::http::NetworkRequest request,
+      .WillOnce([&](olp::http::NetworkRequest /*request*/,
                     olp::http::Network::Payload payload,
                     olp::http::Network::Callback callback,
-                    olp::http::Network::HeaderCallback header_callback,
+                    olp::http::Network::HeaderCallback /*header_callback*/,
                     olp::http::Network::DataCallback data_callback) {
         olp::http::RequestId request_id(5);
         if (payload) {
@@ -541,10 +543,10 @@ TEST_F(AuthenticationClientTest, SignInHereUser) {
 
   EXPECT_CALL(*network_, Send(_, _, _, _, _))
       .Times(1)
-      .WillOnce([&](olp::http::NetworkRequest request,
+      .WillOnce([&](olp::http::NetworkRequest /*request*/,
                     olp::http::Network::Payload payload,
                     olp::http::Network::Callback callback,
-                    olp::http::Network::HeaderCallback header_callback,
+                    olp::http::Network::HeaderCallback /*header_callback*/,
                     olp::http::Network::DataCallback data_callback) {
         olp::http::RequestId request_id(5);
         if (payload) {
@@ -592,10 +594,10 @@ TEST_F(AuthenticationClientTest, SignOutUser) {
 
   EXPECT_CALL(*network_, Send(_, _, _, _, _))
       .Times(1)
-      .WillOnce([&](olp::http::NetworkRequest request,
+      .WillOnce([&](olp::http::NetworkRequest /*request*/,
                     olp::http::Network::Payload payload,
                     olp::http::Network::Callback callback,
-                    olp::http::Network::HeaderCallback header_callback,
+                    olp::http::Network::HeaderCallback /*header_callback*/,
                     olp::http::Network::DataCallback data_callback) {
         olp::http::RequestId request_id(5);
         if (payload) {
@@ -659,11 +661,11 @@ TEST_F(AuthenticationClientTest, SignInFederated) {
 
   EXPECT_CALL(*network_, Send(request_matcher, _, _, _, _))
       .Times(1)
-      .WillOnce([&](olp::http::NetworkRequest request,
+      .WillOnce([&](olp::http::NetworkRequest /*request*/,
                     olp::http::Network::Payload payload,
                     olp::http::Network::Callback callback,
-                    olp::http::Network::HeaderCallback header_callback,
-                    olp::http::Network::DataCallback data_callback) {
+                    olp::http::Network::HeaderCallback /*header_callback*/,
+                    olp::http::Network::DataCallback /*data_callback*/) {
         olp::http::RequestId request_id(5);
         if (payload) {
           *payload << kUserSigninResponse;
@@ -701,10 +703,10 @@ TEST_F(AuthenticationClientTest, SignInFacebookData) {
 
   EXPECT_CALL(*network_, Send(_, _, _, _, _))
       .Times(1)
-      .WillOnce([&](olp::http::NetworkRequest request,
+      .WillOnce([&](olp::http::NetworkRequest /*request*/,
                     olp::http::Network::Payload payload,
                     olp::http::Network::Callback callback,
-                    olp::http::Network::HeaderCallback header_callback,
+                    olp::http::Network::HeaderCallback /*header_callback*/,
                     olp::http::Network::DataCallback data_callback) {
         olp::http::RequestId request_id(5);
         if (payload) {
@@ -759,10 +761,10 @@ TEST_F(AuthenticationClientTest, SignInGoogleData) {
 
   EXPECT_CALL(*network_, Send(_, _, _, _, _))
       .Times(1)
-      .WillOnce([&](olp::http::NetworkRequest request,
+      .WillOnce([&](olp::http::NetworkRequest /*request*/,
                     olp::http::Network::Payload payload,
                     olp::http::Network::Callback callback,
-                    olp::http::Network::HeaderCallback header_callback,
+                    olp::http::Network::HeaderCallback /*header_callback*/,
                     olp::http::Network::DataCallback data_callback) {
         olp::http::RequestId request_id(5);
         if (payload) {
@@ -809,10 +811,10 @@ TEST_F(AuthenticationClientTest, SignInArcGisData) {
 
   EXPECT_CALL(*network_, Send(_, _, _, _, _))
       .Times(1)
-      .WillOnce([&](olp::http::NetworkRequest request,
+      .WillOnce([&](olp::http::NetworkRequest /*request*/,
                     olp::http::Network::Payload payload,
                     olp::http::Network::Callback callback,
-                    olp::http::Network::HeaderCallback header_callback,
+                    olp::http::Network::HeaderCallback /*header_callback*/,
                     olp::http::Network::DataCallback data_callback) {
         olp::http::RequestId request_id(5);
         if (payload) {
@@ -867,10 +869,10 @@ TEST_F(AuthenticationClientTest, SignInRefreshData) {
 
   EXPECT_CALL(*network_, Send(_, _, _, _, _))
       .Times(1)
-      .WillOnce([&](olp::http::NetworkRequest request,
+      .WillOnce([&](olp::http::NetworkRequest /*request*/,
                     olp::http::Network::Payload payload,
                     olp::http::Network::Callback callback,
-                    olp::http::Network::HeaderCallback header_callback,
+                    olp::http::Network::HeaderCallback /*header_callback*/,
                     olp::http::Network::DataCallback data_callback) {
         olp::http::RequestId request_id(5);
         if (payload) {
@@ -918,27 +920,28 @@ TEST_F(AuthenticationClientTest, ErrorFieldsData) {
 
   EXPECT_CALL(*network_, Send(_, _, _, _, _))
       .Times(3)
-      .WillRepeatedly([&](olp::http::NetworkRequest request,
-                          olp::http::Network::Payload payload,
-                          olp::http::Network::Callback callback,
-                          olp::http::Network::HeaderCallback header_callback,
-                          olp::http::Network::DataCallback data_callback) {
-        olp::http::RequestId request_id(5);
-        if (payload) {
-          *payload << kResponseErrorFields;
-        }
-        callback(olp::http::NetworkResponse()
-                     .WithRequestId(request_id)
-                     .WithStatus(olp::http::HttpStatusCode::BAD_REQUEST)
-                     .WithError(kErrorFieldsMessage));
-        if (data_callback) {
-          auto raw = const_cast<char*>(kResponseErrorFields.c_str());
-          data_callback(reinterpret_cast<uint8_t*>(raw), 0,
-                        kResponseErrorFields.size());
-        }
+      .WillRepeatedly(
+          [&](olp::http::NetworkRequest /*request*/,
+              olp::http::Network::Payload payload,
+              olp::http::Network::Callback callback,
+              olp::http::Network::HeaderCallback /*header_callback*/,
+              olp::http::Network::DataCallback data_callback) {
+            olp::http::RequestId request_id(5);
+            if (payload) {
+              *payload << kResponseErrorFields;
+            }
+            callback(olp::http::NetworkResponse()
+                         .WithRequestId(request_id)
+                         .WithStatus(olp::http::HttpStatusCode::BAD_REQUEST)
+                         .WithError(kErrorFieldsMessage));
+            if (data_callback) {
+              auto raw = const_cast<char*>(kResponseErrorFields.c_str());
+              data_callback(reinterpret_cast<uint8_t*>(raw), 0,
+                            kResponseErrorFields.size());
+            }
 
-        return olp::http::SendOutcome(request_id);
-      });
+            return olp::http::SendOutcome(request_id);
+          });
 
   AuthenticationClient::UserProperties properties;
   client_->SignInHereUser(
@@ -1106,11 +1109,11 @@ TEST_F(AuthenticationClientTest, IntrospectApp) {
   {
     SCOPED_TRACE("Successful request");
     EXPECT_CALL(*network_, Send(IsGetRequest(kIntrospectUrl), _, _, _, _))
-        .WillOnce([&](olp::http::NetworkRequest request,
+        .WillOnce([&](olp::http::NetworkRequest /*request*/,
                       olp::http::Network::Payload payload,
                       olp::http::Network::Callback callback,
-                      olp::http::Network::HeaderCallback header_callback,
-                      olp::http::Network::DataCallback data_callback) {
+                      olp::http::Network::HeaderCallback /*header_callback*/,
+                      olp::http::Network::DataCallback /*data_callback*/) {
           olp::http::RequestId request_id(3);
           if (payload) {
             *payload << kIntrospectAppResponse;
@@ -1155,11 +1158,11 @@ TEST_F(AuthenticationClientTest, IntrospectApp) {
   {
     SCOPED_TRACE("Invalid access token");
     EXPECT_CALL(*network_, Send(IsGetRequest(kIntrospectUrl), _, _, _, _))
-        .WillOnce([&](olp::http::NetworkRequest request,
+        .WillOnce([&](olp::http::NetworkRequest /*request*/,
                       olp::http::Network::Payload payload,
                       olp::http::Network::Callback callback,
-                      olp::http::Network::HeaderCallback header_callback,
-                      olp::http::Network::DataCallback data_callback) {
+                      olp::http::Network::HeaderCallback /*header_callback*/,
+                      olp::http::Network::DataCallback /*data_callback*/) {
           olp::http::RequestId request_id(3);
           if (payload) {
             *payload << kInvalidAccessTokenResponse;

--- a/tests/integration/olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,49 +134,51 @@ class HereAccountOauth2Test : public ::testing::Test {
 TEST_F(HereAccountOauth2Test, AutoRefreshingTokenCancelSync) {
   EXPECT_CALL(*network_, Send(_, _, _, _, _))
       .Times(2)
-      .WillRepeatedly([&](olp::http::NetworkRequest request,
-                          olp::http::Network::Payload payload,
-                          olp::http::Network::Callback callback,
-                          olp::http::Network::HeaderCallback header_callback,
-                          olp::http::Network::DataCallback data_callback) {
-        olp::http::RequestId request_id(5);
-        if (payload) {
-          *payload << kResponseValidJson;
-        }
-        callback(olp::http::NetworkResponse()
-                     .WithRequestId(request_id)
-                     .WithStatus(olp::http::HttpStatusCode::OK)
-                     .WithError(kErrorOk));
-        if (data_callback) {
-          auto raw = const_cast<char*>(kResponseValidJson.c_str());
-          data_callback(reinterpret_cast<uint8_t*>(raw), 0,
-                        kResponseValidJson.size());
-        }
+      .WillRepeatedly(
+          [&](olp::http::NetworkRequest /*request*/,
+              olp::http::Network::Payload payload,
+              olp::http::Network::Callback callback,
+              olp::http::Network::HeaderCallback /*header_callback*/,
+              olp::http::Network::DataCallback data_callback) {
+            olp::http::RequestId request_id(5);
+            if (payload) {
+              *payload << kResponseValidJson;
+            }
+            callback(olp::http::NetworkResponse()
+                         .WithRequestId(request_id)
+                         .WithStatus(olp::http::HttpStatusCode::OK)
+                         .WithError(kErrorOk));
+            if (data_callback) {
+              auto raw = const_cast<char*>(kResponseValidJson.c_str());
+              data_callback(reinterpret_cast<uint8_t*>(raw), 0,
+                            kResponseValidJson.size());
+            }
 
-        return olp::http::SendOutcome(request_id);
-      });
+            return olp::http::SendOutcome(request_id);
+          });
   EXPECT_CALL(*network_, Send(IsGetRequest(kTimestampUrl), _, _, _, _))
       .Times(2)
-      .WillRepeatedly([&](olp::http::NetworkRequest request,
-                          olp::http::Network::Payload payload,
-                          olp::http::Network::Callback callback,
-                          olp::http::Network::HeaderCallback header_callback,
-                          olp::http::Network::DataCallback data_callback) {
-        olp::http::RequestId request_id(5);
-        if (payload) {
-          *payload << kResponseTime;
-        }
-        callback(olp::http::NetworkResponse()
-                     .WithRequestId(request_id)
-                     .WithStatus(olp::http::HttpStatusCode::OK));
-        if (data_callback) {
-          auto raw = const_cast<char*>(kResponseTime.c_str());
-          data_callback(reinterpret_cast<uint8_t*>(raw), 0,
-                        kResponseTime.size());
-        }
+      .WillRepeatedly(
+          [&](olp::http::NetworkRequest /*request*/,
+              olp::http::Network::Payload payload,
+              olp::http::Network::Callback callback,
+              olp::http::Network::HeaderCallback /*header_callback*/,
+              olp::http::Network::DataCallback data_callback) {
+            olp::http::RequestId request_id(5);
+            if (payload) {
+              *payload << kResponseTime;
+            }
+            callback(olp::http::NetworkResponse()
+                         .WithRequestId(request_id)
+                         .WithStatus(olp::http::HttpStatusCode::OK));
+            if (data_callback) {
+              auto raw = const_cast<char*>(kResponseTime.c_str());
+              data_callback(reinterpret_cast<uint8_t*>(raw), 0,
+                            kResponseTime.size());
+            }
 
-        return olp::http::SendOutcome(request_id);
-      });
+            return olp::http::SendOutcome(request_id);
+          });
   Settings settings({key_, secret_});
   settings.network_request_handler = network_;
   TokenEndpoint token_endpoint(settings);
@@ -193,10 +195,10 @@ TEST_F(HereAccountOauth2Test, AutoRefreshingTokenCancelSync) {
 
 TEST_F(HereAccountOauth2Test, AutoRefreshingTokenBackendError) {
   EXPECT_CALL(*network_, Send(_, _, _, _, _))
-      .WillOnce([&](olp::http::NetworkRequest request,
+      .WillOnce([&](olp::http::NetworkRequest /*request*/,
                     olp::http::Network::Payload payload,
                     olp::http::Network::Callback callback,
-                    olp::http::Network::HeaderCallback header_callback,
+                    olp::http::Network::HeaderCallback /*header_callback*/,
                     olp::http::Network::DataCallback data_callback) {
         olp::http::RequestId request_id(5);
         if (payload) {
@@ -215,11 +217,11 @@ TEST_F(HereAccountOauth2Test, AutoRefreshingTokenBackendError) {
         return olp::http::SendOutcome(request_id);
       });
   EXPECT_CALL(*network_, Send(IsGetRequest(kTimestampUrl), _, _, _, _))
-      .WillOnce([&](olp::http::NetworkRequest request,
-                          olp::http::Network::Payload payload,
-                          olp::http::Network::Callback callback,
-                          olp::http::Network::HeaderCallback header_callback,
-                          olp::http::Network::DataCallback data_callback) {
+      .WillOnce([&](olp::http::NetworkRequest /*request*/,
+                    olp::http::Network::Payload payload,
+                    olp::http::Network::Callback callback,
+                    olp::http::Network::HeaderCallback /*header_callback*/,
+                    olp::http::Network::DataCallback data_callback) {
         olp::http::RequestId request_id(5);
         if (payload) {
           *payload << kResponseTime;
@@ -253,49 +255,51 @@ TEST_F(HereAccountOauth2Test, AutoRefreshingTokenBackendError) {
 TEST_F(HereAccountOauth2Test, AutoRefreshingTokenCancelAsync) {
   EXPECT_CALL(*network_, Send(_, _, _, _, _))
       .Times(2)
-      .WillRepeatedly([&](olp::http::NetworkRequest request,
-                          olp::http::Network::Payload payload,
-                          olp::http::Network::Callback callback,
-                          olp::http::Network::HeaderCallback header_callback,
-                          olp::http::Network::DataCallback data_callback) {
-        olp::http::RequestId request_id(5);
-        if (payload) {
-          *payload << kResponseValidJson;
-        }
-        callback(olp::http::NetworkResponse()
-                     .WithRequestId(request_id)
-                     .WithStatus(olp::http::HttpStatusCode::OK)
-                     .WithError(kErrorOk));
-        if (data_callback) {
-          auto raw = const_cast<char*>(kResponseValidJson.c_str());
-          data_callback(reinterpret_cast<uint8_t*>(raw), 0,
-                        kResponseValidJson.size());
-        }
+      .WillRepeatedly(
+          [&](olp::http::NetworkRequest /*request*/,
+              olp::http::Network::Payload payload,
+              olp::http::Network::Callback callback,
+              olp::http::Network::HeaderCallback /*header_callback*/,
+              olp::http::Network::DataCallback data_callback) {
+            olp::http::RequestId request_id(5);
+            if (payload) {
+              *payload << kResponseValidJson;
+            }
+            callback(olp::http::NetworkResponse()
+                         .WithRequestId(request_id)
+                         .WithStatus(olp::http::HttpStatusCode::OK)
+                         .WithError(kErrorOk));
+            if (data_callback) {
+              auto raw = const_cast<char*>(kResponseValidJson.c_str());
+              data_callback(reinterpret_cast<uint8_t*>(raw), 0,
+                            kResponseValidJson.size());
+            }
 
-        return olp::http::SendOutcome(request_id);
-      });
+            return olp::http::SendOutcome(request_id);
+          });
   EXPECT_CALL(*network_, Send(IsGetRequest(kTimestampUrl), _, _, _, _))
       .Times(2)
-      .WillRepeatedly([&](olp::http::NetworkRequest request,
-                          olp::http::Network::Payload payload,
-                          olp::http::Network::Callback callback,
-                          olp::http::Network::HeaderCallback header_callback,
-                          olp::http::Network::DataCallback data_callback) {
-        olp::http::RequestId request_id(5);
-        if (payload) {
-          *payload << kResponseTime;
-        }
-        callback(olp::http::NetworkResponse()
-                     .WithRequestId(request_id)
-                     .WithStatus(olp::http::HttpStatusCode::OK));
-        if (data_callback) {
-          auto raw = const_cast<char*>(kResponseTime.c_str());
-          data_callback(reinterpret_cast<uint8_t*>(raw), 0,
-                        kResponseTime.size());
-        }
+      .WillRepeatedly(
+          [&](olp::http::NetworkRequest /*request*/,
+              olp::http::Network::Payload payload,
+              olp::http::Network::Callback callback,
+              olp::http::Network::HeaderCallback /*header_callback*/,
+              olp::http::Network::DataCallback data_callback) {
+            olp::http::RequestId request_id(5);
+            if (payload) {
+              *payload << kResponseTime;
+            }
+            callback(olp::http::NetworkResponse()
+                         .WithRequestId(request_id)
+                         .WithStatus(olp::http::HttpStatusCode::OK));
+            if (data_callback) {
+              auto raw = const_cast<char*>(kResponseTime.c_str());
+              data_callback(reinterpret_cast<uint8_t*>(raw), 0,
+                            kResponseTime.size());
+            }
 
-        return olp::http::SendOutcome(request_id);
-      });
+            return olp::http::SendOutcome(request_id);
+          });
   Settings settings({key_, secret_});
   settings.network_request_handler = network_;
   TokenEndpoint token_endpoint(settings);

--- a/tests/integration/olp-cpp-sdk-dataservice-write/IndexLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/IndexLayerClientTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,11 +109,11 @@ class IndexLayerClientTest : public ::testing::Test {
     ON_CALL(network, Send(_, _, _, _, _))
         .WillByDefault(testing::DoAll(
             ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(-1), ""),
-            [](olp::http::NetworkRequest request,
-               olp::http::Network::Payload payload,
-               olp::http::Network::Callback callback,
-               olp::http::Network::HeaderCallback header_callback,
-               olp::http::Network::DataCallback data_callback) {
+            [](olp::http::NetworkRequest /*request*/,
+               olp::http::Network::Payload /*payload*/,
+               olp::http::Network::Callback /*callback*/,
+               olp::http::Network::HeaderCallback /*header_callback*/,
+               olp::http::Network::DataCallback /*data_callback*/) {
               auto fail_helper = []() { FAIL(); };
               fail_helper();
               return olp::http::SendOutcome(5);

--- a/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientCacheTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -153,11 +153,11 @@ class StreamLayerClientCacheTest : public ::testing::Test {
     ON_CALL(network, Send(_, _, _, _, _))
         .WillByDefault(testing::DoAll(
             ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(-1), ""),
-            [](olp::http::NetworkRequest request,
-               olp::http::Network::Payload payload,
-               olp::http::Network::Callback callback,
-               olp::http::Network::HeaderCallback header_callback,
-               olp::http::Network::DataCallback data_callback) {
+            [](olp::http::NetworkRequest /*request*/,
+               olp::http::Network::Payload /*payload*/,
+               olp::http::Network::Callback /*callback*/,
+               olp::http::Network::HeaderCallback /*header_callback*/,
+               olp::http::Network::DataCallback /*data_callback*/) {
               auto fail_helper = []() { FAIL(); };
               fail_helper();
               return olp::http::SendOutcome(5);

--- a/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/StreamLayerClientTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -160,11 +160,11 @@ class StreamLayerClientTest : public ::testing::Test {
     ON_CALL(network, Send(_, _, _, _, _))
         .WillByDefault(testing::DoAll(
             ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(-1), ""),
-            [](olp::http::NetworkRequest request,
-               olp::http::Network::Payload payload,
-               olp::http::Network::Callback callback,
-               olp::http::Network::HeaderCallback header_callback,
-               olp::http::Network::DataCallback data_callback) {
+            [](olp::http::NetworkRequest /*request*/,
+               olp::http::Network::Payload /*payload*/,
+               olp::http::Network::Callback /*callback*/,
+               olp::http::Network::HeaderCallback /*header_callback*/,
+               olp::http::Network::DataCallback /*data_callback*/) {
               auto fail_helper = []() { FAIL(); };
               fail_helper();
               return olp::http::SendOutcome(5);

--- a/tests/integration/olp-cpp-sdk-dataservice-write/VolatileLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/VolatileLayerClientTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,11 +81,11 @@ class VolatileLayerClientTest : public ::testing::Test {
     ON_CALL(network, Send(_, _, _, _, _))
         .WillByDefault(testing::DoAll(
             ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(-1), ""),
-            [](olp::http::NetworkRequest request,
-               olp::http::Network::Payload payload,
-               olp::http::Network::Callback callback,
-               olp::http::Network::HeaderCallback header_callback,
-               olp::http::Network::DataCallback data_callback) {
+            [](olp::http::NetworkRequest /*request*/,
+               olp::http::Network::Payload /*payload*/,
+               olp::http::Network::Callback /*callback*/,
+               olp::http::Network::HeaderCallback /*header_callback*/,
+               olp::http::Network::DataCallback /*data_callback*/) {
               auto fail_helper = []() { FAIL(); };
               fail_helper();
               return olp::http::SendOutcome(5);

--- a/tests/performance/MemoryTest.cpp
+++ b/tests/performance/MemoryTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -207,7 +207,7 @@ TEST_P(MemoryTest, ReadLatestVersionCatalogClient) {
   const auto& parameter = GetParam();
   auto settings = CreateCatalogClientSettings();
 
-  StartThreads([=](uint8_t thread_id) {
+  StartThreads([=](uint8_t /*thread_id*/) {
     olp::dataservice::read::CatalogClient service_client(kCatalog, settings);
 
     const auto end_timestamp =
@@ -243,7 +243,7 @@ TEST_P(MemoryTest, ReadMetadataCatalogClient) {
   const auto& parameter = GetParam();
   auto settings = CreateCatalogClientSettings();
 
-  StartThreads([=](uint8_t thread_id) {
+  StartThreads([=](uint8_t /*thread_id*/) {
     olp::dataservice::read::CatalogClient service_client(kCatalog, settings);
 
     const auto end_timestamp =
@@ -289,7 +289,7 @@ TEST_P(MemoryTest, ReadNPartitionsFromVersionedLayer) {
 
   auto settings = CreateCatalogClientSettings();
 
-  StartThreads([=](uint8_t thread_id) {
+  StartThreads([=](uint8_t /*thread_id*/) {
     olp::dataservice::read::VersionedLayerClient service_client(
         kCatalog, kVersionedLayerId, settings);
 
@@ -325,7 +325,7 @@ TEST_P(MemoryTest, PrefetchPartitionsFromVersionedLayer) {
 
   auto settings = CreateCatalogClientSettings();
 
-  StartThreads([=](uint8_t thread_id) {
+  StartThreads([=](uint8_t /*thread_id*/) {
     olp::dataservice::read::VersionedLayerClient service_client(
         kCatalog, kVersionedLayerId, settings);
 

--- a/tests/performance/NullCache.h
+++ b/tests/performance/NullCache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,29 +27,29 @@
  */
 class NullCache : public olp::cache::KeyValueCache {
  public:
-  bool Put(const std::string& key, const boost::any& value,
-           const olp::cache::Encoder& encoder,
-           time_t expiry = (std::numeric_limits<time_t>::max)()) override {
+  bool Put(const std::string& /*key*/, const boost::any& /*value*/,
+           const olp::cache::Encoder& /*encoder*/,
+           time_t /*expiry*/) override {
     return false;
   }
 
-  bool Put(const std::string& key,
-           const std::shared_ptr<std::vector<unsigned char>> value,
-           time_t expiry = (std::numeric_limits<time_t>::max)()) override {
+  bool Put(const std::string& /*key*/,
+           const std::shared_ptr<std::vector<unsigned char>> /*value*/,
+           time_t /*expiry*/) override {
     return false;
   }
 
-  boost::any Get(const std::string& key,
-                 const olp::cache::Decoder& encoder) override {
+  boost::any Get(const std::string& /*key*/,
+                 const olp::cache::Decoder& /*encoder*/) override {
     return {};
   }
 
   std::shared_ptr<std::vector<unsigned char>> Get(
-      const std::string& key) override {
+      const std::string& /*key*/) override {
     return nullptr;
   }
 
-  bool Remove(const std::string& key) override { return true; }
+  bool Remove(const std::string& /*key*/) override { return true; }
 
-  bool RemoveKeysWithPrefix(const std::string& prefix) override { return true; }
+  bool RemoveKeysWithPrefix(const std::string& /*prefix*/) override { return true; }
 };


### PR DESCRIPTION
Enable compiler warnings and treat them as errors:
 * unused parameters
 * unused functions

Updated the psv script to trigger an error on new warnings.

Relates-To: OLPEDGE-1728
Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>