### PR TITLE
Extend the deprecation period for some classes

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/TokenEndpoint.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/TokenEndpoint.h
@@ -41,7 +41,7 @@ class AutoRefreshingToken;
  * @brief Corresponds to the token endpoint as specified in the OAuth2.0
  * specification.
  */
-class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed in 04.2020")
+class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed in 10.2020")
     TokenEndpoint {
  public:
   // Needed to avoid endless warnings from TokenRequest/TokenResult

--- a/olp-cpp-sdk-authentication/include/olp/authentication/TokenProvider.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/TokenProvider.h
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include <olp/authentication/AuthenticationCredentials.h>
 #include <olp/authentication/AutoRefreshingToken.h>
@@ -47,7 +48,7 @@ PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
  *
  * @see `TokenProviderDefault`
  */
-template <long long MinimumValidity>
+template <uint64_t MinimumValidity>
 class TokenProvider {
  public:
   /**

--- a/olp-cpp-sdk-authentication/include/olp/authentication/TokenRequest.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/TokenRequest.h
@@ -31,7 +31,7 @@ namespace authentication {
  * @brief Holds the parameters of the OAuth2.0 Authorization
  * Grant request.
  */
-class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed in 04.2020")
+class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed in 10.2020")
     TokenRequest {
  public:
   /**


### PR DESCRIPTION
Extend the deprecation period for TokenEndpoint and TokenRequest.
Fix some of the cpplint warnings.

Relates-To: OLPEDGE-1855

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>