### PR TITLE
PrefetchTiles for VolatileLayerClientImpl.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -221,8 +221,7 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
               request.CreateKey(layer_id).c_str());
           return response.GetError();
         }
-
-        request.WithVersion(response.GetResult().GetVersion());
+        auto version = response.GetResult().GetVersion();
 
         const auto key = request.CreateKey(layer_id);
         OLP_SDK_LOG_INFO_F(kLogTag, "PrefetchTiles: using key=%s", key.c_str());
@@ -253,7 +252,8 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
                             sliced_tiles.size(), key.c_str());
 
         auto sub_tiles = repository::PrefetchTilesRepository::GetSubTiles(
-            catalog, layer_id, request, sliced_tiles, context, settings);
+            catalog, layer_id, request, version, sliced_tiles, context,
+            settings);
 
         if (!sub_tiles.IsSuccessful()) {
           return sub_tiles.GetError();

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -25,6 +25,8 @@
 #include <olp/core/client/PendingRequests.h>
 #include <olp/core/client/TaskContext.h>
 #include <olp/core/logging/Log.h>
+#include <olp/dataservice/read/CatalogVersionRequest.h>
+#include <olp/dataservice/read/PrefetchTileResult.h>
 
 #include "Common.h"
 #include "repositories/CatalogRepository.h"
@@ -33,6 +35,7 @@
 #include "repositories/ExecuteOrSchedule.inl"
 #include "repositories/PartitionsCacheRepository.h"
 #include "repositories/PartitionsRepository.h"
+#include "repositories/PrefetchTilesRepository.h"
 
 namespace olp {
 namespace dataservice {
@@ -40,6 +43,13 @@ namespace read {
 
 namespace {
 constexpr auto kLogTag = "VolatileLayerClientImpl";
+
+bool IsOnlyInputTiles(const PrefetchTilesRequest& request) {
+  return !(request.GetMinLevel() > 0 &&
+           request.GetMinLevel() < request.GetMaxLevel() &&
+           request.GetMaxLevel() < geo::TileKey().Level() &&
+           request.GetMinLevel() < geo::TileKey().Level());
+}
 }  // namespace
 
 VolatileLayerClientImpl::VolatileLayerClientImpl(
@@ -147,6 +157,198 @@ bool VolatileLayerClientImpl::RemoveFromCache(const std::string& partition_id) {
 bool VolatileLayerClientImpl::RemoveFromCache(const geo::TileKey& tile) {
   auto partition_id = tile.ToHereTile();
   return RemoveFromCache(partition_id);
+}
+
+client::CancellationToken VolatileLayerClientImpl::PrefetchTiles(
+    PrefetchTilesRequest request, PrefetchTilesResponseCallback callback) {
+  // Used as empty response to be able to execute initial task
+  using EmptyResponse = Response<PrefetchTileNoError>;
+  using PrefetchResult = PrefetchTilesResult::value_type;
+  using PrefetchResultFuture = std::future<PrefetchResult>;
+  using PrefetchResultPromise = std::promise<PrefetchResult>;
+  using client::CancellationContext;
+  using client::ErrorCode;
+
+  auto catalog = catalog_;
+  auto layer_id = layer_id_;
+  auto settings = settings_;
+  auto pending_requests = pending_requests_;
+
+  auto token = AddTask(
+      settings.task_scheduler, pending_requests,
+      [=](CancellationContext context) mutable -> EmptyResponse {
+        const auto& tile_keys = request.GetTileKeys();
+        if (tile_keys.empty()) {
+          OLP_SDK_LOG_WARNING_F(kLogTag,
+                                "PrefetchTiles : invalid request, layer=%s",
+                                layer_id.c_str());
+          return {{ErrorCode::InvalidArgument, "Empty tile key list"}};
+        }
+
+        const auto key = request.CreateKey(layer_id);
+        OLP_SDK_LOG_INFO_F(kLogTag, "PrefetchTiles: using key=%s", key.c_str());
+
+        // Calculate the minimal set of Tile keys and depth to
+        // cover tree.
+        bool request_only_input_tiles = IsOnlyInputTiles(request);
+        unsigned int min_level =
+            (request_only_input_tiles ? 0 : request.GetMinLevel());
+        unsigned int max_level =
+            (request_only_input_tiles ? 0 : request.GetMaxLevel());
+
+        auto sliced_tiles = repository::PrefetchTilesRepository::GetSlicedTiles(
+            tile_keys, min_level, max_level);
+
+        if (sliced_tiles.empty()) {
+          OLP_SDK_LOG_WARNING_F(kLogTag,
+                                "PrefetchTiles: tile/level mismatch, key=%s",
+                                key.c_str());
+          return {{ErrorCode::InvalidArgument, "TileKeys/levels mismatch"}};
+        }
+
+        OLP_SDK_LOG_DEBUG_F(kLogTag, "PrefetchTiles, subquads=%zu, key=%s",
+                            sliced_tiles.size(), key.c_str());
+
+        auto sub_tiles = repository::PrefetchTilesRepository::GetSubTiles(
+            catalog, layer_id, request, boost::none, sliced_tiles, context,
+            settings);
+
+        if (!sub_tiles.IsSuccessful()) {
+          return sub_tiles.GetError();
+        }
+
+        const auto& tiles_result = sub_tiles.GetResult();
+        if (tiles_result.empty()) {
+          OLP_SDK_LOG_WARNING_F(
+              kLogTag, "PrefetchTiles: subtiles empty, key=%s", key.c_str());
+          return {{ErrorCode::InvalidArgument, "Subquads retrieval failed"}};
+        }
+
+        OLP_SDK_LOG_INFO_F(kLogTag, "Prefetch start, key=%s, tiles=%zu",
+                           key.c_str(), tiles_result.size());
+
+        // Once we have the data create for each subtile a task and push it
+        // onto the TaskScheduler. One additional last task is added which
+        // waits for all previous tasks to finish so that it may call the user
+        // with the result.
+        auto futures = std::make_shared<std::vector<PrefetchResultFuture>>();
+        std::vector<CancellationContext> contexts;
+        contexts.reserve(tiles_result.size() + 1u);
+        auto it = tiles_result.begin();
+        auto skip_tile = [&](const geo::TileKey& tile_key) {
+          if (request_only_input_tiles) {
+            return (std::find(tile_keys.begin(), tile_keys.end(), tile_key) ==
+                    tile_keys.end());
+          }
+          // skip tiles outside min/max segment
+          return (tile_key.Level() < request.GetMinLevel() ||
+                  tile_key.Level() > request.GetMaxLevel());
+        };
+
+        while (!context.IsCancelled() && it != tiles_result.end()) {
+          auto const& tile = it->first;
+          if (skip_tile(tile)) {
+            it++;
+            continue;
+          }
+
+          auto const& handle = it->second;
+          auto const& biling_tag = request.GetBillingTag();
+          auto promise = std::make_shared<PrefetchResultPromise>();
+          auto flag = std::make_shared<std::atomic_bool>(false);
+          futures->emplace_back(promise->get_future());
+          auto context_it = contexts.emplace(contexts.end());
+
+          AddTask(
+              settings.task_scheduler, pending_requests,
+              [=](CancellationContext inner_context) {
+                auto data = repository::DataRepository::GetVolatileData(
+                    catalog, layer_id,
+                    DataRequest().WithDataHandle(handle).WithBillingTag(
+                        biling_tag),
+                    inner_context, settings);
+
+                if (!data.IsSuccessful()) {
+                  promise->set_value(std::make_shared<PrefetchTileResult>(
+                      tile, data.GetError()));
+                } else {
+                  promise->set_value(std::make_shared<PrefetchTileResult>(
+                      tile, PrefetchTileNoError()));
+                }
+
+                flag->exchange(true);
+                return EmptyResponse(PrefetchTileNoError());
+              },
+              [=](EmptyResponse) {
+                if (!flag->load()) {
+                  // If above task was cancelled we might need to set
+                  // promise else below task will wait forever
+                  promise->set_value(std::make_shared<PrefetchTileResult>(
+                      tile,
+                      client::ApiError(ErrorCode::Cancelled, "Cancelled")));
+                }
+              },
+              *context_it);
+          it++;
+        }
+
+        // Task to wait for previously triggered data download to collect
+        // responses and trigger user callback.
+        AddTask(
+            settings.task_scheduler, pending_requests,
+            [=](CancellationContext inner_context) -> PrefetchTilesResponse {
+              PrefetchTilesResult result;
+              result.reserve(futures->size());
+
+              for (auto& future : *futures) {
+                // Check if cancelled in between.
+                if (inner_context.IsCancelled()) {
+                  return {{ErrorCode::Cancelled, "Cancelled"}};
+                }
+
+                auto tile_result = future.get();
+                result.emplace_back(std::move(tile_result));
+              }
+
+              OLP_SDK_LOG_INFO_F(kLogTag, "Prefetch done, key=%s, tiles=%zu",
+                                 key.c_str(), result.size());
+              return PrefetchTilesResponse(std::move(result));
+            },
+            callback, *contexts.emplace(contexts.end()));
+
+        context.ExecuteOrCancelled([&]() {
+          return client::CancellationToken([contexts]() {
+            for (auto context : contexts) {
+              context.CancelOperation();
+            }
+          });
+        });
+
+        return EmptyResponse(PrefetchTileNoError());
+      },
+      // Because the handling of prefetch tiles responses is performed by the
+      // inner-task, no need to set a callback here. Otherwise, the user would
+      // be notified with empty results.
+      // It is possible to not invoke inner task, when it was cancelled before
+      // execution.
+      [callback](EmptyResponse response) {
+        // Inner task only generates successfull result
+        if (!response.IsSuccessful()) {
+          callback(response.GetError());
+        }
+      });
+
+  return token;
+}
+
+client::CancellableFuture<PrefetchTilesResponse>
+VolatileLayerClientImpl::PrefetchTiles(PrefetchTilesRequest request) {
+  auto promise = std::make_shared<std::promise<PrefetchTilesResponse>>();
+  auto callback = [=](PrefetchTilesResponse resp) {
+    promise->set_value(std::move(resp));
+  };
+  auto token = PrefetchTiles(std::move(request), std::move(callback));
+  return client::CancellableFuture<PrefetchTilesResponse>(token, promise);
 }
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
@@ -25,6 +25,7 @@
 #include <olp/core/geo/tiling/TileKey.h>
 #include <olp/dataservice/read/DataRequest.h>
 #include <olp/dataservice/read/PartitionsRequest.h>
+#include <olp/dataservice/read/PrefetchTilesRequest.h>
 #include <olp/dataservice/read/Types.h>
 
 namespace olp {
@@ -63,6 +64,12 @@ class VolatileLayerClientImpl {
   virtual bool RemoveFromCache(const std::string& partition_id);
 
   virtual bool RemoveFromCache(const geo::TileKey& tile);
+
+  virtual client::CancellationToken PrefetchTiles(
+      PrefetchTilesRequest request, PrefetchTilesResponseCallback callback);
+
+  virtual client::CancellableFuture<PrefetchTilesResponse> PrefetchTiles(
+      PrefetchTilesRequest request);
 
  private:
   client::HRN catalog_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
@@ -63,6 +63,7 @@ class PrefetchTilesRepository {
   static SubTilesResponse GetSubTiles(
       const client::HRN& catalog, const std::string& layer_id,
       const PrefetchTilesRequest& request,
+      boost::optional<std::int64_t> version,
       const RootTilesForRequest& root_tiles,
       client::CancellationContext context,
       const client::OlpClientSettings& settings);
@@ -71,9 +72,17 @@ class PrefetchTilesRepository {
   static SubQuadsResponse GetSubQuads(const client::HRN& catalog,
                                       const std::string& layer_id,
                                       const PrefetchTilesRequest& request,
-                                      geo::TileKey tile, int32_t depth,
+                                      std::int64_t version, geo::TileKey tile,
+                                      int32_t depth,
                                       const client::OlpClientSettings& settings,
                                       client::CancellationContext context);
+
+  static SubQuadsResponse GetVolatileSubQuads(
+      const client::HRN& catalog, const std::string& layer_id,
+      const PrefetchTilesRequest& request, geo::TileKey tile, int32_t depth,
+      const client::OlpClientSettings& settings,
+      client::CancellationContext context);
+
   static void SplitSubtree(RootTilesForRequest& root_tiles_depth,
                            RootTilesForRequest::iterator subtree_to_split);
 };


### PR DESCRIPTION
Second part of prefetch update of VolatileLayerClient. This change
contains impl update and unit tests. The method loads data for specified
tile and levels.

Resolves: OLPEDGE-794

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>