### PR TITLE
Fix the failed test.

### DIFF
--- a/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
@@ -254,12 +254,6 @@ class AuthenticationClient::Impl final {
 
   /**
    * @brief Constructor
-   * @param token_cache_limit Maximum number of tokens that will be cached.
-   */
-  Impl(const std::string& authentication_server_url, size_t token_cache_limit);
-
-  /**
-   * @brief Constructor
    * @param settings The authentication settings that can be used to configure
    * the `Impl`  instance.
    */
@@ -360,16 +354,6 @@ class AuthenticationClient::Impl final {
   std::shared_ptr<client::PendingRequests> pending_requests_;
   mutable std::mutex token_mutex_;
 };
-
-AuthenticationClient::Impl::Impl(const std::string& authentication_server_url,
-                                 size_t token_cache_limit)
-    : client_token_cache_(std::make_shared<SignInCacheType>(token_cache_limit)),
-      user_token_cache_(
-          std::make_shared<SignInUserCacheType>(token_cache_limit)),
-      pending_requests_(std::make_shared<client::PendingRequests>()) {
-  settings_.token_endpoint_url = authentication_server_url;
-  settings_.token_cache_limit = token_cache_limit;
-}
 
 AuthenticationClient::Impl::Impl(AuthenticationSettings settings)
     : client_token_cache_(

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -628,7 +628,8 @@ TEST_F(AuthenticationClientTest, NetworkProxySettings) {
   proxy_settings.WithType(olp::http::NetworkProxySettings::Type::SOCKS4);
   settings.network_proxy_settings = proxy_settings;
 
-  auto client = std::make_unique<AuthenticationClient>(settings);
+  // Override the default client with a new one with proxy.
+  client_ = std::make_unique<AuthenticationClient>(settings);
 
   std::time_t now;
   auto response = SignInClient(credentials, now, kExpiryTime);


### PR DESCRIPTION
Remove the old unused constructor.

Resolves: OLPEDGE-1859

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>