### PR TITLE
Enable deprecated-declaration warning as error

### DIFF
--- a/examples/ProtectedCacheExample.cpp
+++ b/examples/ProtectedCacheExample.cpp
@@ -105,7 +105,7 @@ int RunExampleReadWithCache(const AccessKey& access_key,
 
   // Create appropriate layer client with HRN, layer name and settings.
   olp::dataservice::read::VersionedLayerClient layer_client(
-      olp::client::HRN(catalog), first_layer_id, client_settings);
+      olp::client::HRN(catalog), first_layer_id, boost::none, client_settings);
 
   // Retrieve the partition data
   // Create a DataRequest with appropriate LayerId and PartitionId

--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationCredentials.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationCredentials.h
@@ -96,15 +96,6 @@ class AUTHENTICATION_API AuthenticationCredentials {
   AuthenticationCredentials(std::string key, std::string secret);
 
   /**
-   * @brief Creates the `AuthenticationCredentials` instance that is a copy
-   * of the `other` parameter that contains the access credentials.
-   *
-   * @param other The `AuthenticationCredentials` instance from which the access
-   * key ID and access key secret are copied.
-   */
-  AuthenticationCredentials(const AuthenticationCredentials& other);
-
-  /**
    * @brief Gets the access key ID from the `AuthenticationCredentials`
    * instance.
    *

--- a/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
@@ -919,9 +919,8 @@ client::CancellationToken AuthenticationClient::Impl::IntrospectApp(
   auto introspect_app_task =
       [=](client::CancellationContext context) -> ResponseType {
     if (!settings_.network_request_handler) {
-      client::ApiError result({static_cast<int>(http::ErrorCode::IO_ERROR),
+      return client::ApiError({static_cast<int>(http::ErrorCode::IO_ERROR),
                                "Cannot introspect app while offline"});
-      return std::move(result);
     }
 
     client::AuthenticationSettings auth_settings;
@@ -949,12 +948,10 @@ client::CancellationToken AuthenticationClient::Impl::IntrospectApp(
       if (!document.HasParseError() && document.HasMember(Constants::MESSAGE)) {
         msg = document[Constants::MESSAGE].GetString();
       }
-      client::ApiError error({http_result.status, msg});
-      return std::move(error);
+      return client::ApiError({http_result.status, msg});
     }
 
-    IntrospectAppResult response_result = GetIntrospectAppResult(document);
-    return std::move(response_result);
+    return GetIntrospectAppResult(document);
   };
 
   // wrap_callback needed to convert client::ApiError into AuthenticationError.

--- a/olp-cpp-sdk-authentication/src/AuthenticationCredentials.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationCredentials.cpp
@@ -95,10 +95,6 @@ AuthenticationCredentials::AuthenticationCredentials(std::string key,
                                                      std::string secret)
     : key_(std::move(key)), secret_(std::move(secret)) {}
 
-AuthenticationCredentials::AuthenticationCredentials(
-    const AuthenticationCredentials& other)
-    : key_(other.key_), secret_(other.secret_) {}
-
 const std::string& AuthenticationCredentials::GetKey() const { return key_; }
 
 const std::string& AuthenticationCredentials::GetSecret() const {

--- a/olp-cpp-sdk-authentication/tests/AuthenticationCredentialsTest.cpp
+++ b/olp-cpp-sdk-authentication/tests/AuthenticationCredentialsTest.cpp
@@ -90,3 +90,12 @@ TEST(AuthenticationCredentialsTest, ReadFromFile) {
     EXPECT_FALSE(credentials);
   }
 }
+
+
+TEST(AuthenticationCredentialsTest, CanBeCopied) {
+  AuthenticationCredentials credentials("test_key", "test_secred");
+  AuthenticationCredentials copy = credentials;
+  EXPECT_EQ(credentials.GetKey(), copy.GetKey());
+  EXPECT_EQ(credentials.GetSecret(), copy.GetSecret());
+}
+

--- a/olp-cpp-sdk-core/include/olp/core/client/ApiResponse.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/ApiResponse.h
@@ -67,15 +67,6 @@ class ApiResponse {
   ApiResponse(const ErrorType& error) : error_(error), success_(false) {}
 
   /**
-   * @brief Creates the `ApiResponse` instance that is a copy of the `r`
-   * parameter.
-   *
-   * @param r The `ApiResponse` instance from which the response is copied.
-   */
-  ApiResponse(const ApiResponse& r)
-      : result_(r.result_), error_(r.error_), success_(r.success_) {}
-
-  /**
    * @brief Checks the status of the request attempt.
    *
    * @return True if the request is successfully completed; false otherwise.

--- a/olp-cpp-sdk-core/src/client/OlpClientSettingsFactory.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClientSettingsFactory.cpp
@@ -55,7 +55,7 @@ OlpClientSettingsFactory::CreateDefaultCache(cache::CacheSettings settings) {
         settings.disk_path_protected.get_value_or("(empty)").c_str());
     return nullptr;
   }
-  return std::move(cache);
+  return cache;
 }
 
 }  // namespace client

--- a/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.cpp
@@ -65,7 +65,7 @@ ApiClientLookup::ApiClientResponse ApiClientLookup::LookupApi(
       client::OlpClient client;
       client.SetSettings(std::move(settings));
       client.SetBaseUrl(*url);
-      return std::move(client);
+      return client;
     } else if (options == CacheOnly) {
       return client::ApiError(
           client::ErrorCode::NotFound,
@@ -117,7 +117,7 @@ ApiClientLookup::ApiClientResponse ApiClientLookup::LookupApi(
   client::OlpClient service_client;
   service_client.SetBaseUrl(service_url);
   service_client.SetSettings(settings);
-  return std::move(service_client);
+  return service_client;
 }
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.cpp
@@ -59,7 +59,7 @@ boost::optional<model::Data> DataCacheRepository::Get(
     return boost::none;
   }
 
-  return std::move(cachedData);
+  return cachedData;
 }
 
 bool DataCacheRepository::Clear(const std::string& layer_id,

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
@@ -296,7 +296,7 @@ PartitionsResponse PartitionsRepository::GetPartitionForVersionedTile(
                            partition.GetDataHandle().c_str());
         model::Partitions result;
         result.SetPartitions({partition});
-        return std::move(result);
+        return result;
       }
     }
   } else if (request.GetFetchOption() == CacheOnly) {
@@ -371,7 +371,7 @@ PartitionsResponse PartitionsRepository::QueryPartitionForVersionedTile(
     return ApiError(ErrorCode::NotFound,
                     "Partition for requested TileKey was not found.");
   }
-  return std::move(result);
+  return result;
 }
 
 model::Partitions PartitionsRepository::GetTileFromCache(

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -37,6 +37,11 @@
 #include <olp/core/generated/parser/JsonParser.h>
 // clang-format on
 
+// Remove after OLPEDGE-1794
+#include <olp/core/porting/warning_disable.h>
+PORTING_PUSH_WARNINGS()
+PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
+
 namespace {
 using namespace olp;
 using namespace client;
@@ -928,3 +933,5 @@ TEST_F(PartitionsRepositoryTest, GetPartitionForVersionedTile) {
   }
 }
 }  // namespace
+
+PORTING_POP_WARNINGS()

--- a/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientTest.cpp
@@ -42,9 +42,9 @@ const auto kTimeout = std::chrono::seconds(5);
 constexpr auto kBlobDataHandle = R"(4eed6ed1-0d32-43b9-ae79-043cb4256432)";
 
 TEST(VersionedLayerClientTest, CanBeMoved) {
-  VersionedLayerClient client_a(olp::client::HRN(), "", {});
+  VersionedLayerClient client_a(olp::client::HRN(), "", boost::none, {});
   VersionedLayerClient client_b(std::move(client_a));
-  VersionedLayerClient client_c(olp::client::HRN(), "", {});
+  VersionedLayerClient client_c(olp::client::HRN(), "", boost::none, {});
   client_c = std::move(client_b);
 }
 
@@ -55,7 +55,7 @@ TEST(VersionedLayerClientTest, GetData) {
   settings.network_request_handler = network_mock;
   settings.cache = cache_mock;
 
-  VersionedLayerClient client(kHrn, kLayerId, settings);
+  VersionedLayerClient client(kHrn, kLayerId, boost::none, settings);
   {
     SCOPED_TRACE("Get Data with PartitionId and DataHandle");
     std::promise<DataResponse> promise;

--- a/scripts/linux/psv/build_psv.sh
+++ b/scripts/linux/psv/build_psv.sh
@@ -26,7 +26,7 @@ ulimit -c unlimited
 mkdir -p build
 cd build
 cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-    -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -Wno-deprecated-declarations" \
+    -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" \
     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
     -DOLP_SDK_BUILD_EXAMPLES=ON \
     -DBUILD_SHARED_LIBS=ON \

--- a/scripts/linux/weekly/build_centos_debug_wv.sh
+++ b/scripts/linux/weekly/build_centos_debug_wv.sh
@@ -31,8 +31,8 @@ export BUILD_DIR="$WORKSPACE/$BUILD_DIR_NAME"
 export ARCHIVE_FILE_NAME="binaries.tar.gz"      # artifact name is defined by CI so please do not rename it
 export BUILD_ZIP=1                              # always build artifacts
 
-export CMAKE_CXX_FLAGS="-march=x86-64 -gdwarf-2 -g3 -O0 -fno-builtin -Wall -Wextra -Werror -Wno-deprecated-declarations"
-export CMAKE_C_FLAGS="-march=x86-64 -gdwarf-2 -g3 -O0 -fno-builtin -Wall -Wextra -Werror -Wno-deprecated-declarations"
+export CMAKE_CXX_FLAGS="-march=x86-64 -gdwarf-2 -g3 -O0 -fno-builtin -Wall -Wextra -Werror"
+export CMAKE_C_FLAGS="-march=x86-64 -gdwarf-2 -g3 -O0 -fno-builtin -Wall -Wextra -Werror"
 
 # Add more parameters into CMAKE_PARAM below when needed
 export FLAVOR="Debug"

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -23,6 +23,7 @@
 
 #include <olp/core/logging/Log.h>
 #include <olp/core/porting/make_unique.h>
+#include <olp/core/porting/warning_disable.h>
 #include <testutils/CustomParameters.hpp>
 #include "AuthenticationTestUtils.h"
 #include "TestConstants.h"
@@ -613,6 +614,9 @@ TEST_F(AuthenticationClientTest, SignOutUser) {
   EXPECT_STREQ(kErrorNoContent.c_str(), response4.error.c_str());
 }
 
+PORTING_PUSH_WARNINGS()
+PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
+
 TEST_F(AuthenticationClientTest, NetworkProxySettings) {
   AuthenticationCredentials credentials(id_, secret_);
 
@@ -631,6 +635,8 @@ TEST_F(AuthenticationClientTest, NetworkProxySettings) {
               olp::client::ErrorCode::ServiceUnavailable);
   EXPECT_STRNE(response.GetError().GetMessage().c_str(), kErrorOk.c_str());
 }
+
+PORTING_POP_WARNINGS()
 
 TEST_F(AuthenticationClientTest, ErrorFields) {
   static const std::string PASSWORD = "password";

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.cpp
@@ -45,9 +45,12 @@ void AuthenticationCommonTestFixture::SetUp() {
   task_scheduler_ =
       olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler();
 
-  client_ = std::make_unique<AuthenticationClient>(kHereAccountStagingURL);
-  client_->SetNetwork(network_);
-  client_->SetTaskScheduler(task_scheduler_);
+  AuthenticationSettings settings;
+  settings.network_request_handler = network_;
+  settings.task_scheduler = task_scheduler_;
+  settings.token_endpoint_url = kHereAccountStagingURL;
+
+  client_ = std::make_unique<AuthenticationClient>(settings);
 }
 
 void AuthenticationCommonTestFixture::TearDown() {

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationProductionTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationProductionTest.cpp
@@ -44,10 +44,12 @@ class AuthenticationProductionTest : public ::testing::Test {
 
   void SetUp() override {
     // Use production HERE Account server
-    client_ = std::make_unique<AuthenticationClient>();
-    client_->SetTaskScheduler(
-        olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler());
-    client_->SetNetwork(s_network_);
+    AuthenticationSettings settings;
+    settings.network_request_handler = s_network_;
+    settings.task_scheduler =
+        olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler();
+
+    client_ = std::make_unique<AuthenticationClient>(settings);
   }
 
   void TearDown() override { client_.reset(); }

--- a/tests/functional/olp-cpp-sdk-authentication/HereAccountOauth2ProductionTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/HereAccountOauth2ProductionTest.cpp
@@ -28,11 +28,16 @@
 #include <olp/core/client/OlpClientSettingsFactory.h>
 #include <olp/core/http/HttpStatusCode.h>
 #include <olp/core/http/NetworkProxySettings.h>
+#include <olp/core/porting/warning_disable.h>
 #include <testutils/CustomParameters.hpp>
 
 #include "Utils.h"
 
 using namespace ::olp::authentication;
+
+//  OLPEDGE-1797
+PORTING_PUSH_WARNINGS()
+PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
 
 namespace {
 constexpr auto kTestMaxExecutionTime = std::chrono::seconds(30);
@@ -653,3 +658,6 @@ TEST_F(HereAccountOuauth2ProductionTest, AutoRefreshingTokenMultiThread) {
 }
 
 }  // namespace
+
+
+PORTING_POP_WARNINGS()

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVersionedLayerClientTest.cpp
@@ -250,7 +250,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, CancelAllBatch) {
           .GetFuture();
 
   std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  versioned_client->CancelAll();
+  versioned_client->CancelPendingRequests();
 
   auto response = response_future.get();
   ASSERT_FALSE(response.IsSuccessful());
@@ -511,7 +511,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatchCancel) {
                   .WithPartitionId("1111"))
           .GetFuture();
 
-  versioned_client->CancelAll();
+  versioned_client->CancelPendingRequests();
 
   auto publish_to_batch_response = publish_to_batch_future.get();
   ASSERT_FALSE(publish_to_batch_response.IsSuccessful());

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVolatileLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVolatileLayerClientTest.cpp
@@ -359,7 +359,7 @@ TEST_F(DataserviceWriteVolatileLayerClientTest, CancelAllRequests) {
   auto future = volatile_client->GetBaseVersion().GetFuture();
 
   std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  volatile_client->CancelAll();
+  volatile_client->CancelPendingRequests();
 
   auto response = future.get();
   ASSERT_FALSE(response.IsSuccessful());

--- a/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -118,13 +118,15 @@ class AuthenticationClientTest : public ::testing::Test {
   AuthenticationClientTest()
       : key_("key"), secret_("secret"), scope_("scope") {}
   void SetUp() {
-    client_ = std::make_unique<AuthenticationClient>(kTokenEndpointUrl);
-
     network_ = std::make_shared<NetworkMock>();
     task_scheduler_ =
         olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler();
-    client_->SetNetwork(network_);
-    client_->SetTaskScheduler(task_scheduler_);
+
+    AuthenticationSettings settings;
+    settings.network_request_handler = network_;
+    settings.task_scheduler = task_scheduler_;
+    settings.token_endpoint_url = kTokenEndpointUrl;
+    client_ = std::make_unique<AuthenticationClient>(settings);
   }
 
   void TearDown() {}

--- a/tests/integration/olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
@@ -25,8 +25,13 @@
 #include <olp/core/client/OlpClientSettingsFactory.h>
 #include <olp/core/http/HttpStatusCode.h>
 #include <olp/core/porting/make_unique.h>
+#include <olp/core/porting/warning_disable.h>
 
 #include "AuthenticationMockedResponses.h"
+
+//  OLPEDGE-1797
+PORTING_PUSH_WARNINGS()
+PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
 
 using namespace olp::authentication;
 using namespace olp::tests::common;
@@ -108,14 +113,16 @@ class HereAccountOauth2Test : public ::testing::Test {
  public:
   HereAccountOauth2Test() : key_("key"), secret_("secret") {}
   void SetUp() {
-    client_ = std::make_unique<AuthenticationClient>(
-        "https://authentication.server.url");
-
     network_ = std::make_shared<NetworkMock>();
     task_scheduler_ =
         olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler();
-    client_->SetNetwork(network_);
-    client_->SetTaskScheduler(task_scheduler_);
+
+    AuthenticationSettings settings;
+    settings.network_request_handler = network_;
+    settings.task_scheduler = task_scheduler_;
+    settings.token_endpoint_url = "https://authentication.server.url";
+
+    client_ = std::make_unique<AuthenticationClient>(settings);
   }
 
   void TearDown() {
@@ -313,3 +320,5 @@ TEST_F(HereAccountOauth2Test, AutoRefreshingTokenCancelAsync) {
             .MoveResult();
       });
 }
+
+PORTING_POP_WARNINGS()

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientCacheTest.cpp
@@ -110,7 +110,7 @@ TEST_P(VersionedLayerClientCacheTest, GetDataWithPartitionId) {
 
   auto catalog_client =
       std::make_unique<olp::dataservice::read::VersionedLayerClient>(
-          hrn, "testlayer", settings_);
+          hrn, "testlayer", boost::none, settings_);
 
   auto request = olp::dataservice::read::DataRequest();
   request.WithPartitionId("269");
@@ -158,7 +158,7 @@ TEST_P(VersionedLayerClientCacheTest, GetPartitionsLayerVersions) {
 
   auto catalog_client =
       std::make_unique<olp::dataservice::read::VersionedLayerClient>(
-          hrn, "testlayer", settings_);
+          hrn, "testlayer", boost::none, settings_);
 
   auto request = olp::dataservice::read::PartitionsRequest();
   auto future = catalog_client->GetPartitions(request);
@@ -185,7 +185,7 @@ TEST_P(VersionedLayerClientCacheTest, GetPartitions) {
 
   auto catalog_client =
       std::make_unique<olp::dataservice::read::VersionedLayerClient>(
-          hrn, "testlayer", settings_);
+          hrn, "testlayer", boost::none, settings_);
 
   auto request = olp::dataservice::read::PartitionsRequest();
   auto future = catalog_client->GetPartitions(request);

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -29,7 +29,7 @@
 #include <olp/core/cache/KeyValueCache.h>
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
-#include <olp/core/porting/make_unique.h>
+#include <olp/core/porting/warning_disable.h>
 #include <olp/dataservice/read/VersionedLayerClient.h>
 #include <olp/dataservice/read/model/Partitions.h>
 
@@ -39,6 +39,9 @@ using namespace olp::dataservice::read;
 using namespace olp::tests::common;
 using namespace testing;
 
+// OLPEDGE-1799
+PORTING_PUSH_WARNINGS()
+PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
 namespace {
 
 std::string GetArgument(const std::string& name) {
@@ -340,7 +343,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataFromPartitionAsync) {
   auto layer = GetArgument("dataservice_read_test_layer");
   auto version = std::stoi(GetArgument("dataservice_read_test_layer_version"));
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, version, *settings_);
   ASSERT_TRUE(client);
 
@@ -379,7 +382,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
       GetArgument("dataservice_read_test_catalog"));
   auto layer = GetArgument("dataservice_read_test_layer");
   auto version = std::stoi(GetArgument("dataservice_read_test_layer_version"));
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, version, *settings_);
 
   auto partition = GetArgument("dataservice_read_test_partition");
@@ -418,7 +421,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataFromPartitionSync) {
 
   auto sync_settings = *settings_;
   sync_settings.task_scheduler.reset();
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, version, sync_settings);
   ASSERT_TRUE(client);
 
@@ -456,7 +459,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
 
   auto sync_settings = *settings_;
   sync_settings.task_scheduler.reset();
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, version, sync_settings);
   ASSERT_TRUE(client);
 
@@ -502,7 +505,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
 
   auto sync_settings = *settings_;
   sync_settings.task_scheduler.reset();
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, sync_settings);
   ASSERT_TRUE(client);
 
@@ -535,7 +538,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
 
   auto sync_settings = *settings_;
   sync_settings.task_scheduler.reset();
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, sync_settings);
   ASSERT_TRUE(client);
 
@@ -574,7 +577,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
 
   auto sync_settings = *settings_;
   sync_settings.task_scheduler.reset();
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, 269, sync_settings);
   ASSERT_TRUE(client);
 
@@ -615,7 +618,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataEmptyPartitionsSync) {
 
   auto sync_settings = *settings_;
   sync_settings.task_scheduler.reset();
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, version, sync_settings);
   ASSERT_TRUE(client);
 
@@ -652,7 +655,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
   auto layer = GetArgument("dataservice_read_test_layer");
   auto version = std::stoi(GetArgument("dataservice_read_test_layer_version"));
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, *settings_);
   ASSERT_TRUE(client);
 
@@ -699,7 +702,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
   auto layer = GetArgument("dataservice_read_test_layer");
   auto version = std::stoi(GetArgument("dataservice_read_test_layer_version"));
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, *settings_);
   ASSERT_TRUE(client);
 
@@ -748,7 +751,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
   auto layer = GetArgument("dataservice_read_test_layer");
   auto version = std::stoi(GetArgument("dataservice_read_test_layer_version"));
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, *settings_);
   ASSERT_TRUE(client);
 
@@ -801,7 +804,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
   auto layer = GetArgument("dataservice_read_test_layer");
   auto version = std::stoi(GetArgument("dataservice_read_test_layer_version"));
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, *settings_);
   ASSERT_TRUE(client);
 
@@ -857,7 +860,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
   auto layer = GetArgument("dataservice_read_test_layer");
   auto version = std::stoi(GetArgument("dataservice_read_test_layer_version"));
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, *settings_);
   ASSERT_TRUE(client);
 
@@ -887,7 +890,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetPartitionsNoError) {
       GetArgument("dataservice_read_test_catalog"));
   auto layer = GetArgument("dataservice_read_test_layer");
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, *settings_);
 
   auto request = olp::dataservice::read::PartitionsRequest();
@@ -909,7 +912,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
       GetArgument("dataservice_read_test_catalog"));
   auto layer = GetArgument("dataservice_read_test_layer");
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, *settings_);
 
   auto request = olp::dataservice::read::PartitionsRequest();
@@ -931,7 +934,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
   settings_->task_scheduler->ScheduleTask(
       []() { std::this_thread::sleep_for(std::chrono::seconds(1)); });
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, *settings_);
 
   auto request = olp::dataservice::read::PartitionsRequest();
@@ -958,7 +961,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetEmptyPartitions) {
                                        olp::http::HttpStatusCode::OK),
                                    HTTP_RESPONSE_EMPTY_PARTITIONS));
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, *settings_);
 
   auto request = olp::dataservice::read::PartitionsRequest();
@@ -999,7 +1002,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetPartitions429Error) {
         return olp::http::HttpStatusCode::TOO_MANY_REQUESTS == response.status;
       };
   settings_->retry_settings = retry_settings;
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, *settings_);
 
   auto request = olp::dataservice::read::PartitionsRequest();
@@ -1042,7 +1045,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, ApiLookup429) {
         return olp::http::HttpStatusCode::TOO_MANY_REQUESTS == response.status;
       };
   settings_->retry_settings = retry_settings;
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, *settings_);
 
   auto request = olp::dataservice::read::PartitionsRequest();
@@ -1063,7 +1066,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetPartitionsForInvalidLayer) {
       GetArgument("dataservice_read_test_catalog"));
   auto layer = "somewhat_not_okay";
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, *settings_);
 
   auto request = olp::dataservice::read::PartitionsRequest();
@@ -1084,7 +1087,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetPartitionsCacheWithUpdate) {
   auto catalog = olp::client::HRN::FromString(
       GetArgument("dataservice_read_test_catalog"));
   auto layer = GetArgument("dataservice_read_test_layer");
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, *settings_);
 
   // Request 1
@@ -1123,7 +1126,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetPartitions403CacheClear) {
       GetArgument("dataservice_read_test_catalog"));
   auto layer = GetArgument("dataservice_read_test_layer");
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, *settings_);
   {
     testing::InSequence s;
@@ -1189,7 +1192,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetPartitionsGarbageResponse) {
       GetArgument("dataservice_read_test_catalog"));
   auto layer = GetArgument("dataservice_read_test_layer");
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, *settings_);
 
   EXPECT_CALL(*network_mock_,
@@ -1218,7 +1221,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
       GetArgument("dataservice_read_test_catalog"));
   auto layer = GetArgument("dataservice_read_test_layer");
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, *settings_);
 
   // Setup the expected calls :
@@ -1274,7 +1277,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
       GetArgument("dataservice_read_test_catalog"));
   auto layer = GetArgument("dataservice_read_test_layer");
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, *settings_);
 
   // Setup the expected calls :
@@ -1330,7 +1333,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
       GetArgument("dataservice_read_test_catalog"));
   auto layer = GetArgument("dataservice_read_test_layer");
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, *settings_);
 
   // Setup the expected calls :
@@ -1383,7 +1386,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetPartitionsVersion2) {
       GetArgument("dataservice_read_test_catalog"));
   auto layer = GetArgument("dataservice_read_test_layer");
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, 2, *settings_);
 
   EXPECT_CALL(*network_mock_,
@@ -1410,7 +1413,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetPartitionsInvalidVersion) {
       GetArgument("dataservice_read_test_catalog"));
   auto layer = GetArgument("dataservice_read_test_layer");
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, 10, *settings_);
 
   auto request = olp::dataservice::read::PartitionsRequest();
@@ -1455,7 +1458,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetPartitionsCacheOnly) {
       GetArgument("dataservice_read_test_catalog"));
   auto layer = GetArgument("dataservice_read_test_layer");
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, *settings_);
 
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_PARTITIONS), _, _, _, _))
@@ -1479,7 +1482,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetPartitionsOnlineOnly) {
       GetArgument("dataservice_read_test_catalog"));
   auto layer = GetArgument("dataservice_read_test_layer");
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, *settings_);
 
   {
@@ -1532,7 +1535,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesWithCache) {
   olp::client::HRN catalog(GetTestCatalog());
   constexpr auto kLayerId = "hype-test-prefetch";
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, kLayerId, *settings_);
   ASSERT_TRUE(client);
 
@@ -1611,7 +1614,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchSibilingTilesDefaultLeve
   olp::client::HRN catalog(GetTestCatalog());
   constexpr auto kLayerId = "hype-test-prefetch";
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, kLayerId, *settings_);
   ASSERT_TRUE(client);
 
@@ -1683,7 +1686,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesWrongLevels) {
                      .WithMinLevel(0)
                      .WithMaxLevel(0);
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, kLayerId, 4, *settings_);
   ASSERT_TRUE(client);
 
@@ -1723,7 +1726,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
   constexpr auto kLayerId = "prefetch-catalog";
   constexpr auto kParitionId = "prefetch-partition";
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, kLayerId, *settings_);
   ASSERT_TRUE(client);
 
@@ -1774,7 +1777,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesCancelOnLookup) {
   constexpr auto kLayerId = "prefetch-catalog";
   constexpr auto kParitionId = "prefetch-partition";
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, kLayerId, *settings_);
   ASSERT_TRUE(client);
 
@@ -1814,7 +1817,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
                      .WithMinLevel(10)
                      .WithMaxLevel(12);
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, kLayerId, *settings_);
   ASSERT_TRUE(client);
 
@@ -1847,7 +1850,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
                      .WithMinLevel(10)
                      .WithMaxLevel(12);
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, kLayerId, *settings_);
   ASSERT_TRUE(client);
 
@@ -1892,7 +1895,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetData404Error) {
                                        olp::http::HttpStatusCode::NOT_FOUND),
                                    "Resource not found."));
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       hrn, "testlayer", *settings_);
 
   auto request = olp::dataservice::read::DataRequest();
@@ -1931,7 +1934,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetData429Error) {
         return olp::http::HttpStatusCode::TOO_MANY_REQUESTS == response.status;
       };
   settings_->retry_settings = retry_settings;
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       hrn, "testlayer", *settings_);
 
   auto request = olp::dataservice::read::DataRequest();
@@ -1964,7 +1967,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetData403CacheClear) {
   }
 
   auto client =
-      std::make_unique<VersionedLayerClient>(hrn, "testlayer", *settings_);
+      std::make_shared<VersionedLayerClient>(hrn, "testlayer", *settings_);
   auto request = DataRequest();
   request.WithPartitionId("269");
   // Populate cache
@@ -1989,7 +1992,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataCacheWithUpdate) {
   olp::client::HRN hrn(GetTestCatalog());
 
   auto client =
-      std::make_unique<VersionedLayerClient>(hrn, "testlayer", *settings_);
+      std::make_shared<VersionedLayerClient>(hrn, "testlayer", *settings_);
   auto request = DataRequest();
   request.WithPartitionId("269").WithFetchOption(CacheWithUpdate);
   // Request 1
@@ -2012,7 +2015,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
   olp::client::HRN hrn(GetTestCatalog());
 
   auto client =
-      std::make_unique<VersionedLayerClient>(hrn, "testlayer", *settings_);
+      std::make_shared<VersionedLayerClient>(hrn, "testlayer", *settings_);
   auto partitions_request = PartitionsRequest().WithFetchOption(OnlineOnly);
   auto data_request =
       DataRequest().WithPartitionId("269").WithFetchOption(OnlineOnly);
@@ -2070,7 +2073,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, CancelPendingRequestsPrefetch) {
   olp::client::HRN hrn(GetTestCatalog());
 
   auto client =
-      std::make_unique<VersionedLayerClient>(hrn, "testlayer", *settings_);
+      std::make_shared<VersionedLayerClient>(hrn, "testlayer", *settings_);
   auto prefetch_request = PrefetchTilesRequest();
   auto data_request =
       DataRequest().WithPartitionId("269").WithFetchOption(OnlineOnly);
@@ -2155,7 +2158,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
               Send(IsGetRequest(URL_LATEST_CATALOG_VERSION), _, _, _, _))
       .Times(0);
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       hrn, "testlayer", *settings_);
 
   auto request = olp::dataservice::read::DataRequest();
@@ -2212,7 +2215,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_QUERY), _, _, _, _))
       .Times(0);
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       hrn, "testlayer", *settings_);
 
   auto request = olp::dataservice::read::DataRequest();
@@ -2269,7 +2272,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
               Send(IsGetRequest(URL_QUERY_PARTITION_269), _, _, _, _))
       .Times(0);
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       hrn, "testlayer", *settings_);
 
   auto request = olp::dataservice::read::DataRequest();
@@ -2326,7 +2329,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
       .Times(0);
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       hrn, "testlayer", *settings_);
 
   auto request = olp::dataservice::read::DataRequest();
@@ -2382,7 +2385,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
       .Times(0);
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       hrn, "testlayer", *settings_);
 
   auto request = olp::dataservice::read::DataRequest();
@@ -2435,7 +2438,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
   EXPECT_CALL(*network_mock_, Cancel(request_id))
       .WillOnce(testing::Invoke(std::move(cancel_mock)));
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       hrn, "testlayer", *settings_);
 
   auto request = olp::dataservice::read::DataRequest();
@@ -2469,7 +2472,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
        GetDataWithPartitionIdVersion2) {
   olp::client::HRN hrn(GetTestCatalog());
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       hrn, "testlayer", 2, *settings_);
 
   EXPECT_CALL(*network_mock_,
@@ -2496,7 +2499,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
        GetDataWithPartitionIdInvalidVersion) {
   olp::client::HRN hrn(GetTestCatalog());
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       hrn, "testlayer", 10, *settings_);
 
   auto request = olp::dataservice::read::DataRequest();
@@ -2522,7 +2525,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataCacheOnly) {
 
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
       .Times(0);
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       hrn, "testlayer", *settings_);
 
   auto request = olp::dataservice::read::DataRequest();
@@ -2550,7 +2553,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataOnlineOnly) {
                                "Server busy at the moment."));
   }
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       hrn, "testlayer", *settings_);
 
   auto request = olp::dataservice::read::DataRequest();
@@ -2574,7 +2577,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataOnlineOnly) {
 TEST_F(DataserviceReadVersionedLayerClientTest, GetTile) {
   olp::client::HRN hrn(GetTestCatalog());
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       hrn, "testlayer", 4, *settings_);
 
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(kHttpLookupQuery), _, _, _, _))
@@ -2616,7 +2619,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetTileCacheOnly) {
 
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
       .Times(0);
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       hrn, "testlayer", 4, *settings_);
 
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(kHttpLookupQuery), _, _, _, _))
@@ -2644,7 +2647,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetTileCacheOnly) {
 
 TEST_F(DataserviceReadVersionedLayerClientTest, GetTileOnlineOnly) {
   olp::client::HRN hrn(GetTestCatalog());
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       hrn, "testlayer", 4, *settings_);
   {
     EXPECT_CALL(*network_mock_,
@@ -2705,7 +2708,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetTileOnlineOnly) {
 
 TEST_F(DataserviceReadVersionedLayerClientTest, GetTileCacheWithUpdate) {
   olp::client::HRN hrn(GetTestCatalog());
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       hrn, "testlayer", 4, *settings_);
 
   auto request = olp::dataservice::read::TileRequest()
@@ -2730,7 +2733,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetTileCacheWithUpdate) {
 
 TEST_F(DataserviceReadVersionedLayerClientTest, GetTileTwoSequentialCalls) {
   olp::client::HRN hrn(GetTestCatalog());
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       hrn, "testlayer", 4, *settings_);
 
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(kHttpLookupQuery), _, _, _, _))
@@ -2819,7 +2822,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, RemoveFromCachePartition) {
   auto layer = GetArgument("dataservice_read_test_layer");
   auto version = std::stoi(GetArgument("dataservice_read_test_layer_version"));
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, version, *settings_);
   ASSERT_TRUE(client);
 
@@ -2877,7 +2880,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, RemoveFromCacheTileKey) {
   auto layer = GetArgument("dataservice_read_test_layer");
   auto version = std::stoi(GetArgument("dataservice_read_test_layer_version"));
 
-  auto client = std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+  auto client = std::make_shared<olp::dataservice::read::VersionedLayerClient>(
       catalog, layer, version, *settings_);
   ASSERT_TRUE(client);
 
@@ -2989,3 +2992,5 @@ TEST_F(DataserviceReadVersionedLayerClientTest, CheckLookupApiCacheExpiration) {
 }
 
 }  // namespace
+
+PORTING_POP_WARNINGS()

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientTest.cpp
@@ -27,6 +27,7 @@
 #include <olp/core/http/Network.h>
 #include <olp/core/logging/Log.h>
 #include <olp/core/porting/make_unique.h>
+#include <olp/core/porting/warning_disable.h>
 #include <olp/dataservice/read/PartitionsRequest.h>
 #include <olp/dataservice/read/PrefetchTileResult.h>
 #include <olp/dataservice/read/VolatileLayerClient.h>
@@ -211,6 +212,9 @@ TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitions) {
   ASSERT_EQ(4u, partitions_response.GetResult().GetPartitions().size());
 }
 
+PORTING_PUSH_WARNINGS()
+PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
+
 TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitionsVersionIsIgnored) {
   olp::client::HRN hrn(GetTestCatalog());
 
@@ -260,6 +264,8 @@ TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitionsVersionIsIgnored) {
     ASSERT_EQ(4u, partitions_response.GetResult().GetPartitions().size());
   }
 }
+
+PORTING_POP_WARNINGS()
 
 TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitionsCancellableFuture) {
   olp::client::HRN hrn(GetTestCatalog());

--- a/tests/performance/MemoryTest.cpp
+++ b/tests/performance/MemoryTest.cpp
@@ -291,7 +291,7 @@ TEST_P(MemoryTest, ReadNPartitionsFromVersionedLayer) {
 
   StartThreads([=](uint8_t /*thread_id*/) {
     olp::dataservice::read::VersionedLayerClient service_client(
-        kCatalog, kVersionedLayerId, settings);
+        kCatalog, kVersionedLayerId, boost::none, settings);
 
     const auto end_timestamp =
         std::chrono::steady_clock::now() + parameter.runtime;
@@ -327,7 +327,7 @@ TEST_P(MemoryTest, PrefetchPartitionsFromVersionedLayer) {
 
   StartThreads([=](uint8_t /*thread_id*/) {
     olp::dataservice::read::VersionedLayerClient service_client(
-        kCatalog, kVersionedLayerId, settings);
+        kCatalog, kVersionedLayerId, boost::none, settings);
 
     const auto end_timestamp =
         std::chrono::steady_clock::now() + parameter.runtime;
@@ -343,7 +343,6 @@ TEST_P(MemoryTest, PrefetchPartitionsFromVersionedLayer) {
       auto request = olp::dataservice::read::PrefetchTilesRequest()
                          .WithMaxLevel(level + 2)
                          .WithMinLevel(level)
-                         .WithVersion(17)
                          .WithTileKeys(tile_keys);
       total_requests_.fetch_add(1);
       auto token = service_client.PrefetchTiles(


### PR DESCRIPTION
Removed AuthenticationCredentials explicit copy ctor.
Removed ApiResponse explicit copy ctor.
Updated many places with new AuthentionClient ctor.
Tests that are still use deprecated API have warnings disabled.
Change make_unique to make_shared since the warning was generated in
make_unique template function.

Relates-To: OLPEDGE-1800

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>