### PR TITLE
Calculate total bytes sent/received on Windows

### DIFF
--- a/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.h
+++ b/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.h
@@ -65,13 +65,16 @@ class NetworkWinHttp : public Network {
 
     Callback user_callback;
     std::shared_ptr<std::ostream> payload;
-    std::uint64_t size;
+    std::uint64_t content_length;
     std::uint64_t count;
     std::uint64_t offset;
     RequestId request_id;
     int status;
     bool completed;
     bool cancelled;
+
+    std::uint64_t bytes_uploaded;
+    std::uint64_t bytes_downloaded;
   };
 
   struct ConnectionData {


### PR DESCRIPTION
Calculations are approximate, number bytes sent is calculated as a
size of body and a size of headers. Number of bytes received is
calculated as size of headers plus content length if available, else
a sum of chunks sizes.

Relates-To: OLPEDGE-1760

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>