### PR TITLE
[OLD] Replace boost archive with boost github repo

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,7 @@ jobs:
   pool:
     vmImage: 'macOS-10.14'
   steps:
+  - script: brew install boost
   - bash: scripts/macos/psv/azure_macos_build_psv.sh
     displayName: 'MacOS Build'
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 HERE Europe B.V.
+# Copyright (C) 2019-2020 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -58,7 +58,8 @@ set(OLP_SDK_CPP_LEVELDB_TAG "1.21")
 set(OLP_SDK_CPP_RAPIDJSON_URL "https://github.com/Tencent/rapidjson.git")
 set(OLP_SDK_CPP_RAPIDJSON_TAG "master")
 
-set(OLP_SDK_CPP_BOOST_URL "https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz")
+set(OLP_SDK_CPP_BOOST_URL "https://github.com/boostorg/boost.git")
+set(OLP_SDK_CPP_BOOST_TAG "boost-1.72.0")
 
 # Add external projects
 find_package(GTest QUIET)

--- a/external/boost/CMakeLists.txt
+++ b/external/boost/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 HERE Europe B.V.
+# Copyright (C) 2019-2020 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 # Boost
 # Download and unpack boost at configure time
 
-configure_file(CMakeLists.txt.boost.in download/CMakeLists.txt)
+configure_file(CMakeLists.txt.boost.in download/CMakeLists.txt @ONLY)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
 

--- a/external/boost/CMakeLists.txt.boost.in
+++ b/external/boost/CMakeLists.txt.boost.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 HERE Europe B.V.
+# Copyright (C) 2019-2020 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,15 +17,68 @@
 
 cmake_minimum_required(VERSION 3.9)
 
-project(boost-download NONE)
+project(boost-download CXX)
 
 include(ExternalProject)
-ExternalProject_Add(Boost
-  URL               @OLP_SDK_CPP_BOOST_URL@
-  DOWNLOAD_DIR      "${CMAKE_CURRENT_BINARY_DIR}/download"
-  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/external_boost"
-  CONFIGURE_COMMAND ""
-  BUILD_COMMAND     ""
-  INSTALL_COMMAND   ""
-  TEST_COMMAND      ""
+
+if (WIN32)
+    set(BOOTSTRAP_CMD bootstrap.bat)
+    set(B2_CMD b2.exe)
+else()
+    set(BOOTSTRAP_CMD ./bootstrap.sh)
+    set(B2_CMD ./b2)
+endif()
+
+ExternalProject_Add(boost-download
+    GIT_REPOSITORY      @OLP_SDK_CPP_BOOST_URL@
+    GIT_TAG             @OLP_SDK_CPP_BOOST_TAG@ 
+    GIT_SUBMODULES      libs/any
+                        libs/assert
+                        libs/config
+                        libs/container_hash
+                        libs/core
+                        libs/detail
+                        libs/format
+                        libs/function_types
+                        libs/headers
+                        libs/integer
+                        libs/io
+                        libs/iterator
+                        libs/move
+                        libs/mpl
+                        libs/numeric/conversion
+                        libs/optional
+                        libs/predef
+                        libs/preprocessor
+                        libs/random
+                        libs/serialization
+                        libs/smart_ptr
+                        libs/static_assert
+                        libs/throw_exception
+                        libs/tti
+                        libs/type_index
+                        libs/type_traits
+                        libs/utility
+                        libs/uuid
+                        libs/winapi
+                        tools/build
+                        tools/boost_install
+    SOURCE_DIR          @CMAKE_CURRENT_BINARY_DIR@/external_boost
+    UPDATE_COMMAND      ""
+    CONFIGURE_COMMAND   ""
+    BUILD_COMMAND       ""
+    INSTALL_COMMAND     ""
+    TEST_COMMAND        ""
+)
+
+ExternalProject_Add_Step(boost-download boost-bootstrap
+    WORKING_DIRECTORY   @CMAKE_CURRENT_BINARY_DIR@/external_boost
+    COMMAND             ${BOOTSTRAP_CMD}
+    DEPENDEES           install
+)
+
+ExternalProject_Add_Step(boost-download boost-b2
+    WORKING_DIRECTORY   @CMAKE_CURRENT_BINARY_DIR@/external_boost
+    COMMAND             ${B2_CMD} headers
+    DEPENDEES           boost-bootstrap
 )


### PR DESCRIPTION
Initializing boost from a github is more natural approach.

Resolves: OLPEDGE-1661, OLPEDGE-789

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>