### PR TITLE
Fix Boost bootstrap during cross compile.

### DIFF
--- a/external/boost/CMakeLists.txt
+++ b/external/boost/CMakeLists.txt
@@ -21,13 +21,10 @@
 if (WIN32)
     set(BOOTSTRAP_CMD bootstrap.bat)
     set(B2_CMD b2.exe)
-elseif (APPLE)
-    # Reset the CXX (path to compiler) before running bootstrap.
+else()
+    # Reset the CXX (path to compiler) before running bootstrap since we can cross compile.
     # Else we need to specify the -sysroot argument with CXXFLAGS.
     set(BOOTSTRAP_CMD unset CXX && ./bootstrap.sh)
-    set(B2_CMD ./b2)
-else()
-    set(BOOTSTRAP_CMD ./bootstrap.sh)
     set(B2_CMD ./b2)
 endif()
 


### PR DESCRIPTION
Let the bootstrap figure out the toolset it needs.

Relates-To: OLPEDGE-1661

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>