### PR TITLE
Rvalue issue in PrefetchTilesRequest fixed.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,20 +62,6 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
    */
   inline PrefetchTilesRequest& WithTileKeys(
       std::vector<geo::TileKey> tile_keys) {
-    tile_keys_ = std::move(tile_keys);
-    return *this;
-  }
-
-  /**
-   * @brief Sets the vector of the root tile keys for the request.
-   *
-   * @param tile_keys The rvalue reference to the vector with the root tile keys
-   * of the prefetch.
-   *
-   * @return A reference to the updated `PrefetchTilesRequest` instance.
-   */
-  inline PrefetchTilesRequest& WithTileKeys(
-      std::vector<geo::TileKey>&& tile_keys) {
     tile_keys_ = std::move(tile_keys);
     return *this;
   }

--- a/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(OLP_SDK_DATASERVICE_READ_TEST_SOURCES
     ParserTest.cpp
     PartitionsRepositoryTest.cpp
     PrefetchRepositoryTest.cpp
+    PrefetchTilesRequestTest.cpp
     QueryApiTest.cpp
     SerializerTest.cpp
     StreamApiTest.cpp

--- a/olp-cpp-sdk-dataservice-read/tests/PrefetchTilesRequestTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PrefetchTilesRequestTest.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <olp/core/geo/tiling/TileKey.h>
+#include <olp/dataservice/read/PrefetchTilesRequest.h>
+
+using namespace ::testing;
+using namespace olp::geo;
+using namespace olp::dataservice::read;
+using TileKeys = std::vector<TileKey>;
+
+namespace {
+
+TEST(PrefetchTilesRequestTest, TileKeys) {
+  {
+    SCOPED_TRACE("lvalue test");
+
+    PrefetchTilesRequest request;
+    const TileKeys expected_tiles = {TileKey::FromHereTile("1234"),
+                                     TileKey::FromHereTile("12345")};
+
+    request.WithTileKeys(expected_tiles);
+
+    EXPECT_EQ(expected_tiles, request.GetTileKeys());
+  }
+  {
+    SCOPED_TRACE("rvalue test");
+
+    PrefetchTilesRequest request;
+    const TileKeys expected_tiles = {TileKey::FromHereTile("1234"),
+                                     TileKey::FromHereTile("12345")};
+    const TileKeys expected_tiles2 = {TileKey::FromHereTile("12346"),
+                                      TileKey::FromHereTile("123456")};
+
+    auto tile_keys = expected_tiles;
+    request.WithTileKeys(std::move(tile_keys));
+
+    EXPECT_EQ(expected_tiles, request.GetTileKeys());
+
+    request.WithTileKeys(
+        {TileKey::FromHereTile("12346"), TileKey::FromHereTile("123456")});
+
+    EXPECT_EQ(expected_tiles2, request.GetTileKeys());
+  }
+}
+
+}  // namespace


### PR DESCRIPTION
Because of two WithTileKeys overloads using a copy parameter input,
and accordingly rvalue reference input, users were not able to std::move
efficiently any TileKey list as it would result in a compilation error
due to the ambiguous nature of the two overloads. This is now fixed and
user should be able to move efficiently any give vector into the request
structure by using WithTileKeys.

Relates-To: OLPEDGE-1838

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>