### PR TITLE
Improvement for FV scripts

### DIFF
--- a/scripts/linux/fv/gitlab-olp-cpp-sdk-authentication-test.sh
+++ b/scripts/linux/fv/gitlab-olp-cpp-sdk-authentication-test.sh
@@ -19,6 +19,5 @@
 
 
 echo ">>> Core - Authentication Test ... >>>"
-source $FV_HOME/olp-cpp-sdk-authentication-test.variables
 $REPO_HOME/build/olp-cpp-sdk-authentication/tests/olp-cpp-sdk-authentication-tests \
     --gtest_output="xml:$REPO_HOME/reports/olp-authentication-test-report.xml"

--- a/scripts/linux/fv/gitlab-olp-cpp-sdk-core-test.sh
+++ b/scripts/linux/fv/gitlab-olp-cpp-sdk-core-test.sh
@@ -19,7 +19,6 @@
 
 
 echo ">>> Core Test ... >>>"
-source $FV_HOME/olp-cpp-sdk-core-test.variables
 $REPO_HOME/build/olp-cpp-sdk-core/tests/olp-cpp-sdk-core-tests \
     --gtest_output="xml:$REPO_HOME/reports/olp-core-test-report.xml" \
     --gtest_filter=-"DefaultCacheTest.BadPathMutable"

--- a/scripts/linux/fv/gitlab-olp-cpp-sdk-dataservice-read-test.sh
+++ b/scripts/linux/fv/gitlab-olp-cpp-sdk-dataservice-read-test.sh
@@ -19,6 +19,5 @@
 
 
 echo ">>> Core - SOURCE DATASERVICE READ Test ... >>>"
-source $FV_HOME/olp-cpp-sdk-dataservice-read-test.variables
 $REPO_HOME/build/olp-cpp-sdk-dataservice-read/tests/olp-cpp-sdk-dataservice-read-tests \
     --gtest_output="xml:$REPO_HOME/reports/olp-dataservice-read-test-report.xml"

--- a/scripts/linux/fv/gitlab-olp-cpp-sdk-dataservice-write-test.sh
+++ b/scripts/linux/fv/gitlab-olp-cpp-sdk-dataservice-write-test.sh
@@ -19,6 +19,5 @@
 
 
 echo ">>> Core - SOURCE DATASERVICE WRITE Test ... >>>"
-source $FV_HOME/olp-cpp-sdk-dataservice-write-test.variables
 $REPO_HOME/build/olp-cpp-sdk-dataservice-write/tests/olp-cpp-sdk-dataservice-write-tests \
     --gtest_output="xml:$REPO_HOME/reports/olp-dataservice-write-test-report.xml"

--- a/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test.sh
+++ b/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test.sh
@@ -18,7 +18,6 @@
 # License-Filename: LICENSE
 
 echo ">>> Functional Test ... >>>"
-source $FV_HOME/olp-cpp-sdk-functional-test.variables
 $REPO_HOME/build/tests/functional/olp-cpp-sdk-functional-tests \
     --gtest_output="xml:$REPO_HOME/reports/olp-functional-test-report.xml" \
     --gtest_filter="-ArcGisAuthenticationTest.SignInArcGis":"FacebookAuthenticationTest.SignInFacebook"

--- a/scripts/linux/fv/gitlab-olp-cpp-sdk-integration-test.sh
+++ b/scripts/linux/fv/gitlab-olp-cpp-sdk-integration-test.sh
@@ -19,6 +19,5 @@
 
 
 echo ">>> Integration Test ... >>>"
-source $FV_HOME/olp-cpp-sdk-integration-test.variables
 $REPO_HOME/build/tests/integration/olp-cpp-sdk-integration-tests \
     --gtest_output="xml:$REPO_HOME/reports/olp-integration-test-report.xml"

--- a/scripts/linux/fv/gitlab_test_fv.sh
+++ b/scripts/linux/fv/gitlab_test_fv.sh
@@ -44,6 +44,7 @@ ulimit -c unlimited
 # Test failure must return code 1 only. Other return code are not handled in retry.
 # Allowing tests failures (exit codes not 0) for online tests is done by set command below. Process is controlled by retry mechanism below.
 # Stop after 2nd retry.
+source ${FV_HOME}/olp-cpp-sdk-functional-test.variables
 set +e
 for RETRY_COUNT in 1 2
 do
@@ -65,14 +66,21 @@ done
 set -e
 # End of retry part. This part can be removed any time later or after all online tests are stable.
 
-
 # Run integration tests
+source ${FV_HOME}/olp-cpp-sdk-integration-test.variables
 ${FV_HOME}/gitlab-olp-cpp-sdk-integration-test.sh || TEST_FAILURE=1
 
 # Run unit tests
+source ${FV_HOME}/olp-cpp-sdk-authentication-test.variables
 ${FV_HOME}/gitlab-olp-cpp-sdk-authentication-test.sh || TEST_FAILURE=1
+
+source ${FV_HOME}/olp-cpp-sdk-core-test.variables
 ${FV_HOME}/gitlab-olp-cpp-sdk-core-test.sh || TEST_FAILURE=1
+
+source ${FV_HOME}/olp-cpp-sdk-dataservice-read-test.variables
 ${FV_HOME}/gitlab-olp-cpp-sdk-dataservice-read-test.sh || TEST_FAILURE=1
+
+source ${FV_HOME}/olp-cpp-sdk-dataservice-write-test.variables
 ${FV_HOME}/gitlab-olp-cpp-sdk-dataservice-write-test.sh || TEST_FAILURE=1
 
 


### PR DESCRIPTION
During development we found that .variables injection may be
failed and skipped as error during FV execution. It's caused
by exit status which we set after FV functinal tests passed.
To fix that I moved variables injection on higher level.
Do the same for all FV test group.This way is already used
in NV tests.

Relates-To: OLPEDGE-1738

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>