### PR TITLE
Fix warning about uninitialized variable.

### DIFF
--- a/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.cpp
+++ b/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.cpp
@@ -1062,7 +1062,8 @@ NetworkWinHttp::RequestData::RequestData(
       in_use(false) {}
 
 NetworkWinHttp::RequestData::RequestData()
-    : http_request(NULL),
+    : self(nullptr),
+      http_request(NULL),
       request_id(static_cast<RequestId>(RequestIdConstants::RequestIdInvalid)),
       ignore_data(),
       no_compression(false),


### PR DESCRIPTION
Fix warning about uninitialized variable in the default RequestData
constructor.

Resolves: OLPEDGE-1783

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>