### PR TITLE
Add measurement of downloaded/uploaded data Linux.

### DIFF
--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.h
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.h
@@ -277,14 +277,6 @@ class NetworkCurl : public olp::http::Network,
    * @return @c true if the thread is started, @c false otherwise.
    */
   inline bool IsStarted() const;
-  /**
-   * @brief CURL get upload/download data.
-   * @param[in] handle CURL easy handle.
-   * @param[out] uploadBytes uploaded bytes(headers+data).
-   * @param[out] downloadBytes downloaded bytes(headers+data).
-   */
-  static void GetTraficData(CURL* handle, uint64_t& uploadBytes,
-                            uint64_t& downloadBytes);
 
   /// Contexts for every network request.
   std::vector<RequestHandle> handles_;

--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.h
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.h
@@ -277,6 +277,14 @@ class NetworkCurl : public olp::http::Network,
    * @return @c true if the thread is started, @c false otherwise.
    */
   inline bool IsStarted() const;
+  /**
+   * @brief CURL get upload/download data.
+   * @param[in] handle CURL easy handle.
+   * @param[out] uploadBytes uploaded bytes(headers+data).
+   * @param[out] downloadBytes downloaded bytes(headers+data).
+   */
+  static void GetTraficData(CURL* handle, uint64_t& uploadBytes,
+                            uint64_t& downloadBytes);
 
   /// Contexts for every network request.
   std::vector<RequestHandle> handles_;


### PR DESCRIPTION
Use curl_easy_getinfo to get size of headers and data
(CURLINFO_HEADER_SIZE, CURLINFO_SIZE_DOWNLOAD).
Get upload size using CURLINFO_REQUEST_SIZE.

Relates-To: OLPEDGE-1759

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>