### PR TITLE
Remove unused restoreKey in Azure ccache

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,8 +73,6 @@ jobs:
     inputs:
         key: 'ccache | "$(Agent.OS)" | ./week_number.txt '
         path: $(CCACHE_DIR)
-        restoreKeys: |
-            ccache | "$(Agent.OS)"
     displayName: ccache
   - bash: scripts/linux/psv/build_psv.sh
     displayName: 'Linux Clang Build'


### PR DESCRIPTION
Restore key may prevent correct ccache hit.

Relates-To: OLPEDGE-1731

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>