### PR TITLE
Modify links

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Additionally, the SDK includes classes for work with geospatial tiling schemes t
 
 We try to develop and maintain our API in a way that preserves its compatibility with the existing applications. Changes in OLP SDK for C++ are greatly influenced by the Data API development. Data API introduces breaking changes 6 months in advance. Therefore, you may need to migrate to a new version of OLP SDK for C++ every half a year.
 
-For more information on Data API, see its [Developer Guide](https://developer.here.com/olp/documentation/data-api/data_dev_guide/index.html) and [API Reference](https://developer.here.com/olp/documentation/data-api/api-reference.html).
+For more information on Data API, see its <a href="https://developer.here.com/olp/documentation/data-api/data_dev_guide/index.html" target="_blank">Developer Guide</a> and <a href="https://developer.here.com/olp/documentation/data-api/api-reference.html" target="_blank">API Reference</a>.
 
-When new API is introduced in OLP SDK for C++, the old one is not deleted straight away. The standard deprecation time is 6 months. It gives you time to switch to new code. All of the deprecated methods, functions, and parameters are documented in the OLP SDK for C++ [API Reference](https://developer.here.com/olp/documentation/sdk-cpp/api_reference/index.html) and [changelog](CHANGELOG.md).
+When new API is introduced in OLP SDK for C++, the old one is not deleted straight away. The standard deprecation time is 6 months. It gives you time to switch to new code. All of the deprecated methods, functions, and parameters are documented in the OLP SDK for C++ <a href="https://developer.here.com/olp/documentation/sdk-cpp/api_reference/index.html" target="_blank">API Reference</a> and <a href="https://github.com/heremaps/here-olp-sdk-cpp/blob/master/CHANGELOG.md" target="_blank">changelog</a>.
 
 ## Supported Platforms
 


### PR DESCRIPTION
Markdown links are not built correctly on the portal(docs.in.here.com).
Links of the HTML format should be used instead.

Relates-To: OLPEDGE-1732

Signed-off-by: Halyna Dumych <ext-halyna.dumych@here.com>