### PR TITLE
Change commit checker job to run only on PR

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,7 @@ jobs:
 - job: Commit_checker
   pool:
     vmImage: 'ubuntu-18.04'
+  condition: eq(variables['Build.Reason'], 'PullRequest')
   steps:
     - bash: scripts/misc/commit_checker.sh
       displayName: 'Commit checker script'


### PR DESCRIPTION
Job must run only for Pull requests.
Master builds to be avoided.

Relates-TO: OLPEDGE-1573

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>