### PR TITLE
Add use_local_time parameter to AuthenticationSettings

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationSettings.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationSettings.h
@@ -77,6 +77,12 @@ struct AUTHENTICATION_API AuthenticationSettings {
    * in-memory cache.
    */
   size_t token_cache_limit{100u};
+
+  /**
+   * @brief Uses system system time in authentication requests rather than
+   * requesting time from authentication server.
+   */
+  bool use_system_time{false};
 };
 
 }  // namespace authentication


### PR DESCRIPTION
Add use_local_time parameter to AuthenticationSettings to
control if AuthenticationClient will try to get time from server
or use local machine time instead.

Resolves: OLPEDGE-1762

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>