### PR TITLE
Add use_system_time to Settings

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationSettings.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationSettings.h
@@ -81,6 +81,10 @@ struct AUTHENTICATION_API AuthenticationSettings {
   /**
    * @brief Uses system system time in authentication requests rather than
    * requesting time from authentication server.
+   *
+   * @note Please make sure that the system time does not deviate from the
+   * official UTC time as it might result in error responses from the
+   * authentication server.
    */
   bool use_system_time{false};
 };

--- a/olp-cpp-sdk-authentication/include/olp/authentication/Settings.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/Settings.h
@@ -87,6 +87,16 @@ struct AUTHENTICATION_API Settings {
    * supported.
    */
   std::string token_endpoint_url{kHereAccountProductionTokenUrl};
+
+  /**
+   * @brief Uses system system time in authentication requests rather than
+   * requesting time from authentication server.
+   *
+   * @note Please make sure that the system time does not deviate from the
+   * official UTC time as it might result in error responses from the
+   * authentication server.
+   */
+  bool use_system_time{false};
 };
 
 }  // namespace authentication

--- a/olp-cpp-sdk-authentication/src/TokenEndpoint.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenEndpoint.cpp
@@ -42,6 +42,7 @@ AuthenticationSettings ConvertSettings(Settings settings) {
   auth_settings.task_scheduler = settings.task_scheduler;
   auth_settings.network_request_handler = settings.network_request_handler;
   auth_settings.token_endpoint_url = settings.token_endpoint_url;
+  auth_settings.use_system_time = settings.use_system_time;
   return auth_settings;
 }
 }  // namespace


### PR DESCRIPTION
Add use_system_time parameter to Settings class.
Convert it to AuthenticationSettings in TokenEndpoint.
Add integratin test to check usage of system/server time.

Relates-To: OLPEDGE-1785

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>