### PR TITLE
Fix the boost configuration on windows

### DIFF
--- a/external/boost/CMakeLists.txt.boost.in
+++ b/external/boost/CMakeLists.txt.boost.in
@@ -57,8 +57,8 @@ ExternalProject_Add(boost-download
                         tools/boost_install
     SOURCE_DIR          @CMAKE_CURRENT_BINARY_DIR@/external_boost
     UPDATE_COMMAND      ""
-    CONFIGURE_COMMAND   cd @CMAKE_CURRENT_BINARY_DIR@/external_boost && @BOOTSTRAP_CMD@
-    BUILD_COMMAND       cd @CMAKE_CURRENT_BINARY_DIR@/external_boost && @B2_CMD@ headers
+    CONFIGURE_COMMAND   cd @CMAKE_CURRENT_BINARY_DIR@/external_boost && @BOOTSTRAP_CMD@ && cd @CMAKE_CURRENT_BINARY_DIR@/external_boost && @B2_CMD@ headers
+    BUILD_COMMAND       ""
     INSTALL_COMMAND     ""
     TEST_COMMAND        ""
 )


### PR DESCRIPTION
Skip the build step on windows.

Resolves: OLPEDGE-1778, OLPEDGE-1756

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>