### PR TITLE
Eviction for mutable cache.

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.h
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.h
@@ -88,6 +88,9 @@ class DefaultCacheImpl {
   /// Returns true if key is found in the LRU cache, false - otherwise.
   bool PromoteKeyLru(const std::string& key);
 
+  /// Returns evicted data size.
+  uint64_t MaybeEvictData(leveldb::WriteBatch& batch);
+
   /// Puts data into the mutable cache
   bool PutMutableCache(const std::string& key, const leveldb::Slice& value,
                        time_t expiry);

--- a/tests/common/matchers/NetworkUrlMatchers.h
+++ b/tests/common/matchers/NetworkUrlMatchers.h
@@ -34,6 +34,18 @@ MATCHER_P(IsGetRequest, url, "") {
          url == arg.GetUrl() && (!arg.GetBody() || arg.GetBody()->empty());
 }
 
+MATCHER_P(IsGetRequestPrefix, url, "") {
+  if (olp::http::NetworkRequest::HttpVerb::GET != arg.GetVerb()) {
+    return false;
+  }
+
+  std::string url_string(url);
+  auto res =
+      std::mismatch(url_string.begin(), url_string.end(), arg.GetUrl().begin());
+
+  return (res.first == url_string.end());
+}
+
 MATCHER_P(IsPutRequest, url, "") {
   return olp::http::NetworkRequest::HttpVerb::PUT == arg.GetVerb() &&
          url == arg.GetUrl();


### PR DESCRIPTION
If mutable cache reached max_disk_storage size, user will not be able
to put new values. Removing least recently used items allows to use the
cache further.

Eviction process strarts after 90% threshold and goes till 85%, so all
values can be removed in one batch and number of disk calls is
minimized.

Resolves: OLPEDGE-1592, OLPEDGE-1822

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>