### PR TITLE
Deprecate AutoRefreshingToken class

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AutoRefreshingToken.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AutoRefreshingToken.h
@@ -45,7 +45,8 @@ static constexpr auto kForceRefresh = std::chrono::seconds(0);
  * Requests a new token from the token endpoint and automatically refreshes it
  * when the token is about to expire.
  */
-class AUTHENTICATION_API AutoRefreshingToken {
+class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed by 10.2020.")
+    AutoRefreshingToken {
  public:
   // Needed to avoid endless warnings from TokenRequest/TokenResult
   PORTING_PUSH_WARNINGS()


### PR DESCRIPTION
Mark AutoRefreshingToken class as deprecated.

Relates-To: OLPEDGE-1737

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>