### PR TITLE
Implement buckets for DefaultNetwork

### DIFF
--- a/olp-cpp-sdk-core/src/http/DefaultNetwork.h
+++ b/olp-cpp-sdk-core/src/http/DefaultNetwork.h
@@ -19,10 +19,13 @@
 
 #pragma once
 
+#include <atomic>
 #include <mutex>
+#include <unordered_map>
 
 #include <olp/core/CoreApi.h>
 #include <olp/core/http/Network.h>
+#include <olp/core/thread/Atomic.h>
 
 namespace olp {
 namespace http {
@@ -55,14 +58,29 @@ class DefaultNetwork final : public Network {
   /// Implements the `SetDefaultHeaders` method of the `Network` class.
   void SetDefaultHeaders(Headers headers) override;
 
+  /// Implements the `SetCurrentBucket` method of the `Network` class.
+  void SetCurrentBucket(uint8_t bucket_id) override;
+
+  /// Implements the `GetStatistics` method of the `Network` class.
+  Statistics GetStatistics(uint8_t bucket_id) override;
+
  private:
   void AppendUserAgent(Headers& request_headers) const;
   void AppendDefaultHeaders(Headers& request_headers) const;
 
-  std::shared_ptr<Network> network_;
+  void LockStatistics(uint8_t bucket_id,
+                      std::function<void(Statistics&)> callback);
+
+  std::atomic_uint8_t current_statistics_bucket_;
+
+  using BucketsContainer = std::unordered_map<uint8_t, Statistics>;
+  thread::Atomic<BucketsContainer> buckets_;
+
   std::mutex default_headers_mutex_;
   Headers default_headers_;
   std::string user_agent_;
+
+  std::shared_ptr<Network> network_;
 };
 
 }  // namespace http


### PR DESCRIPTION
Track the number of requests and metrics. Users can now track the
network in/out number of bytes. Calculations rely on network impl's
to provide the correct download/upload numbers in network response.

Relates-To: OLPEDGE-1754

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>