### PR TITLE
Track mutable cache size.

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.h
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.h
@@ -54,20 +54,43 @@ class DefaultCacheImpl {
   /// as value.
   using DiskLruCache = utils::LruCache<std::string, size_t>;
 
-  /// return LRU mutable cache, used for tests.
+  /// Returns LRU mutable cache, used for tests.
   const std::unique_ptr<DiskLruCache>& GetMutableCacheLru() const {
     return mutable_cache_lru_;
   };
 
+  /// Returns mutable cache, used for tests.
+  const std::unique_ptr<DiskCache>& GetMutableCache() const {
+    return mutable_cache_;
+  };
+
+  /// Returns memory cache, used for tests.
+  const std::unique_ptr<InMemoryCache>& GetMemoryCache() const {
+    return memory_cache_;
+  };
+
+  /// Returns mutable cache size, used for tests.
+  uint64_t GetMutableCacheSize() const { return mutable_cache_data_size_; }
+
+  /// Gets expiry key, used for tests.
+  std::string GetExpiryKey(const std::string& key) const;
+
  private:
   /// Initializes LRU mutable cache if possible.
   void InitializeLru();
+
+  /// Removes key from the mutable lru cache;
+  void RemoveKeyLru(const std::string& key);
 
   /// Removes all keys with specified prefix from LRU mutable cache.
   void RemoveKeysWithPrefixLru(const std::string& key);
 
   /// Returns true if key is found in the LRU cache, false - otherwise.
   bool PromoteKeyLru(const std::string& key);
+
+  /// Puts data into the mutable cache
+  bool PutMutableCache(const std::string& key, const leveldb::Slice& value,
+                       time_t expiry);
 
   DefaultCache::StorageOpenResult SetupStorage();
 
@@ -80,6 +103,7 @@ class DefaultCacheImpl {
   std::unique_ptr<DiskCache> mutable_cache_;
   std::unique_ptr<DiskLruCache> mutable_cache_lru_;
   std::unique_ptr<DiskCache> protected_cache_;
+  uint64_t mutable_cache_data_size_;
   std::mutex cache_lock_;
 };
 

--- a/olp-cpp-sdk-core/src/cache/DiskCache.h
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.h
@@ -106,7 +106,7 @@ class DiskCache {
   boost::optional<std::string> Get(const std::string& key);
 
   /// Remove single key/value from DB.
-  bool Remove(const std::string& key);
+  bool Remove(const std::string& key, uint64_t& removed_data_size);
 
   /// Get a new leveldb cache iterator. Use options.fill_cache = false for bulk
   /// scans.
@@ -116,8 +116,9 @@ class DiskCache {
   /// the same time.
   OperationOutcome ApplyBatch(std::unique_ptr<leveldb::WriteBatch> batch);
 
-  /// Empty prefix deleted everything from DB.
-  bool RemoveKeysWithPrefix(const std::string& prefix);
+  /// Empty prefix deleted everything from DB. Returns size of removed data.
+  bool RemoveKeysWithPrefix(const std::string& prefix,
+                            uint64_t& removed_data_size);
 
  private:
   std::string disk_cache_path_;

--- a/olp-cpp-sdk-core/tests/cache/DefaultCacheImplTest.cpp
+++ b/olp-cpp-sdk-core/tests/cache/DefaultCacheImplTest.cpp
@@ -41,6 +41,41 @@ class DefaultCacheImplHelper : public DefaultCacheImpl {
     return lru_cache->FindNoPromote(key) != lru_cache->end();
   }
 
+  bool ContainsMemoryCache(const std::string& key) const {
+    const auto& memory_cache = GetMemoryCache();
+    if (!memory_cache) {
+      return false;
+    }
+
+    return !memory_cache->Get(key).empty();
+  }
+
+  bool ContainsMutableCache(const std::string& key) const {
+    const auto& disk_cache = GetMutableCache();
+    if (!disk_cache) {
+      return false;
+    }
+
+    return disk_cache->Get(key) != boost::none;
+  }
+
+  uint64_t Size() const { return GetMutableCacheSize(); }
+
+  uint64_t CalculateExpirySize(const std::string& key) const {
+    const auto expiry_key = GetExpiryKey(key);
+    const auto& disk_cache = GetMutableCache();
+    if (!disk_cache) {
+      return 0u;
+    }
+
+    const auto expiry_str = disk_cache->Get(expiry_key).get_value_or({});
+    if (expiry_str.empty()) {
+      return 0u;
+    }
+
+    return expiry_key.size() + expiry_str.size();
+  }
+
   DiskLruCache::const_iterator BeginLru() {
     const auto& lru_cache = GetMutableCacheLru();
     if (!lru_cache) {
@@ -198,8 +233,7 @@ TEST(DefaultCacheImplTest, LruCacheGetPromote) {
   {
     SCOPED_TRACE("Get decode promote");
 
-    auto value =
-        cache.Get(key1, [=](const std::string&) { return data_string; });
+    cache.Get(key1, [=](const std::string&) { return data_string; });
     auto it = cache.BeginLru();
 
     EXPECT_EQ(key1, it->key());
@@ -208,7 +242,7 @@ TEST(DefaultCacheImplTest, LruCacheGetPromote) {
   {
     SCOPED_TRACE("Get binary promote");
 
-    auto value = cache.Get(key2);
+    cache.Get(key2);
     auto it = cache.BeginLru();
 
     EXPECT_EQ(key2, it->key());
@@ -285,6 +319,249 @@ TEST(DefaultCacheImplTest, LruCacheRemove) {
     ASSERT_TRUE(result);
     EXPECT_FALSE(cache.ContainsLru(key1));
     EXPECT_FALSE(cache.ContainsLru(key2));
+  }
+}
+
+TEST(DefaultCacheImplTest, MutableCacheSize) {
+  const std::string key1{"somekey1"};
+  const std::string key2{"somekey2"};
+  const std::string key3{"anotherkey1"};
+  const std::string invalid_key{"invalid"};
+  const std::string data_string{"this is key's data"};
+  constexpr auto expiry = 321;
+  std::vector<unsigned char> binary_data = {1, 2, 3};
+  const auto data_ptr =
+      std::make_shared<std::vector<unsigned char>>(binary_data);
+
+  std::string cache_path = olp::utils::Dir::TempDirectory() + "/unittest";
+  olp::cache::CacheSettings settings;
+  settings.disk_path_mutable = cache_path;
+
+  {
+    SCOPED_TRACE("Put decode");
+
+    settings.eviction_policy = EvictionPolicy::kNone;
+    DefaultCacheImplHelper cache(settings);
+    cache.Open();
+    cache.Clear();
+
+    cache.Put(
+        key1, data_string, [=]() { return data_string; },
+        (std::numeric_limits<time_t>::max)());
+    auto data_size = key1.size() + data_string.size();
+
+    EXPECT_EQ(data_size, cache.Size());
+
+    cache.Put(
+        key2, data_string, [=]() { return data_string; }, expiry);
+    data_size +=
+        key2.size() + data_string.size() + cache.CalculateExpirySize(key2);
+
+    EXPECT_EQ(data_size, cache.Size());
+  }
+
+  {
+    SCOPED_TRACE("Put binary");
+
+    settings.eviction_policy = EvictionPolicy::kNone;
+    DefaultCacheImplHelper cache(settings);
+    cache.Open();
+    cache.Clear();
+
+    cache.Put(key1, data_ptr, (std::numeric_limits<time_t>::max)());
+    auto data_size = key1.size() + binary_data.size();
+
+    EXPECT_EQ(data_size, cache.Size());
+
+    cache.Put(key2, data_ptr, expiry);
+    data_size +=
+        key2.size() + binary_data.size() + cache.CalculateExpirySize(key2);
+
+    EXPECT_EQ(data_size, cache.Size());
+  }
+
+  {
+    SCOPED_TRACE("Remove from cache");
+
+    DefaultCacheImplHelper cache(settings);
+    cache.Open();
+    cache.Clear();
+
+    cache.Put(key1, data_ptr, (std::numeric_limits<time_t>::max)());
+    cache.Put(
+        key2, data_string, [=]() { return data_string; },
+        (std::numeric_limits<time_t>::max)());
+
+    cache.Remove(key1);
+    cache.Remove(key2);
+    cache.Remove(invalid_key);
+
+    EXPECT_EQ(0u, cache.Size());
+  }
+
+  {
+    SCOPED_TRACE("RemoveWithPrefix");
+
+    DefaultCacheImplHelper cache(settings);
+    cache.Open();
+    cache.Clear();
+
+    cache.Put(key1, data_ptr, (std::numeric_limits<time_t>::max)());
+    cache.Put(key2, data_ptr, expiry);
+    cache.Put(
+        key3, data_string, [=]() { return data_string; }, expiry);
+    const auto data_size =
+        key3.size() + data_string.size() + cache.CalculateExpirySize(key3);
+
+    cache.RemoveKeysWithPrefix(invalid_key);
+    cache.RemoveKeysWithPrefix("some");
+
+    EXPECT_EQ(data_size, cache.Size());
+  }
+
+  {
+    SCOPED_TRACE("Expiry");
+
+    DefaultCacheImplHelper cache(settings);
+    cache.Open();
+    cache.Clear();
+
+    cache.Put(key1, data_ptr, -1);
+    cache.Put(
+        key2, data_string, [=]() { return data_string; }, -1);
+
+    cache.Get(key1);
+    cache.Get(key2, [](const std::string& value) { return value; });
+
+    EXPECT_EQ(0, cache.Size());
+  }
+
+  {
+    SCOPED_TRACE("Clear/close/open");
+    const std::string data_string{"this is key's data"};
+    const std::string key{"somekey"};
+
+    settings.eviction_policy = EvictionPolicy::kNone;
+    DefaultCacheImplHelper cache(settings);
+
+    cache.Open();
+    cache.Clear();
+
+    cache.Put(
+        key, data_string, [=]() { return data_string; },
+        (std::numeric_limits<time_t>::max)());
+    const auto data_size = key.size() + data_string.size();
+    cache.Close();
+    EXPECT_EQ(0u, cache.Size());
+
+    cache.Open();
+    EXPECT_EQ(data_size, cache.Size());
+
+    cache.Clear();
+    EXPECT_EQ(0u, cache.Size());
+  }
+
+  {
+    SCOPED_TRACE("Cache not blocked");
+
+    const auto prefix = "somekey";
+    const auto data_size = 1024u;
+    std::vector<unsigned char> binary_data(data_size);
+    olp::cache::CacheSettings settings;
+    settings.disk_path_mutable = cache_path;
+    settings.eviction_policy = EvictionPolicy::kNone;
+    settings.max_disk_storage = 2u * 1024u * 1024u;
+    DefaultCacheImplHelper cache(settings);
+
+    cache.Open();
+    cache.Clear();
+
+    // fill the cache till it full
+    auto count = 0u;
+    const auto max_count = settings.max_disk_storage / data_size;
+    auto total_size = 0u;
+    for (; count < max_count; ++count) {
+      const auto key = prefix + std::to_string(count);
+      const auto elem_size = key.size() + binary_data.size();
+      if (total_size + elem_size > settings.max_disk_storage) {
+        break;
+      }
+
+      const auto result = cache.Put(
+          key, std::make_shared<std::vector<unsigned char>>(binary_data),
+          (std::numeric_limits<time_t>::max)());
+      total_size += elem_size;
+      ASSERT_TRUE(result);
+    }
+
+    auto result =
+        cache.Put(prefix + std::to_string(count),
+                  std::make_shared<std::vector<unsigned char>>(binary_data),
+                  (std::numeric_limits<time_t>::max)());
+    EXPECT_FALSE(result);
+    EXPECT_TRUE(total_size < settings.max_disk_storage);
+    EXPECT_EQ(total_size, cache.Size());
+
+    cache.Remove(prefix + std::to_string(count - 1));
+    cache.Remove(prefix + std::to_string(count - 2));
+    result =
+        cache.Put(prefix + std::to_string(count),
+                  std::make_shared<std::vector<unsigned char>>(binary_data),
+                  (std::numeric_limits<time_t>::max)());
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(total_size > cache.Size());
+  }
+}
+
+TEST(DefaultCacheImplTest, LruCacheEviction) {
+  std::string cache_path = olp::utils::Dir::TempDirectory() + "/unittest";
+
+  {
+    SCOPED_TRACE("kNone evicts nothing");
+
+    const auto prefix = "somekey";
+    const auto data_size = 1024u;
+    std::vector<unsigned char> binary_data(data_size);
+    olp::cache::CacheSettings settings;
+    settings.disk_path_mutable = cache_path;
+    settings.eviction_policy = EvictionPolicy::kNone;
+    settings.max_disk_storage = 2u * 1024u * 1024u;
+    DefaultCacheImplHelper cache(settings);
+
+    cache.Open();
+    cache.Clear();
+
+    // fill the cache till it full
+    auto count = 0u;
+    const auto max_count = settings.max_disk_storage / data_size;
+    for (; count < max_count; ++count) {
+      const auto key = prefix + std::to_string(count);
+      const auto result = cache.Put(
+          key, std::make_shared<std::vector<unsigned char>>(binary_data),
+          (std::numeric_limits<time_t>::max)());
+      if (!result) {
+        break;
+      }
+
+      EXPECT_TRUE(cache.ContainsMutableCache(key));
+      EXPECT_TRUE(cache.ContainsMemoryCache(key));
+    }
+
+    // maximum is reached = cache to full.
+    ASSERT_FALSE(count == max_count);
+    EXPECT_FALSE(cache.HasLruCache());
+
+    // check all data is in the cache.
+    for (auto i = 0u; i < count; ++i) {
+      const auto key = prefix + std::to_string(i);
+      const auto value = cache.Get(key);
+
+      EXPECT_TRUE(value.get() != nullptr);
+      EXPECT_TRUE(cache.ContainsMutableCache(key));
+      EXPECT_TRUE(cache.ContainsMemoryCache(key));
+    }
+    cache.Clear();
   }
 }
 


### PR DESCRIPTION
Size of mutable cache limited by DiskCacheSizeLimitEnv. Because of
leveldb implementation, its size increasing even after removing items
from the cache. So env can't be used for cache size limitation and
eviction.

Resolves: olpedge-1592

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>