### PR TITLE
QuadTreeIndexVolatile method for QueryApi.

### DIFF
--- a/olp-cpp-sdk-core/src/client/OlpClient.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClient.cpp
@@ -27,6 +27,7 @@
 
 #include "olp/core/client/Condition.h"
 #include "olp/core/client/ErrorCode.h"
+#include "olp/core/http/HttpStatusCode.h"
 #include "olp/core/http/NetworkConstants.h"
 #include "olp/core/logging/Log.h"
 #include "olp/core/utils/Url.h"
@@ -372,6 +373,11 @@ HttpResponse OlpClient::CallApi(std::string path, std::string method,
                                 OlpClient::RequestBodyType post_body,
                                 std::string content_type,
                                 CancellationContext context) const {
+  if (!settings_.network_request_handler) {
+    return HttpResponse(static_cast<int>(olp::http::ErrorCode::OFFLINE_ERROR),
+                        "Network request handler is empty.");
+  }
+
   const auto& retry_settings = settings_.retry_settings;
   auto network_settings =
       http::NetworkSettings()

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.cpp
@@ -38,6 +38,9 @@ constexpr auto kLogTag = "read::QueryApi";
 
 std::string ConcatStringArray(const std::vector<std::string>& strings,
                               const std::string& delimiter) {
+  if (strings.empty()) {
+    return {};
+  }
   if (strings.size() == 1) {
     return strings.front();
   }
@@ -122,7 +125,41 @@ QueryApi::QuadTreeIndexResponse QueryApi::QuadTreeIndex(
       metadata_uri, "GET", std::move(query_params), std::move(header_params),
       {}, nullptr, std::string{}, std::move(context));
 
-  OLP_SDK_LOG_TRACE_F(kLogTag, "QuadTreeIndex, uri=%s, status=%d",
+  OLP_SDK_LOG_DEBUG_F(kLogTag, "QuadTreeIndex, uri=%s, status=%d",
+                      metadata_uri.c_str(), response.status);
+  if (response.status != olp::http::HttpStatusCode::OK) {
+    return client::ApiError(response.status, response.response.str());
+  }
+
+  return olp::parser::parse<model::Index>(response.response);
+}
+
+QueryApi::QuadTreeIndexResponse QueryApi::QuadTreeIndexVolatile(
+    const client::OlpClient& client, const std::string& layer_id,
+    const std::string& quad_key, int32_t depth,
+    boost::optional<std::vector<std::string>> additional_fields,
+    boost::optional<std::string> billing_tag,
+    client::CancellationContext context) {
+  std::multimap<std::string, std::string> header_params;
+  header_params.insert(std::make_pair("Accept", "application/json"));
+
+  std::multimap<std::string, std::string> query_params;
+  if (additional_fields) {
+    query_params.insert(std::make_pair(
+        "additionalFields", ConcatStringArray(*additional_fields, ",")));
+  }
+  if (billing_tag) {
+    query_params.insert(std::make_pair("billingTag", *billing_tag));
+  }
+
+  std::string metadata_uri = "/layers/" + layer_id + "/quadkeys/" + quad_key +
+                             "/depths/" + std::to_string(depth);
+
+  client::HttpResponse response = client.CallApi(
+      metadata_uri, "GET", std::move(query_params), std::move(header_params),
+      {}, nullptr, std::string{}, std::move(context));
+
+  OLP_SDK_LOG_DEBUG_F(kLogTag, "QuadTreeIndex, uri=%s, status=%d",
                       metadata_uri.c_str(), response.status);
   if (response.status != olp::http::HttpStatusCode::OK) {
     return client::ApiError(response.status, response.response.str());

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.h
@@ -112,6 +112,41 @@ class QueryApi {
       boost::optional<std::vector<std::string>> additional_fields,
       boost::optional<std::string> billing_tag,
       client::CancellationContext context);
+
+  /**
+   * @brief Gets index metadata
+   * Gets metadata synchronously for the requested index. Only available for
+   * layers where the partitioning scheme is &#x60;heretile&#x60;.
+   *
+   * @param layer_id The ID of the layer specified in the request.
+   * Content of this parameter must refer to a valid layer already configured
+   * in the catalog configuration. Exactly one layer ID must be
+   * provided.
+   * @param quad_key The geometric area specified by an index in the request,
+   * represented as a HERE tile
+   * @param depth The recursion depth
+   * of the response. If set to 0, the response includes only data for the
+   * quad_key specified in the request. In this way, depth describes the maximum
+   * length of the subQuadKeys in the response. The maximum allowed value for
+   * the depth parameter is 4.
+   * @param additional_fields Additional fields - &#x60;dataSize&#x60;,
+   * &#x60;checksum&#x60;, &#x60;compressedDataSize&#x60;
+   * @param billing_tag Billing Tag is an optional free-form tag used to
+   * group billing records together. If supplied, it must be between 4 - 16
+   * characters and  contain only alphanumeric ASCII characters  [A-Za-z0-9].
+   * Grouping billing records by billing tag will be available in a future
+   * release.
+   * @param context A CancellationContext instance which can be used to cancel
+   * call of this method.
+   * @param The result of this operation as a client::ApiResponse object with \c
+   * model::Index as a result
+   **/
+  static QuadTreeIndexResponse QuadTreeIndexVolatile(
+      const client::OlpClient& client, const std::string& layer_id,
+      const std::string& quad_key, int32_t depth,
+      boost::optional<std::vector<std::string>> additional_fields,
+      boost::optional<std::string> billing_tag,
+      client::CancellationContext context);
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(OLP_SDK_DATASERVICE_READ_TEST_SOURCES
     ParserTest.cpp
     PartitionsRepositoryTest.cpp
     PrefetchRepositoryTest.cpp
+    QueryApiTest.cpp
     SerializerTest.cpp
     StreamApiTest.cpp
     StreamLayerClientImplTest.cpp

--- a/olp-cpp-sdk-dataservice-read/tests/QueryApiTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/QueryApiTest.cpp
@@ -1,0 +1,253 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gmock/gmock-matchers.h>
+#include <gmock/gmock.h>
+#include <matchers/NetworkUrlMatchers.h>
+#include <mocks/NetworkMock.h>
+#include <olp/core/client/OlpClient.h>
+#include <olp/core/client/OlpClientFactory.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include "generated/api/QueryApi.h"
+
+namespace {
+constexpr auto kLayerid = "test-layer";
+constexpr auto kQuadKey = "23618401";
+constexpr auto kNodeBaseUrl =
+    "https://some.node.base.url/stream/v2/catalogs/"
+    "hrn:here:data::olp-here-test:hereos-internal-test-v2";
+constexpr auto kUrlQuadTreeIndexVolatile =
+    R"(https://some.node.base.url/stream/v2/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2/layers/test-layer/quadkeys/23618401/depths/2)";
+
+constexpr auto kUrlQuadTreeIndexVolatileAllInputs =
+    R"(https://some.node.base.url/stream/v2/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2/layers/test-layer/quadkeys/23618401/depths/2?additionalFields=checksum%2CdataSize&billingTag=OlpCppSdkTest)";
+
+constexpr auto kHttpResponseEmpty = R"jsonString()jsonString";
+constexpr auto kHttpResponseQuadTreeIndexVolatile =
+    R"jsonString({ "parentQuads": [ { "additionalMetadata": "string", "checksum": "string", "compressedDataSize": 0, "dataHandle": "675911FF6236B7C7604BF8B105F1BB58", "dataSize": 0, "crc": "c3f276d7", "partition": "73982", "version": 0 } ], "subQuads": [ { "additionalMetadata": "string", "checksum": "291f66029c232400e3403cd6e9cfd36e", "compressedDataSize": 200, "dataHandle": "1b2ca68f-d4a0-4379-8120-cd025640510c", "dataSize": 1024, "crc": "c3f276d7", "subQuadKey": "string", "version": 1 } ] })jsonString";
+
+using namespace ::testing;
+using namespace olp;
+using namespace olp::client;
+using namespace olp::dataservice::read;
+using namespace olp::tests::common;
+
+class QueryApiTest : public Test {
+ protected:
+  void SetUp() override {
+    network_mock_ = std::make_shared<NetworkMock>();
+
+    settings_ = std::make_shared<OlpClientSettings>();
+    settings_->network_request_handler = network_mock_;
+
+    client_ = OlpClientFactory::Create(*settings_);
+    client_->SetBaseUrl(kNodeBaseUrl);
+  }
+  void TearDown() override { network_mock_.reset(); }
+
+ protected:
+  std::shared_ptr<OlpClientSettings> settings_;
+  std::shared_ptr<OlpClient> client_;
+  std::shared_ptr<NetworkMock> network_mock_;
+};
+
+TEST_F(QueryApiTest, QuadTreeIndexVolatile) {
+  {
+    SCOPED_TRACE("Request metadata for tile.");
+    EXPECT_CALL(
+        *network_mock_,
+        Send(AllOf(IsGetRequest(kUrlQuadTreeIndexVolatile)), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(
+            http::NetworkResponse().WithStatus(http::HttpStatusCode::OK),
+            kHttpResponseQuadTreeIndexVolatile));
+
+    int32_t depth = 2;
+    auto index_response =
+        olp::dataservice::read::QueryApi::QuadTreeIndexVolatile(
+            *client_, kLayerid, kQuadKey, depth, boost::none, boost::none,
+            olp::client::CancellationContext{});
+
+    ASSERT_TRUE(index_response.IsSuccessful());
+    auto result = index_response.GetResult();
+    ASSERT_EQ(1u, result.GetSubQuads().size());
+    ASSERT_EQ(1u, result.GetParentQuads().size());
+  }
+  {
+    SCOPED_TRACE("Request with billing tag + additional fields.");
+    EXPECT_CALL(*network_mock_,
+                Send(AllOf(IsGetRequest(kUrlQuadTreeIndexVolatileAllInputs)), _,
+                     _, _, _))
+        .WillOnce(ReturnHttpResponse(
+            http::NetworkResponse().WithStatus(http::HttpStatusCode::OK),
+            kHttpResponseQuadTreeIndexVolatile));
+
+    int32_t depth = 2;
+    std::string billing_tag = "OlpCppSdkTest";
+    std::vector<std::string> additional_fields = {"checksum", "dataSize"};
+    auto index_response =
+        olp::dataservice::read::QueryApi::QuadTreeIndexVolatile(
+            *client_, kLayerid, kQuadKey, depth, additional_fields, billing_tag,
+            olp::client::CancellationContext{});
+
+    ASSERT_TRUE(index_response.IsSuccessful());
+    auto result = index_response.GetResult();
+    ASSERT_EQ(1u, result.GetSubQuads().size());
+    ASSERT_EQ(1u, result.GetParentQuads().size());
+  }
+  // negative tests
+  {
+    SCOPED_TRACE("Requested quead not found.");
+    EXPECT_CALL(
+        *network_mock_,
+        Send(AllOf(IsGetRequest(kUrlQuadTreeIndexVolatile)), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(
+            http::NetworkResponse().WithStatus(http::HttpStatusCode::NOT_FOUND),
+            kHttpResponseEmpty));
+
+    int32_t depth = 2;
+    auto index_response =
+        olp::dataservice::read::QueryApi::QuadTreeIndexVolatile(
+            *client_, kLayerid, kQuadKey, depth, boost::none, boost::none,
+            olp::client::CancellationContext{});
+
+    ASSERT_FALSE(index_response.IsSuccessful());
+    auto error = index_response.GetError();
+    ASSERT_EQ(http::HttpStatusCode::NOT_FOUND, error.GetHttpStatusCode());
+    ASSERT_EQ(kHttpResponseEmpty, error.GetMessage());
+  }
+  {
+    SCOPED_TRACE("Not configured olp client");
+    auto client = OlpClient();
+    int32_t depth = 2;
+    auto index_response =
+        olp::dataservice::read::QueryApi::QuadTreeIndexVolatile(
+            client, kLayerid, kQuadKey, depth, boost::none, boost::none,
+            olp::client::CancellationContext{});
+
+    ASSERT_FALSE(index_response.IsSuccessful());
+    auto error = index_response.GetError();
+    ASSERT_EQ(static_cast<int>(olp::http::ErrorCode::OFFLINE_ERROR), error.GetHttpStatusCode());
+  }
+  {
+    SCOPED_TRACE("Invalid layer id");
+    EXPECT_CALL(*network_mock_, Send(_, _, _, _, _))
+        .WillOnce(ReturnHttpResponse(http::NetworkResponse().WithStatus(
+                                         http::HttpStatusCode::BAD_REQUEST),
+                                     kHttpResponseEmpty));
+    int32_t depth = 2;
+    auto index_response =
+        olp::dataservice::read::QueryApi::QuadTreeIndexVolatile(
+            *client_, {}, kQuadKey, depth, boost::none, boost::none,
+            olp::client::CancellationContext{});
+
+    ASSERT_FALSE(index_response.IsSuccessful());
+    auto error = index_response.GetError();
+    ASSERT_EQ(http::HttpStatusCode::BAD_REQUEST, error.GetHttpStatusCode());
+    ASSERT_EQ(kHttpResponseEmpty, error.GetMessage());
+  }
+  {
+    SCOPED_TRACE("Invalid quad key.");
+    EXPECT_CALL(*network_mock_, Send(_, _, _, _, _))
+        .WillOnce(ReturnHttpResponse(http::NetworkResponse().WithStatus(
+                                         http::HttpStatusCode::BAD_REQUEST),
+                                     kHttpResponseEmpty));
+    int32_t depth = 2;
+    auto index_response =
+        olp::dataservice::read::QueryApi::QuadTreeIndexVolatile(
+            *client_, kLayerid, {}, depth, boost::none, boost::none,
+            olp::client::CancellationContext{});
+
+    ASSERT_FALSE(index_response.IsSuccessful());
+    auto error = index_response.GetError();
+    ASSERT_EQ(http::HttpStatusCode::BAD_REQUEST, error.GetHttpStatusCode());
+    ASSERT_EQ(kHttpResponseEmpty, error.GetMessage());
+  }
+  {
+    SCOPED_TRACE("Invalid depth.");
+    EXPECT_CALL(*network_mock_, Send(_, _, _, _, _))
+        .WillOnce(ReturnHttpResponse(http::NetworkResponse().WithStatus(
+                                         http::HttpStatusCode::BAD_REQUEST),
+                                     kHttpResponseEmpty));
+    int32_t depth = -1;
+    auto index_response =
+        olp::dataservice::read::QueryApi::QuadTreeIndexVolatile(
+            *client_, kLayerid, kQuadKey, depth, boost::none, boost::none,
+            olp::client::CancellationContext{});
+
+    ASSERT_FALSE(index_response.IsSuccessful());
+    auto error = index_response.GetError();
+    ASSERT_EQ(http::HttpStatusCode::BAD_REQUEST, error.GetHttpStatusCode());
+    ASSERT_EQ(kHttpResponseEmpty, error.GetMessage());
+  }
+  {
+    SCOPED_TRACE("Empty additional fields.");
+    EXPECT_CALL(*network_mock_, Send(_, _, _, _, _))
+        .WillOnce(ReturnHttpResponse(http::NetworkResponse().WithStatus(
+                                         http::HttpStatusCode::BAD_REQUEST),
+                                     kHttpResponseEmpty));
+
+    int32_t depth = 2;
+    std::vector<std::string> empty_fields;
+    auto index_response =
+        olp::dataservice::read::QueryApi::QuadTreeIndexVolatile(
+            *client_, kLayerid, kQuadKey, depth, empty_fields, boost::none,
+            olp::client::CancellationContext{});
+
+    ASSERT_FALSE(index_response.IsSuccessful());
+    auto error = index_response.GetError();
+    ASSERT_EQ(http::HttpStatusCode::BAD_REQUEST, error.GetHttpStatusCode());
+    ASSERT_EQ(kHttpResponseEmpty, error.GetMessage());
+  }
+  {
+    SCOPED_TRACE("Empty billing tag.");
+    EXPECT_CALL(*network_mock_, Send(_, _, _, _, _))
+        .WillOnce(ReturnHttpResponse(http::NetworkResponse().WithStatus(
+                                         http::HttpStatusCode::BAD_REQUEST),
+                                     kHttpResponseEmpty));
+
+    int32_t depth = 2;
+    std::string empty_tag;
+    auto index_response =
+        olp::dataservice::read::QueryApi::QuadTreeIndexVolatile(
+            *client_, kLayerid, kQuadKey, depth, boost::none, empty_tag,
+            olp::client::CancellationContext{});
+
+    ASSERT_FALSE(index_response.IsSuccessful());
+    auto error = index_response.GetError();
+    ASSERT_EQ(http::HttpStatusCode::BAD_REQUEST, error.GetHttpStatusCode());
+    ASSERT_EQ(kHttpResponseEmpty, error.GetMessage());
+  }
+  {
+    SCOPED_TRACE("Cancelled CancellationContext");
+
+    auto context = olp::client::CancellationContext();
+    context.CancelOperation();
+    int32_t depth = 2;
+    auto index_response =
+        olp::dataservice::read::QueryApi::QuadTreeIndexVolatile(
+            *client_, kLayerid, kQuadKey, depth, boost::none, boost::none,
+            context);
+
+    ASSERT_FALSE(index_response.IsSuccessful());
+    auto error = index_response.GetError();
+    ASSERT_EQ(olp::client::ErrorCode::Cancelled, error.GetErrorCode());
+  }
+}
+
+}  // namespace


### PR DESCRIPTION
This is a part of prefetch update of VolatileLayerClient. The method is
loading tile metadata like QueryApi::QuadTreeIndex(), but for volatile
layer.

Resolves: OLPEDGE-794

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>