### PR TITLE
Removes internal deprecated compiler warnings.

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AutoRefreshingToken.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AutoRefreshingToken.h
@@ -47,6 +47,10 @@ static constexpr auto kForceRefresh = std::chrono::seconds(0);
  */
 class AUTHENTICATION_API AutoRefreshingToken {
  public:
+  // Needed to avoid endless warnings from TokenRequest/TokenResult
+  PORTING_PUSH_WARNINGS()
+  PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
+
   /**
    * @brief Specifies the callback signature that is required
    * when the get token request is completed.
@@ -130,9 +134,8 @@ class AUTHENTICATION_API AutoRefreshingToken {
    * refreshed.
    * @param token_request The token request that is sent to the token endpoint.
    */
-  PORTING_PUSH_WARNINGS()
-  PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
   AutoRefreshingToken(TokenEndpoint token_endpoint, TokenRequest token_request);
+
   PORTING_POP_WARNINGS()
 
  private:

--- a/olp-cpp-sdk-authentication/include/olp/authentication/TokenProvider.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/TokenProvider.h
@@ -28,6 +28,10 @@
 #include "TokenEndpoint.h"
 #include "TokenResult.h"
 
+// Needed to avoid endless warnings from TokenEndpoint/TokenResponse
+PORTING_PUSH_WARNINGS()
+PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
+
 namespace olp {
 namespace authentication {
 /** @file TokenProvider.h */
@@ -127,5 +131,6 @@ class TokenProvider {
  */
 using TokenProviderDefault = TokenProvider<kDefaultMinimumValidity>;
 
+PORTING_POP_WARNINGS()
 }  // namespace authentication
 }  // namespace olp


### PR DESCRIPTION
TokenProvider which is widely used by all OLP SDK users to request tokens
uses internally TokenEndpoint and AutoRefreshingToken which are
marked as deprecated and create compiler warnings. This is now
filtered out by pragmas.

Resolves: OLPEDGE-1768

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>