### PR TITLE
Add API to remove single partition/tilekey from cache for VolatileLayerClient

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
@@ -26,6 +26,7 @@
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClientSettings.h>
+#include <olp/core/geo/tiling/TileKey.h>
 #include <olp/dataservice/read/DataRequest.h>
 #include <olp/dataservice/read/PartitionsRequest.h>
 #include <olp/dataservice/read/Types.h>
@@ -182,6 +183,14 @@ class DATASERVICE_READ_API VolatileLayerClient final {
    * @return True if partition data is removed successfully; false otherwise.
    */
   bool RemoveFromCache(const std::string& partition_id);
+  /**
+   * @brief Removes the tile from the mutable disk cache.
+   *
+   * @param tile The tile key that should be removed.
+   *
+   * @return True if tile data is removed successfully; false otherwise.
+   */
+  bool RemoveFromCache(const geo::TileKey& tile);
 
  private:
   std::unique_ptr<VolatileLayerClientImpl> impl_;

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
@@ -175,6 +175,7 @@ class DATASERVICE_READ_API VolatileLayerClient final {
    * request.
    */
   olp::client::CancellableFuture<DataResponse> GetData(DataRequest request);
+
   /**
    * @brief Removes the partition from the mutable disk cache.
    *
@@ -183,6 +184,7 @@ class DATASERVICE_READ_API VolatileLayerClient final {
    * @return True if partition data is removed successfully; false otherwise.
    */
   bool RemoveFromCache(const std::string& partition_id);
+
   /**
    * @brief Removes the tile from the mutable disk cache.
    *

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
@@ -174,6 +174,14 @@ class DATASERVICE_READ_API VolatileLayerClient final {
    * request.
    */
   olp::client::CancellableFuture<DataResponse> GetData(DataRequest request);
+  /**
+   * @brief Removes the partition from the mutable disk cache.
+   *
+   * @param partition_id The partition ID that should be removed.
+   *
+   * @return True if partition data is removed successfully; false otherwise.
+   */
+  bool RemoveFromCache(const std::string& partition_id);
 
  private:
   std::unique_ptr<VolatileLayerClientImpl> impl_;

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClient.cpp
@@ -67,6 +67,11 @@ olp::client::CancellableFuture<DataResponse> VolatileLayerClient::GetData(
 bool VolatileLayerClient::RemoveFromCache(const std::string& partition_id) {
   return impl_->RemoveFromCache(partition_id);
 }
+
+bool VolatileLayerClient::RemoveFromCache(const geo::TileKey& tile) {
+  return impl_->RemoveFromCache(tile);
+}
+
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClient.cpp
@@ -63,6 +63,10 @@ olp::client::CancellableFuture<DataResponse> VolatileLayerClient::GetData(
     DataRequest request) {
   return impl_->GetData(std::move(request));
 }
+
+bool VolatileLayerClient::RemoveFromCache(const std::string& partition_id) {
+  return impl_->RemoveFromCache(partition_id);
+}
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -144,6 +144,11 @@ bool VolatileLayerClientImpl::RemoveFromCache(const std::string& partition_id) {
   return data_repository.Clear(layer_id_, partition.get().GetDataHandle());
 }
 
+bool VolatileLayerClientImpl::RemoveFromCache(const geo::TileKey& tile) {
+  auto partition_id = tile.ToHereTile();
+  return RemoveFromCache(partition_id);
+}
+
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -28,8 +28,10 @@
 
 #include "Common.h"
 #include "repositories/CatalogRepository.h"
+#include "repositories/DataCacheRepository.h"
 #include "repositories/DataRepository.h"
 #include "repositories/ExecuteOrSchedule.inl"
+#include "repositories/PartitionsCacheRepository.h"
 #include "repositories/PartitionsRepository.h"
 
 namespace olp {
@@ -122,6 +124,24 @@ client::CancellableFuture<DataResponse> VolatileLayerClientImpl::GetData(
   };
   auto token = GetData(std::move(request), std::move(callback));
   return olp::client::CancellableFuture<DataResponse>(token, promise);
+}
+
+bool VolatileLayerClientImpl::RemoveFromCache(const std::string& partition_id) {
+  repository::PartitionsCacheRepository cache_repository(catalog_,
+                                                         settings_.cache);
+  boost::optional<model::Partition> partition;
+  if (!cache_repository.ClearPartitionMetadata(boost::none, partition_id,
+                                               layer_id_, partition)) {
+    return false;
+  }
+
+  if (!partition) {
+    // partition are not stored in cache
+    return true;
+  }
+
+  repository::DataCacheRepository data_repository(catalog_, settings_.cache);
+  return data_repository.Clear(layer_id_, partition.get().GetDataHandle());
 }
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
@@ -22,6 +22,7 @@
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClientSettings.h>
+#include <olp/core/geo/tiling/TileKey.h>
 #include <olp/dataservice/read/DataRequest.h>
 #include <olp/dataservice/read/PartitionsRequest.h>
 #include <olp/dataservice/read/Types.h>
@@ -60,6 +61,8 @@ class VolatileLayerClientImpl {
   virtual client::CancellableFuture<DataResponse> GetData(DataRequest request);
 
   virtual bool RemoveFromCache(const std::string& partition_id);
+
+  virtual bool RemoveFromCache(const geo::TileKey& tile);
 
  private:
   client::HRN catalog_;

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
@@ -59,6 +59,8 @@ class VolatileLayerClientImpl {
 
   virtual client::CancellableFuture<DataResponse> GetData(DataRequest request);
 
+  virtual bool RemoveFromCache(const std::string& partition_id);
+
  private:
   client::HRN catalog_;
   std::string layer_id_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
@@ -207,8 +207,8 @@ void PartitionsCacheRepository::ClearPartitions(
 }
 
 bool PartitionsCacheRepository::ClearPartitionMetadata(
-    int64_t catalog_version, const std::string& partition_id,
-    const std::string& layer_id,
+    const boost::optional<int64_t>& catalog_version,
+    const std::string& partition_id, const std::string& layer_id,
     boost::optional<model::Partition>& out_partition) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, layer_id, partition_id, catalog_version);

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
@@ -63,7 +63,7 @@ class PartitionsCacheRepository final {
                        const std::vector<std::string>& partitionIds,
                        const std::string& layer_id);
 
-  bool ClearPartitionMetadata(int64_t catalog_version,
+  bool ClearPartitionMetadata(const boost::optional<int64_t>& catalog_version,
                               const std::string& partition_id,
                               const std::string& layer_id,
                               boost::optional<model::Partition>& out_partition);

--- a/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
@@ -342,12 +342,14 @@ TEST(VolatileLayerClientImplTest, RemoveFromCachePartition) {
     partition.SetDataHandle(kBlobDataHandle);
     return partition;
   };
+
   auto partition_cache_remove = [&](const std::string& prefix) {
     std::string expected_prefix = kHrn.ToCatalogHRNString() + "::" + kLayerId +
                                   "::" + kPartitionId + "::partition";
     EXPECT_EQ(prefix, expected_prefix);
     return true;
   };
+
   auto data_cache_remove = [&](const std::string& prefix) {
     std::string expected_prefix = kHrn.ToCatalogHRNString() + "::" + kLayerId +
                                   "::" + kBlobDataHandle + "::Data";
@@ -358,7 +360,6 @@ TEST(VolatileLayerClientImplTest, RemoveFromCachePartition) {
   VolatileLayerClientImpl client(kHrn, kLayerId, settings);
   {
     SCOPED_TRACE("Successfull remove partition from cache");
-
     EXPECT_CALL(*cache_mock, Get(_, _)).WillOnce(found_cache_response);
     EXPECT_CALL(*cache_mock, RemoveKeysWithPrefix(_))
         .WillOnce(partition_cache_remove)
@@ -403,12 +404,14 @@ TEST(VolatileLayerClientImplTest, RemoveFromCacheTileKey) {
     partition.SetDataHandle(kBlobDataHandle);
     return partition;
   };
+
   auto partition_cache_remove = [&](const std::string& prefix) {
     std::string expected_prefix = kHrn.ToCatalogHRNString() + "::" + kLayerId +
                                   "::" + kPartitionId + "::partition";
     EXPECT_EQ(prefix, expected_prefix);
     return true;
   };
+
   auto data_cache_remove = [&](const std::string& prefix) {
     std::string expected_prefix = kHrn.ToCatalogHRNString() + "::" + kLayerId +
                                   "::" + kBlobDataHandle + "::Data";
@@ -420,7 +423,6 @@ TEST(VolatileLayerClientImplTest, RemoveFromCacheTileKey) {
   VolatileLayerClientImpl client(kHrn, kLayerId, settings);
   {
     SCOPED_TRACE("Successfull remove partition from cache");
-
     EXPECT_CALL(*cache_mock, Get(_, _)).WillOnce(found_cache_response);
     EXPECT_CALL(*cache_mock, RemoveKeysWithPrefix(_))
         .WillOnce(partition_cache_remove)

--- a/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
@@ -389,4 +389,67 @@ TEST(VolatileLayerClientImplTest, RemoveFromCachePartition) {
     ASSERT_FALSE(client.RemoveFromCache(kPartitionId));
   }
 }
+
+TEST(VolatileLayerClientImplTest, RemoveFromCacheTileKey) {
+  olp::client::OlpClientSettings settings;
+  std::shared_ptr<CacheMock> cache_mock = std::make_shared<CacheMock>();
+  settings.cache = cache_mock;
+
+  // successfull mock cache calls
+  auto found_cache_response = [](const std::string& /*key*/,
+                                 const olp::cache::Decoder& /*encoder*/) {
+    auto partition = model::Partition();
+    partition.SetPartition(kPartitionId);
+    partition.SetDataHandle(kBlobDataHandle);
+    return partition;
+  };
+  auto partition_cache_remove = [&](const std::string& prefix) {
+    std::string expected_prefix = kHrn.ToCatalogHRNString() + "::" + kLayerId +
+                                  "::" + kPartitionId + "::partition";
+    EXPECT_EQ(prefix, expected_prefix);
+    return true;
+  };
+  auto data_cache_remove = [&](const std::string& prefix) {
+    std::string expected_prefix = kHrn.ToCatalogHRNString() + "::" + kLayerId +
+                                  "::" + kBlobDataHandle + "::Data";
+    EXPECT_EQ(prefix, expected_prefix);
+    return true;
+  };
+
+  auto tile_key = olp::geo::TileKey::FromHereTile(kPartitionId);
+  VolatileLayerClientImpl client(kHrn, kLayerId, settings);
+  {
+    SCOPED_TRACE("Successfull remove partition from cache");
+
+    EXPECT_CALL(*cache_mock, Get(_, _)).WillOnce(found_cache_response);
+    EXPECT_CALL(*cache_mock, RemoveKeysWithPrefix(_))
+        .WillOnce(partition_cache_remove)
+        .WillOnce(data_cache_remove);
+    ASSERT_TRUE(client.RemoveFromCache(tile_key));
+  }
+  {
+    SCOPED_TRACE("Remove not existing partition from cache");
+    EXPECT_CALL(*cache_mock, Get(_, _))
+        .WillOnce([](const std::string&, const olp::cache::Decoder&) {
+          return boost::any();
+        });
+    ASSERT_TRUE(client.RemoveFromCache(tile_key));
+  }
+  {
+    SCOPED_TRACE("Partition cache failure");
+    EXPECT_CALL(*cache_mock, Get(_, _)).WillOnce(found_cache_response);
+    EXPECT_CALL(*cache_mock, RemoveKeysWithPrefix(_))
+        .WillOnce([](const std::string&) { return false; });
+    ASSERT_FALSE(client.RemoveFromCache(tile_key));
+  }
+  {
+    SCOPED_TRACE("Data cache failure");
+    EXPECT_CALL(*cache_mock, Get(_, _)).WillOnce(found_cache_response);
+    EXPECT_CALL(*cache_mock, RemoveKeysWithPrefix(_))
+        .WillOnce(partition_cache_remove)
+        .WillOnce([](const std::string&) { return false; });
+    ASSERT_FALSE(client.RemoveFromCache(tile_key));
+  }
+}
+
 }  // namespace

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientTest.cpp
@@ -847,13 +847,13 @@ TEST_F(DataserviceReadVolatileLayerClientTest, RemoveFromCachePartition) {
                                        olp::http::HttpStatusCode::OK),
                                    "someData"));
 
-  auto client = std::make_unique<olp::dataservice::read::VolatileLayerClient>(
-      hrn, "testlayer_volatile", settings_);
+  olp::dataservice::read::VolatileLayerClient client(hrn, "testlayer_volatile",
+                                                     settings_);
 
   auto request = olp::dataservice::read::DataRequest();
   request.WithPartitionId(partition_id);
 
-  auto future = client->GetData(request);
+  auto future = client.GetData(request);
 
   auto data_response = future.GetFuture().get();
 
@@ -865,11 +865,60 @@ TEST_F(DataserviceReadVolatileLayerClientTest, RemoveFromCachePartition) {
   ASSERT_EQ("someData", data_string);
 
   // remove the data from cache
-  ASSERT_TRUE(client->RemoveFromCache(partition_id));
+  ASSERT_TRUE(client.RemoveFromCache(partition_id));
 
   // check the data is not available in cache
   request.WithFetchOption(CacheOnly);
-  future = client->GetData(request);
+  future = client.GetData(request);
+  data_response = future.GetFuture().get();
+  ASSERT_FALSE(data_response.IsSuccessful())
+      << ApiErrorToString(data_response.GetError());
+}
+
+TEST_F(DataserviceReadVolatileLayerClientTest, RemoveFromCacheTileKey) {
+  olp::client::HRN hrn(GetTestCatalog());
+
+  auto partition_id = "269";
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(URL_LATEST_CATALOG_VERSION), _, _, _, _))
+      .Times(0);
+
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(URL_QUERY_VOLATILE_PARTITION_269), _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   HTTP_RESPONSE_PARTITIONS_V2));
+
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(URL_VOLATILE_BLOB_DATA), _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   "someData"));
+
+  olp::dataservice::read::VolatileLayerClient client(hrn, "testlayer_volatile",
+                                                     settings_);
+
+  auto request = olp::dataservice::read::DataRequest();
+  request.WithPartitionId(partition_id);
+
+  auto future = client.GetData(request);
+
+  auto data_response = future.GetFuture().get();
+
+  ASSERT_TRUE(data_response.IsSuccessful())
+      << ApiErrorToString(data_response.GetError());
+  ASSERT_LT(0, data_response.GetResult()->size());
+  std::string data_string(data_response.GetResult()->begin(),
+                          data_response.GetResult()->end());
+  ASSERT_EQ("someData", data_string);
+
+  // remove the data from cache
+  auto tile_key = olp::geo::TileKey::FromHereTile(partition_id);
+  ASSERT_TRUE(client.RemoveFromCache(tile_key));
+
+  // check the data is not available in cache
+  request.WithFetchOption(CacheOnly);
+  future = client.GetData(request);
   data_response = future.GetFuture().get();
   ASSERT_FALSE(data_response.IsSuccessful())
       << ApiErrorToString(data_response.GetError());

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientTest.cpp
@@ -717,7 +717,7 @@ TEST_F(DataserviceReadVolatileLayerClientTest, GetVolatileDataHandle) {
 
   ASSERT_TRUE(data_response.IsSuccessful())
       << ApiErrorToString(data_response.GetError());
-  ASSERT_LT(0, data_response.GetResult()->size());
+  ASSERT_FALSE(data_response.GetResult()->empty());
   std::string data_string(data_response.GetResult()->begin(),
                           data_response.GetResult()->end());
   ASSERT_EQ("someData", data_string);
@@ -754,7 +754,7 @@ TEST_F(DataserviceReadVolatileLayerClientTest, GetVolatileDataByPartitionId) {
 
   ASSERT_TRUE(data_response.IsSuccessful())
       << ApiErrorToString(data_response.GetError());
-  ASSERT_LT(0, data_response.GetResult()->size());
+  ASSERT_FALSE(data_response.GetResult()->empty());
   std::string data_string(data_response.GetResult()->begin(),
                           data_response.GetResult()->end());
   ASSERT_EQ("someData", data_string);
@@ -859,7 +859,7 @@ TEST_F(DataserviceReadVolatileLayerClientTest, RemoveFromCachePartition) {
 
   ASSERT_TRUE(data_response.IsSuccessful())
       << ApiErrorToString(data_response.GetError());
-  ASSERT_LT(0, data_response.GetResult()->size());
+  ASSERT_FALSE(data_response.GetResult()->empty());
   std::string data_string(data_response.GetResult()->begin(),
                           data_response.GetResult()->end());
   ASSERT_EQ("someData", data_string);
@@ -898,8 +898,8 @@ TEST_F(DataserviceReadVolatileLayerClientTest, RemoveFromCacheTileKey) {
   olp::dataservice::read::VolatileLayerClient client(hrn, "testlayer_volatile",
                                                      settings_);
 
-  auto request = olp::dataservice::read::DataRequest();
-  request.WithPartitionId(partition_id);
+  auto request =
+      olp::dataservice::read::DataRequest().WithPartitionId(partition_id);
 
   auto future = client.GetData(request);
 
@@ -907,7 +907,7 @@ TEST_F(DataserviceReadVolatileLayerClientTest, RemoveFromCacheTileKey) {
 
   ASSERT_TRUE(data_response.IsSuccessful())
       << ApiErrorToString(data_response.GetError());
-  ASSERT_LT(0, data_response.GetResult()->size());
+  ASSERT_FALSE(data_response.GetResult()->empty());
   std::string data_string(data_response.GetResult()->begin(),
                           data_response.GetResult()->end());
   ASSERT_EQ("someData", data_string);


### PR DESCRIPTION
Add RemoveFromCache by TileKey function to VolatileLayerClient.
Add integration test to check if partition related to removed
TileKey is not longer avialible in cache after deletion.

Relates-To: OLPEDGE-1663

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>