### PR TITLE
Added API to retrieve network statistics.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/http/Network.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/Network.h
@@ -51,6 +51,21 @@ class CORE_API Network {
   /// Represents the request and response payload type
   using Payload = std::shared_ptr<std::ostream>;
 
+  /**
+   * @brief The Statistics structure represents the network statistics for a
+   * specific bucket.
+   */
+  struct Statistics {
+    /// The total bytes downloaded including size of headers and payload.
+    uint64_t bytes_downloaded{0ull};
+    /// The total bytes uploaded including size of headers and payload.
+    uint64_t bytes_uploaded{0ull};
+    /// The total number of requests made by network.
+    uint32_t total_requests{0u};
+    /// The total number of requests failed.
+    uint32_t total_failed{0u};
+  };
+
   virtual ~Network() = default;
 
   /**
@@ -90,7 +105,25 @@ class CORE_API Network {
    *
    * @param headers The default headers.
    */
-  virtual void SetDefaultHeaders(Headers) {}
+  virtual void SetDefaultHeaders(Headers headers);
+
+  /**
+   * @brief Set the current statistics bucket.
+   *
+   * @param[in] bucked_id The bucket ID.
+   */
+  virtual void SetCurrentBucket(uint8_t bucket_id);
+
+  /**
+   * @brief Get the statistics for a bucket.
+   *
+   * By default, this returns the statistics for the default bucket, with the ID 0.
+   *
+   * @param[in] bucked_id The bucket ID.
+   *
+   * @return Statistics which contains the statistic for the requested bucket.
+   */
+  virtual Statistics GetStatistics(uint8_t bucket_id = 0);
 };
 
 /**

--- a/olp-cpp-sdk-core/src/http/Network.cpp
+++ b/olp-cpp-sdk-core/src/http/Network.cpp
@@ -52,6 +52,14 @@ std::shared_ptr<Network> CreateDefaultNetworkImpl(size_t max_requests_count) {
 }
 }  // namespace
 
+void Network::SetDefaultHeaders(Headers /*headers*/) {}
+
+void Network::SetCurrentBucket(uint8_t /*bucket_id*/) {}
+
+Network::Statistics Network::GetStatistics(uint8_t /*bucket_id*/) {
+  return Network::Statistics{};
+}
+
 CORE_API std::shared_ptr<Network> CreateDefaultNetwork(
     size_t max_requests_count) {
   auto network = CreateDefaultNetworkImpl(max_requests_count);


### PR DESCRIPTION
This API should enable users to query network statistics and aggregate
the statistics by buckets (Wifi/Cellular/etc.) when needed.

Resolves: OLPEDGE-1761

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>