### PR TITLE
Add expiration cache test for lookup api.

### DIFF
--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -33,7 +33,7 @@ set(OLP_SDK_INTEGRATIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-dataservice-write/StreamLayerClientTest.cpp
     ./olp-cpp-sdk-dataservice-write/VolatileLayerClientTest.cpp
     ./olp-cpp-sdk-core/DefaultNetworkTest.cpp
-    ./olp-cpp-sdk-core/CacheTest.cpp
+    ./olp-cpp-sdk-core/DefaultCacheTest.cpp
 )
 
 if (ANDROID OR IOS)

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -33,6 +33,7 @@ set(OLP_SDK_INTEGRATIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-dataservice-write/StreamLayerClientTest.cpp
     ./olp-cpp-sdk-dataservice-write/VolatileLayerClientTest.cpp
     ./olp-cpp-sdk-core/DefaultNetworkTest.cpp
+    ./olp-cpp-sdk-core/CacheTest.cpp
 )
 
 if (ANDROID OR IOS)

--- a/tests/integration/olp-cpp-sdk-core/CacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-core/CacheTest.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gtest/gtest.h>
+#include <thread>
+
+#include <olp/core/cache/DefaultCache.h>
+
+namespace {
+using namespace olp::cache;
+
+TEST(CacheTest, DataExpiration) {
+  const std::string content_key = "test_key";
+  CacheSettings settings;
+  settings.max_memory_cache_size = 5;  // bytes
+  settings.disk_path_mutable = "./cache";
+  const auto expire_time = 1;
+
+  {
+    SCOPED_TRACE("Create a disk cache, write data.");
+    DefaultCache cache(settings);
+    EXPECT_EQ(cache.Open(), DefaultCache::StorageOpenResult::Success);
+
+    const std::string content = "12345";
+    auto buffer = std::make_shared<std::vector<unsigned char>>(
+        std::begin(content), std::end(content));
+    EXPECT_TRUE(cache.Put(content_key, buffer, expire_time));
+    // check if data is in cache
+    auto buffer_out_1 = cache.Get(content_key);
+    ASSERT_NE(buffer_out_1, nullptr);
+    cache.Close();
+  }
+
+  std::this_thread::sleep_for(std::chrono::seconds(expire_time + 1));
+
+  {
+    SCOPED_TRACE("Check that data is expired after timeout.");
+    DefaultCache cache(settings);
+    EXPECT_EQ(cache.Open(), DefaultCache::StorageOpenResult::Success);
+
+    auto buffer = cache.Get(content_key);
+    ASSERT_EQ(buffer, nullptr);
+
+    cache.Close();
+  }
+}
+
+}  // namespace

--- a/tests/integration/olp-cpp-sdk-core/DefaultCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-core/DefaultCacheTest.cpp
@@ -25,7 +25,7 @@
 namespace {
 using namespace olp::cache;
 
-TEST(CacheTest, DataExpiration) {
+TEST(DefaultCacheTest, DataExpiration) {
   const std::string content_key = "test_key";
   CacheSettings settings;
   settings.max_memory_cache_size = 5;  // bytes

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -2923,11 +2923,11 @@ TEST_F(DataserviceReadVersionedLayerClientTest, CheckLookupApiCacheExpiration) {
   auto cache = std::make_shared<testing::StrictMock<CacheMock>>();
   settings_->cache = cache;
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = olp::dataservice::read::VersionedLayerClient(
       hrn, "testlayer", 4, *settings_);
 
   // check if expiration time is 1 hour(3600 sec)
-  time_t expirationTime = 3600;
+  time_t expiration_time = 3600;
   EXPECT_CALL(*cache, Get("hrn:here:data::olp-here-test:here-optimized-map-for-"
                           "visualization-2::query::v1::api",
                           _))
@@ -2935,7 +2935,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, CheckLookupApiCacheExpiration) {
       .WillOnce(Return(boost::any()));
   EXPECT_CALL(*cache, Put("hrn:here:data::olp-here-test:here-optimized-map-for-"
                           "visualization-2::query::v1::api",
-                          _, _, expirationTime))
+                          _, _, expiration_time))
       .Times(1)
       .WillOnce(Return(true));
   EXPECT_CALL(*cache, Get("hrn:here:data::olp-here-test:here-optimized-map-for-"
@@ -2945,7 +2945,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, CheckLookupApiCacheExpiration) {
       .WillOnce(Return(boost::any()));
   EXPECT_CALL(*cache, Put("hrn:here:data::olp-here-test:here-optimized-map-for-"
                           "visualization-2::blob::v1::api",
-                          _, _, expirationTime))
+                          _, _, expiration_time))
       .Times(1)
       .WillOnce(Return(true));
 
@@ -2974,9 +2974,8 @@ TEST_F(DataserviceReadVersionedLayerClientTest, CheckLookupApiCacheExpiration) {
       .Times(1)
       .WillOnce(Return(true));
 
-  auto request = olp::dataservice::read::DataRequest();
-  request.WithPartitionId("269").WithFetchOption(OnlineIfNotFound);
-  auto future = client->GetData(request);
+  auto request = olp::dataservice::read::DataRequest().WithPartitionId("269").WithFetchOption(OnlineIfNotFound);
+  auto future = client.GetData(request);
 
   auto data_response = future.GetFuture().get();
 

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -22,6 +22,7 @@
 #include <string>
 
 #include <matchers/NetworkUrlMatchers.h>
+#include <mocks/CacheMock.h>
 #include <mocks/NetworkMock.h>
 #include <olp/authentication/Settings.h>
 #include <olp/core/cache/CacheSettings.h>
@@ -2915,67 +2916,66 @@ TEST_F(DataserviceReadVersionedLayerClientTest, RemoveFromCacheTileKey) {
   ASSERT_FALSE(response.IsSuccessful());
 }
 
-TEST_F(DataserviceReadVersionedLayerClientTest, CheckCacheExpirationLookupApi) {
+TEST_F(DataserviceReadVersionedLayerClientTest, CheckLookupApiCacheExpiration) {
   olp::client::HRN hrn(GetTestCatalog());
-  // reset network mock
-  network_mock_ = std::make_shared<NetworkMock>();
-  settings_->network_request_handler = network_mock_;
 
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
-      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                       olp::http::HttpStatusCode::OK),
-                                   kHttpResponseBlobData_269));
+  // initialize mock cache
+  auto cache = std::make_shared<testing::StrictMock<CacheMock>>();
+  settings_->cache = cache;
 
-  // initialize cache
-  if (!settings_->cache) {
-    settings_->cache =
-        olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
-  }
   auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
       hrn, "testlayer", 4, *settings_);
 
-  // write to cache, but change expiration time
-  time_t expirationTime = 2;
-  const std::string serviceUrl(
-      "https://metadata.data.api.platform.here.com/metadata/v1/catalogs/"
-      "hereos-internal-test-v2");
-  settings_->cache->Put(
-      "hrn:here:data::olp-here-test:here-optimized-map-for-visualization-2::"
-      "metadata::v1::api",
-      serviceUrl, [serviceUrl]() { return serviceUrl; }, expirationTime);
+  // check if expiration time is 1 hour(3600 sec)
+  time_t expirationTime = 3600;
+  EXPECT_CALL(*cache, Get("hrn:here:data::olp-here-test:here-optimized-map-for-"
+                          "visualization-2::query::v1::api",
+                          _))
+      .Times(1)
+      .WillOnce(Return(boost::any()));
+  EXPECT_CALL(*cache, Put("hrn:here:data::olp-here-test:here-optimized-map-for-"
+                          "visualization-2::query::v1::api",
+                          _, _, expirationTime))
+      .Times(1)
+      .WillOnce(Return(true));
+  EXPECT_CALL(*cache, Get("hrn:here:data::olp-here-test:here-optimized-map-for-"
+                          "visualization-2::blob::v1::api",
+                          _))
+      .Times(1)
+      .WillOnce(Return(boost::any()));
+  EXPECT_CALL(*cache, Put("hrn:here:data::olp-here-test:here-optimized-map-for-"
+                          "visualization-2::blob::v1::api",
+                          _, _, expirationTime))
+      .Times(1)
+      .WillOnce(Return(true));
 
-  const std::string serviceUrl2(
-      "https://query.data.api.platform.here.com/query/v1/catalogs/"
-      "hereos-internal-test-v2");
-  settings_->cache->Put(
-      "hrn:here:data::olp-here-test:here-optimized-map-for-visualization-2::"
-      "query::v1::api",
-      serviceUrl2, [serviceUrl2]() { return serviceUrl2; }, expirationTime);
+  EXPECT_CALL(*cache, Get("hrn:here:data::olp-here-test:here-optimized-map-for-"
+                          "visualization-2::testlayer::269::4::partition",
+                          _))
+      .Times(1)
+      .WillOnce(Return(boost::any()));
+  EXPECT_CALL(*cache, Put("hrn:here:data::olp-here-test:here-optimized-map-for-"
+                          "visualization-2::testlayer::269::4::partition",
+                          _, _, _))
+      .Times(1)
+      .WillOnce(Return(true));
 
-  const std::string serviceUrl3(
-      "https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/"
-      "hereos-internal-test-v2");
-  settings_->cache->Put(
-      "hrn:here:data::olp-here-test:here-optimized-map-for-visualization-2::"
-      "blob::v1::api",
-      serviceUrl3, [serviceUrl3]() { return serviceUrl3; }, expirationTime);
-
-  olp::dataservice::read::model::Partition partition;
-  partition.SetPartition("269");
-  partition.SetDataHandle("4eed6ed1-0d32-43b9-ae79-043cb4256432");
-  partition.SetVersion(4);
-  settings_->cache->Put(
-      "hrn:here:data::olp-here-test:here-optimized-map-for-visualization-2::"
-      "testlayer::269::4::partition",
-      partition,
-      [=]() {
-        return R"jsonString({"dataHandle":"4eed6ed1-0d32-43b9-ae79-043cb4256432","partition":"269","version":4})jsonString";
-      },
-      std::numeric_limits<time_t>::max());
+  EXPECT_CALL(
+      *cache,
+      Get("hrn:here:data::olp-here-test:here-optimized-map-for-visualization-2:"
+          ":testlayer::4eed6ed1-0d32-43b9-ae79-043cb4256432::Data"))
+      .Times(1)
+      .WillOnce(Return(nullptr));
+  EXPECT_CALL(
+      *cache,
+      Put("hrn:here:data::olp-here-test:here-optimized-map-for-visualization-2:"
+          ":testlayer::4eed6ed1-0d32-43b9-ae79-043cb4256432::Data",
+          _, _))
+      .Times(1)
+      .WillOnce(Return(true));
 
   auto request = olp::dataservice::read::DataRequest();
-  request.WithPartitionId("269").WithFetchOption(
-      OnlineIfNotFound);  // CacheOnly OnlineIfNotFound
+  request.WithPartitionId("269").WithFetchOption(OnlineIfNotFound);
   auto future = client->GetData(request);
 
   auto data_response = future.GetFuture().get();
@@ -2987,21 +2987,6 @@ TEST_F(DataserviceReadVersionedLayerClientTest, CheckCacheExpirationLookupApi) {
                           data_response.GetResult()->end());
   ASSERT_EQ("DT_2_0031", data_string);
 
-  // remove cached data for partition
-  settings_->cache->Remove(
-      "hrn:here:data::olp-here-test:here-optimized-map-for-visualization-2::"
-      "testlayer::4eed6ed1-0d32-43b9-ae79-043cb4256432::Data");
-
-  // as data expired, second call will send request to lookup api
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
-      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(429),
-                                   "Server busy at the moment."));
-
-  std::this_thread::sleep_for(std::chrono::seconds(4));
-  future = client->GetData(request);
-  data_response = future.GetFuture().get();
-  // second call should fail, becouse data expired in cache
-  ASSERT_FALSE(data_response.IsSuccessful());
 }
 
 }  // namespace


### PR DESCRIPTION
Create mock cache. Run get data for VersionedLayerClient.
Check if lookup api data are stored in cache with expiration time equal
1 hour(3600 seconds). Write core test to check cache expiration. Write 
data with expiration 1 second. Get data from cache to check if data was
stored corectly. Wait 2 seconds and try to get data again. Data should 
be expired.

Relates-To: OLPEDGE-1612

Signed-off-by: Liubov Didkivska ext-liubov.didkivska@here.com