### PR TITLE
Fix flaky test SyncQueueTest.ConcurrentUsage

### DIFF
--- a/olp-cpp-sdk-core/tests/thread/SyncQueueTest.cpp
+++ b/olp-cpp-sdk-core/tests/thread/SyncQueueTest.cpp
@@ -197,7 +197,7 @@ TEST(SyncQueueTest, ConcurrentUsage) {
                1000u;
   };
 
-  while (!sync_queue.Empty() && check_condition()) {
+  while (check_condition()) {
     std::this_thread::sleep_for(kSleep / 3);
   }
 


### PR DESCRIPTION
Fix for flaky test SyncQueueTest.ConcurrentUsage which was failed due
to SyncQueue emptiness check that could be true before all tasks were
actually complete.

Resolves: OLPEDGE-1713

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>