### PR TITLE
Add ccache reset condition for every week

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,11 +67,14 @@ jobs:
   - bash: |
         sudo apt-get install libcurl4-openssl-dev clang-7 ccache -y --no-install-recommends
         echo "##vso[task.prependpath]/usr/lib/ccache"
+        echo week_$(date +%W) > week_number.txt
     displayName: 'Install dependencies'
   - task: Cache@2
     inputs:
-        key: 'ccache | "$(Agent.OS)"'
+        key: 'ccache | "$(Agent.OS)" | ./week_number.txt '
         path: $(CCACHE_DIR)
+        restoreKeys: |
+            ccache | "$(Agent.OS)"
     displayName: ccache
   - bash: scripts/linux/psv/build_psv.sh
     displayName: 'Linux Clang Build'


### PR DESCRIPTION
Every week ccache will be refreshed on PR and master builds
of 'Linux Clang Build' job.
So build time decrease from 9 to 3 mins.
RestoreKeys are needed for partial cache match.
Azure doc is : https://bit.ly/3bxSHcz

Resolves: OLPEDGE-1731

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>