### PR TITLE
Add missing CORE_API export

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/cache/CacheSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/CacheSettings.h
@@ -21,6 +21,7 @@
 
 #include <string>
 
+#include <olp/core/CoreApi.h>
 #include <olp/core/porting/deprecated.h>
 #include <boost/optional.hpp>
 
@@ -47,7 +48,7 @@ enum class EvictionPolicy : unsigned char {
 /**
  * @brief Settings for in-memory and on-disk caching.
  */
-struct CacheSettings {
+struct CORE_API CacheSettings {
   /**
    * @brief The path to the mutable (read-write) on-disk cache where
    * the SDK caches and lookups the content.

--- a/olp-cpp-sdk-core/include/olp/core/client/Condition.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/Condition.h
@@ -32,7 +32,7 @@ namespace client {
  * @brief A helper class that allows one thread to call and wait for a
  * notification in the other thread.
  */
-class Condition final {
+class CORE_API Condition final {
  public:
   Condition() = default;
 

--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
@@ -78,7 +78,7 @@ CORE_API bool DefaultRetryCondition(const olp::client::HttpResponse& response);
  * request. Both functions are user-provided.
  * The struct is used internally by the `OlpClient` class.
  */
-struct AuthenticationSettings {
+struct CORE_API AuthenticationSettings {
   /**
    * @brief Implemented by the client that should return the OAuth2 bearer
    * access token.
@@ -143,7 +143,7 @@ struct AuthenticationSettings {
  * You can customize all of these settings. The settings are used internally by
  * the `OlpClient` class.
  */
-struct RetrySettings {
+struct CORE_API RetrySettings {
   /**
    * @brief Takes the current timeout (in milliseconds) and
    * returns what should be used for the next timeout.
@@ -216,7 +216,7 @@ struct RetrySettings {
 /**
  * @brief Configures the behavior of the `OlpClient` class.
  */
-struct OlpClientSettings {
+struct CORE_API OlpClientSettings {
   /**
    * @brief The retry settings.
    */

--- a/olp-cpp-sdk-core/include/olp/core/client/TaskContext.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/TaskContext.h
@@ -312,7 +312,7 @@ class CORE_API TaskContext {
 /**
  * @brief A helper for unordered containers.
  */
-struct TaskContextHash {
+struct CORE_API TaskContextHash {
   /**
    * @brief The hash function for the `TaskContext` instance.
    *

--- a/olp-cpp-sdk-core/include/olp/core/http/HttpStatusCode.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/HttpStatusCode.h
@@ -30,7 +30,7 @@ namespace http {
  * For more information see
  * https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
  */
-class HttpStatusCode {
+class CORE_API HttpStatusCode {
  public:
   enum : int {
     CONTINUE = 100,

--- a/olp-cpp-sdk-core/include/olp/core/http/NetworkTypes.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/NetworkTypes.h
@@ -74,7 +74,7 @@ enum class ErrorCode {
  * trigger failed.  The caller must check whether the outcome of the request was
  * a success before attempting to access the result or the error.
  */
-class SendOutcome final {
+class CORE_API SendOutcome final {
  public:
   /// Invalid RequestId alias.
   static constexpr RequestId kInvalidRequestId =

--- a/olp-cpp-sdk-core/include/olp/core/http/NetworkUtils.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/NetworkUtils.h
@@ -28,7 +28,7 @@ namespace http {
 /**
  * @brief Network internal utilities
  */
-class NetworkUtils {
+class CORE_API NetworkUtils {
  public:
   static char SimpleToUpper(char c);
   static bool CaseInsensitiveCompare(const std::string& str1,

--- a/olp-cpp-sdk-core/include/olp/core/logging/Appender.h
+++ b/olp-cpp-sdk-core/include/olp/core/logging/Appender.h
@@ -30,7 +30,7 @@ namespace logging {
  * Subclasses should derive from Appender instead of IAppender in order for the
  * type to be automatically registered.
  */
-class IAppender {
+class CORE_API IAppender {
  public:
   virtual ~IAppender() = default;
 

--- a/olp-cpp-sdk-core/include/olp/core/logging/LogMessage.h
+++ b/olp-cpp-sdk-core/include/olp/core/logging/LogMessage.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <olp/core/CoreApi.h>
 #include <olp/core/logging/Level.h>
 #include <chrono>
 
@@ -27,7 +28,7 @@ namespace logging {
 /**
  * @brief Structure holding the data used for a log message.
  */
-struct LogMessage {
+struct CORE_API LogMessage {
   Level level{Level::Off};
   const char* tag{nullptr};
   const char* message{nullptr};

--- a/olp-cpp-sdk-core/include/olp/core/math/Math.h
+++ b/olp-cpp-sdk-core/include/olp/core/math/Math.h
@@ -35,19 +35,19 @@ constexpr double pi = 3.14159265358979323846264338327950288;
 constexpr double two_pi = 6.28318530717958647692528676655900576;
 constexpr double epsilon = std::numeric_limits<double>::epsilon();
 
-inline double Degrees(double radians) {
+CORE_API inline double Degrees(double radians) {
   return radians * 57.295779513082320876798154814105;
 }
 
-inline double Radians(double degrees) {
+CORE_API inline double Radians(double degrees) {
   return degrees * 0.01745329251994329576923690768489;
 }
 
-inline bool EpsilonEqual(double const& x, double const& y) {
+CORE_API inline bool EpsilonEqual(double const& x, double const& y) {
   return std::abs(x - y) < epsilon;
 }
 
-inline double Clamp(double const& x, double const& minVal,
+CORE_API inline double Clamp(double const& x, double const& minVal,
                     double const& maxVal) {
   return min(max(x, minVal), maxVal);
 }
@@ -55,7 +55,7 @@ inline double Clamp(double const& x, double const& minVal,
 //
 // Provide integeral type modulus computation.
 
-inline double Wrap(double value, double lower, double upper) {
+CORE_API inline double Wrap(double value, double lower, double upper) {
   // Return lower bound if the range is singular
   if (EpsilonEqual(lower, upper)) {
     return lower;


### PR DESCRIPTION
Add missing CORE_API macro to classes and structs

Resolves: OLPEDGE-1693

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>