### PR TITLE
Apply pimpl patter to TokenProvider.

### DIFF
--- a/olp-cpp-sdk-authentication/src/TokenEndpoint.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenEndpoint.cpp
@@ -100,7 +100,7 @@ TokenEndpoint::TokenEndpoint(Settings settings) {
   // The underlying auth library expects a base URL and appends /oauth2/token
   // endpoint to it. Therefore if /oauth2/token is found it is stripped from the
   // endpoint URL provided. The underlying auth library should be updated to
-  // supoprt an arbitrary token endpoint URL.
+  // support an arbitrary token endpoint URL.
   auto pos = settings.token_endpoint_url.find(kOauth2TokenEndpoint);
   if (pos != std::string::npos) {
     settings.token_endpoint_url.erase(pos, kOauth2TokenEndpoint.size());

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -18,6 +18,7 @@
 set(OLP_SDK_INTEGRATIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
     ./olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
+    ./olp-cpp-sdk-authentication/TokenProviderTest.cpp
     ./olp-cpp-sdk-dataservice-read/CatalogClientCacheTest.cpp
     ./olp-cpp-sdk-dataservice-read/VolatileLayerClientCacheTest.cpp
     ./olp-cpp-sdk-dataservice-read/VersionedLayerClientCacheTest.cpp

--- a/tests/integration/olp-cpp-sdk-authentication/TokenProviderTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/TokenProviderTest.cpp
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2019-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gmock/gmock.h>
+#include <matchers/NetworkUrlMatchers.h>
+#include <mocks/NetworkMock.h>
+#include <olp/authentication/Settings.h>
+#include <olp/authentication/TokenProvider.h>
+#include <olp/core/client/OlpClientSettings.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/porting/make_unique.h>
+#include <olp/dataservice/read/VersionedLayerClient.h>
+#include "../olp-cpp-sdk-dataservice-read/HttpResponses.h"
+
+using namespace olp;
+using namespace olp::tests::common;
+using namespace testing;
+
+namespace {
+
+// Catalog defines
+static constexpr auto kCatalog =
+    "hrn:here:data::olp-here-test:here-optimized-map-for-visualization-2";
+static constexpr int64_t KVersion = 108;
+static constexpr auto kLayer = "testlayer";
+static constexpr auto kPartition = "269";
+constexpr auto kWaitTimeout = std::chrono::seconds(3);
+
+// Request defines
+static const std::string kTimestampUrl =
+    R"( https://account.api.here.com/timestamp)";
+
+static const std::string kOAuthTokenUrl =
+    R"(https://account.api.here.com/oauth2/token)";
+
+// Response defines
+constexpr char kHttpResponseLookupQuery[] =
+    R"jsonString([{"api":"query","version":"v1","baseURL":"https://query.data.api.platform.here.com/query/v1/catalogs/here-optimized-map-for-visualization-2","parameters":{}}])jsonString";
+
+constexpr char kHttpResponsePartition_269[] =
+    R"jsonString({ "partitions": [{"version":4,"partition":"269","layer":"testlayer","dataHandle":"4eed6ed1-0d32-43b9-ae79-043cb4256432"}]})jsonString";
+
+constexpr char kHttpResponseLookupBlob[] =
+    R"jsonString([{"api":"blob","version":"v1","baseURL":"https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/here-optimized-map-for-visualization-2","parameters":{}}])jsonString";
+
+constexpr char kHttpResponseBlobData_269[] = R"jsonString(DT_2_0031)jsonString";
+
+constexpr char kResponseTime[] = R"JSON({"timestamp":123})JSON";
+
+constexpr char kResponseValidJson[] = R"JSON(
+   {"accessToken":"tyJhbGciOiJSUzUxMiIsImN0eSI6IkpXVCIsImlzcyI6IkhFUkUiLCJhaWQiOiJTcFR5dkQ0RjZ1dWhVY0t3ZjBPRCIsImlhdCI6MTUyMjY5OTY2MywiZXhwIjoxNTIyNzAzMjYzLCJraWQiOiJqMSJ9.ZXlKaGJHY2lPaUprYVhJaUxDSmxibU1pT2lKQk1qVTJRMEpETFVoVE5URXlJbjAuLkNuSXBWVG14bFBUTFhqdFl0ODVodVEuTk1aMzRVSndtVnNOX21Zd3pwa1UydVFfMklCbE9QeWw0VEJWQnZXczcwRXdoQWRld0tpR09KOGFHOWtKeTBoYWg2SS03Y01WbXQ4S3ppUHVKOXZqV2U1Q0F4cER0LU0yQUxhQTJnZWlIZXJuaEEwZ1ZRR3pVakw5OEhDdkpEc2YuQXhxNTRPTG9FVDhqV2ZreTgtZHY4ZUR1SzctRnJOWklGSms0RHZGa2F5Yw.bfSc5sXovW0-yGTqWDZtsVvqIxeNl9IGFbtzRBRkHCHEjthZzeRscB6oc707JTpiuRmDKJe6oFU03RocTS99YBlM3p5rP2moadDNmP3Uag4elo6z0ZE_w1BP7So7rMX1k4NymfEATdmyXVnjAhBlTPQqOYIWV-UNCXWCIzLSuwaJ96N1d8XZeiA1jkpsp4CKfcSSm9hgsKNA95SWPnZAHyqOYlO0sDE28osOIjN2UVSUKlO1BDtLiPLta_dIqvqFUU5aRi_dcYqkJcZh195ojzeAcvDGI6HqS2zUMTdpYUhlwwfpkxGwrFmlAxgx58xKSeVt0sPvtabZBAW8uh2NGg","tokenType":"bearer","expiresIn":3599}
+    )JSON";
+
+static const std::string kResponseToken =
+    "tyJhbGciOiJSUzUxMiIsImN0eSI6IkpXVCIsImlzcyI6IkhFUkUiLCJhaWQiOiJTcFR5dkQ0Rj"
+    "Z1dWhVY0t3ZjBPRCIsImlhdCI6MTUyMjY5OTY2MywiZXhwIjoxNTIyNzAzMjYzLCJraWQiOiJq"
+    "MSJ9."
+    "ZXlKaGJHY2lPaUprYVhJaUxDSmxibU1pT2lKQk1qVTJRMEpETFVoVE5URXlJbjAuLkNuSXBWVG"
+    "14bFBUTFhqdFl0ODVodVEuTk1aMzRVSndtVnNOX21Zd3pwa1UydVFfMklCbE9QeWw0VEJWQnZX"
+    "czcwRXdoQWRld0tpR09KOGFHOWtKeTBoYWg2SS03Y01WbXQ4S3ppUHVKOXZqV2U1Q0F4cER0LU"
+    "0yQUxhQTJnZWlIZXJuaEEwZ1ZRR3pVakw5OEhDdkpEc2YuQXhxNTRPTG9FVDhqV2ZreTgtZHY4"
+    "ZUR1SzctRnJOWklGSms0RHZGa2F5Yw.bfSc5sXovW0-"
+    "yGTqWDZtsVvqIxeNl9IGFbtzRBRkHCHEjthZzeRscB6oc707JTpiuRmDKJe6oFU03RocTS99YB"
+    "lM3p5rP2moadDNmP3Uag4elo6z0ZE_w1BP7So7rMX1k4NymfEATdmyXVnjAhBlTPQqOYIWV-"
+    "UNCXWCIzLSuwaJ96N1d8XZeiA1jkpsp4CKfcSSm9hgsKNA95SWPnZAHyqOYlO0sDE28osOIjN2"
+    "UVSUKlO1BDtLiPLta_dIqvqFUU5aRi_"
+    "dcYqkJcZh195ojzeAcvDGI6HqS2zUMTdpYUhlwwfpkxGwrFmlAxgx58xKSeVt0sPvtabZBAW8u"
+    "h2NGg";
+
+http::NetworkResponse GetResponse(int status) {
+  return http::NetworkResponse().WithStatus(status);
+}
+
+class TokenProviderTest : public ::testing::Test {
+ public:
+  TokenProviderTest()
+      : token_provider_settings_({"fake.key.id", "fake.key.secret"}) {}
+
+  void SetUp() override {
+    network_mock_ = std::make_shared<StrictMock<NetworkMock>>();
+
+    settings_.network_request_handler = network_mock_;
+    settings_.task_scheduler =
+        olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler(1);
+
+    token_provider_settings_.task_scheduler = settings_.task_scheduler;
+    token_provider_settings_.network_request_handler =
+        settings_.network_request_handler;
+  }
+
+  void TearDown() override {
+    testing::Mock::VerifyAndClearExpectations(network_mock_.get());
+    network_mock_.reset();
+    settings_.task_scheduler.reset();
+  }
+
+  template <long long MinimumValidity>
+  client::OlpClientSettings GetSettings() const {
+    olp::client::AuthenticationSettings auth_settings;
+    auth_settings.provider =
+        olp::authentication::TokenProvider<MinimumValidity>(
+            token_provider_settings_);
+
+    olp::client::OlpClientSettings settings = settings_;
+    settings.authentication_settings = auth_settings;
+    return settings;
+  }
+
+  olp::client::OlpClientSettings settings_;
+  olp::authentication::Settings token_provider_settings_;
+  std::shared_ptr<StrictMock<NetworkMock>> network_mock_;
+};
+
+TEST_F(TokenProviderTest, SingleTokenMultipleUsers) {
+  constexpr size_t kCount = 3u;
+  auto settings = GetSettings<authentication::kDefaultMinimumValidity>();
+  auto catalog = olp::client::HRN::FromString(kCatalog);
+
+  {
+    SCOPED_TRACE("Request token once");
+
+    // Setup once expects for the token. All clients need to use the same token.
+    EXPECT_CALL(*network_mock_, Send(_, _, _, _, _))
+        .WillOnce(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
+                                     kResponseTime))
+        .WillOnce(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
+                                     kResponseValidJson));
+
+    ASSERT_TRUE(settings.authentication_settings);
+    ASSERT_TRUE(settings.authentication_settings->provider);
+
+    auto token = settings.authentication_settings->provider();
+    EXPECT_EQ(token, kResponseToken);
+
+    testing::Mock::VerifyAndClearExpectations(network_mock_.get());
+  }
+
+  {
+    SCOPED_TRACE("Multiple requests, multiple clients");
+
+    // Create test layer clients, all using the same token provider
+    for (size_t index = 0; index < kCount; ++index) {
+      EXPECT_CALL(*network_mock_, Send(Not(AnyOf(IsGetRequest(kTimestampUrl),
+                                                 IsGetRequest(kOAuthTokenUrl))),
+                                       _, _, _, _))
+          .WillOnce(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
+                                       kHttpResponseLookupQuery))
+          .WillOnce(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
+                                       kHttpResponsePartition_269))
+          .WillOnce(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
+                                       kHttpResponseLookupBlob))
+          .WillOnce(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
+                                       kHttpResponseBlobData_269));
+
+      auto client = std::make_unique<dataservice::read::VersionedLayerClient>(
+          catalog, kLayer, KVersion, settings);
+
+      auto cancellation_future = client->GetData(
+          dataservice::read::DataRequest().WithPartitionId(kPartition));
+
+      auto future = cancellation_future.GetFuture();
+      ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
+      auto response = future.get();
+
+      ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
+      ASSERT_NE(response.GetResult(), nullptr);
+      ASSERT_FALSE(response.GetResult()->empty());
+
+      // Verify token is still the same
+      auto token = settings.authentication_settings->provider();
+      EXPECT_EQ(token, kResponseToken);
+    }
+  }
+
+  testing::Mock::VerifyAndClearExpectations(network_mock_.get());
+}
+
+}  // namespace

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -1606,8 +1606,8 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesWithCache) {
   }
 }
 
-
-TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchSibilingTilesDefaultLevels) {
+TEST_F(DataserviceReadVersionedLayerClientTest,
+       PrefetchSibilingTilesDefaultLevels) {
   olp::client::HRN catalog(GetTestCatalog());
   constexpr auto kLayerId = "hype-test-prefetch";
 
@@ -1618,25 +1618,25 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchSibilingTilesDefaultLeve
   {
     SCOPED_TRACE("Prefetch tiles online, ");
     std::vector<olp::geo::TileKey> tile_keys = {
-        olp::geo::TileKey::FromHereTile("23618366"), olp::geo::TileKey::FromHereTile("23618365")};
+        olp::geo::TileKey::FromHereTile("23618366"),
+        olp::geo::TileKey::FromHereTile("23618365")};
 
     EXPECT_CALL(*network_mock_,
-            Send(IsGetRequest(URL_QUADKEYS_92259), _, _, _, _))
-        .WillOnce(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                   olp::http::HttpStatusCode::OK),
-                               HTTP_RESPONSE_QUADKEYS_92259));
+                Send(IsGetRequest(URL_QUADKEYS_92259), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     HTTP_RESPONSE_QUADKEYS_92259));
     EXPECT_CALL(*network_mock_,
-            Send(IsGetRequest(URL_QUADKEYS_23618364), _, _, _, _))
+                Send(IsGetRequest(URL_QUADKEYS_23618364), _, _, _, _))
         .Times(0);
     EXPECT_CALL(*network_mock_,
-            Send(IsGetRequest(URL_QUADKEYS_1476147), _, _, _, _))
+                Send(IsGetRequest(URL_QUADKEYS_1476147), _, _, _, _))
         .Times(0);
     EXPECT_CALL(*network_mock_,
-            Send(IsGetRequest(URL_QUADKEYS_5904591), _, _, _, _))
+                Send(IsGetRequest(URL_QUADKEYS_5904591), _, _, _, _))
         .Times(0);
     EXPECT_CALL(*network_mock_,
-            Send(IsGetRequest(URL_QUADKEYS_369036), _, _, _, _))
+                Send(IsGetRequest(URL_QUADKEYS_369036), _, _, _, _))
         .Times(0);
 
     auto request = olp::dataservice::read::PrefetchTilesRequest()
@@ -2923,8 +2923,8 @@ TEST_F(DataserviceReadVersionedLayerClientTest, CheckLookupApiCacheExpiration) {
   auto cache = std::make_shared<testing::StrictMock<CacheMock>>();
   settings_->cache = cache;
 
-  auto client = olp::dataservice::read::VersionedLayerClient(
-      hrn, "testlayer", 4, *settings_);
+  auto client = olp::dataservice::read::VersionedLayerClient(hrn, "testlayer",
+                                                             4, *settings_);
 
   // check if expiration time is 1 hour(3600 sec)
   time_t expiration_time = 3600;
@@ -2974,7 +2974,9 @@ TEST_F(DataserviceReadVersionedLayerClientTest, CheckLookupApiCacheExpiration) {
       .Times(1)
       .WillOnce(Return(true));
 
-  auto request = olp::dataservice::read::DataRequest().WithPartitionId("269").WithFetchOption(OnlineIfNotFound);
+  auto request = olp::dataservice::read::DataRequest()
+                     .WithPartitionId("269")
+                     .WithFetchOption(OnlineIfNotFound);
   auto future = client.GetData(request);
 
   auto data_response = future.GetFuture().get();
@@ -2985,7 +2987,6 @@ TEST_F(DataserviceReadVersionedLayerClientTest, CheckLookupApiCacheExpiration) {
   std::string data_string(data_response.GetResult()->begin(),
                           data_response.GetResult()->end());
   ASSERT_EQ("DT_2_0031", data_string);
-
 }
 
 }  // namespace


### PR DESCRIPTION
To be able to share one single instance of TokenProvider with multiple
users a shared pimpl is applied. This is especially helpfull for
multiple layer clients that access the same catalog with the same
credentials and in turn the same token. This will save a huge amount
of token requests.

Relates-to: OLPEDGE-1791

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>