### PR TITLE
Remove deprecated methods from AuthenticationClient

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
@@ -260,18 +260,6 @@ class AUTHENTICATION_API AuthenticationClient {
   /**
    * @brief Creates the `AuthenticationClient` instance.
    *
-   * @param authentication_server_url The URL of the HERE Account server.
-   * @example "https://account.api.here.com
-   * @param token_cache_limit The maximum number of tokens that can be cached.
-   */
-  OLP_SDK_DEPRECATED("Deprecated. Will be removed in 04.2020")
-  AuthenticationClient(
-      const std::string& authentication_server_url = kHereAccountProductionUrl,
-      size_t token_cache_limit = 100u);
-
-  /**
-   * @brief Creates the `AuthenticationClient` instance.
-   *
    * @param settings The authentication settings that can be used to configure
    * the `AuthenticationClient` instance.
    */
@@ -575,39 +563,6 @@ class AUTHENTICATION_API AuthenticationClient {
    */
   client::CancellationToken IntrospectApp(std::string access_token,
                                           IntrospectAppCallback callback);
-
-  /**
-   * @brief Sets the `NetworkProxySettings` instance used by the underlying
-   * network layer to make requests.
-   *
-   * It is recommended to call this function before you
-   * make any requests using the `AuthenticationClient` instance.
-   *
-   * @param proxy_settings The proxy settings used by the network layer to make
-   * requests.
-   */
-  OLP_SDK_DEPRECATED("Deprecated. Will be removed in 04.2020")
-  void SetNetworkProxySettings(
-      const http::NetworkProxySettings& proxy_settings);
-
-  /**
-   * @brief Sets the `Network` class handler used to make requests.
-   *
-   * @param network The shared `Network` instance used to trigger requests.
-   * Should not be `nullptr`; otherwise, any access to the class method calls
-   * would render `http::ErrorCode::IO_ERROR`.
-   */
-  OLP_SDK_DEPRECATED("Deprecated. Will be removed in 04.2020")
-  void SetNetwork(std::shared_ptr<http::Network> network);
-
-  /**
-   * @brief Sets the `TaskScheduler` class.
-   *
-   * @param task_scheduler The shared `TaskScheduler` instance used for requests
-   * outcomes. If set to `nullptr`, callbacks are sent synchronously.
-   */
-  OLP_SDK_DEPRECATED("Deprecated. Will be removed in 04.2020")
-  void SetTaskScheduler(std::shared_ptr<thread::TaskScheduler> task_scheduler);
 
  private:
   class Impl;

--- a/scripts/misc/cpplint_ci.sh
+++ b/scripts/misc/cpplint_ci.sh
@@ -47,13 +47,17 @@ printf "Installing cpplint using pip\n\n"
 
 pip install --user cpplint
 
-printf "Running cpplint\n\n"
+printf "\n\nRunning cpplint\n\n"
 
 # Exclude warning about <future> <mutex> includes
 CPPLINT_FILTER="--filter=-build/c++11"
 
 # Run the cpplint tool
-cpplint $CPPLINT_FILTER "$FILES"
+cpplint $CPPLINT_FILTER $FILES 2> warnigns.txt
+
+printf "\n\nComplete cpplint\n\n"
+
+cat warnigns.txt
 
 # Despite the error found exit without errors.
 # Remove this exit to make the script blocking on CI.


### PR DESCRIPTION
Adapt authentication test with proxy to new client constructor.

Relates-To: OLPEDGE-1855

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>