### PR TITLE
Fix uninitialized variables count and offset.

### DIFF
--- a/olp-cpp-sdk-core/src/http/android/HttpClient.java
+++ b/olp-cpp-sdk-core/src/http/android/HttpClient.java
@@ -113,15 +113,15 @@ public class HttpClient {
       this.proxyPort = proxyPort;
 
       switch (proxyType) {
-        case 0:
+        case 1:
           this.proxyType = Proxy.Type.HTTP;
           break;
-        case 4:
+        case 2:
           this.proxyType = Proxy.Type.SOCKS;
           break;
+        case 3:
+        case 4:
         case 5:
-        case 6:
-        case 7:
           this.proxyType = Proxy.Type.SOCKS;
           Log.w(
               LOGTAG,
@@ -318,7 +318,6 @@ public class HttpClient {
                 conn.setRequestProperty("Connection", "Close");
             }
 
-            Log.d(LOGTAG, "Printing Request Headers...\n");
             uploadedContentSize += calculateHeadersSize(conn.getRequestProperties());
 
             conn.setDoInput(true);
@@ -327,7 +326,6 @@ public class HttpClient {
             if (request.postData() != null) {
               conn.setDoOutput(true);
               conn.getOutputStream().write(request.postData());
-              Log.d(LOGTAG, "Uploaded data length:" + request.postData().length);
               uploadedContentSize += request.postData().length;
             } else {
               conn.setDoOutput(false);
@@ -385,7 +383,6 @@ public class HttpClient {
               }
             }
 
-            Log.d(LOGTAG, "Printing Response Headers...\n");
             downloadContentSize += calculateHeadersSize(conn.getHeaderFields());
 
             int contentSize = conn.getContentLength();
@@ -560,7 +557,6 @@ public class HttpClient {
       for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
         String header = entry.getKey();
         List<String> values = entry.getValue();
-        Log.d(LOGTAG, header + ":" + values);
         if(header != null) {
           size += header.length();
         }

--- a/olp-cpp-sdk-core/src/http/android/NetworkAndroid.cpp
+++ b/olp-cpp-sdk-core/src/http/android/NetworkAndroid.cpp
@@ -408,13 +408,15 @@ bool NetworkAndroid::Initialize() {
   }
 
   run_thread_ = std::make_unique<std::thread>(NetworkAndroid::Run, this);
+
+  initialized_ = true;
+
   {
     if (!started_) {
       run_thread_ready_cv_.wait(lock);
     }
   }
 
-  initialized_ = true;
   return true;
 }
 
@@ -1048,18 +1050,20 @@ RequestId NetworkAndroid::GenerateNextRequestId() {
 NetworkAndroid::RequestData::RequestData(
     Network::Callback callback, Network::HeaderCallback header_callback,
     Network::DataCallback data_callback, const std::string& url,
-    const std::shared_ptr<std::ostream>& payload)
+    Network::Payload payload)
     : callback(callback),
       header_callback(header_callback),
       data_callback(data_callback),
       url(url),
       payload(payload),
-      obj(nullptr) {}
+      obj(nullptr),
+      count(0),
+      offset(0) {}
 
 NetworkAndroid::ResponseData::ResponseData(
     RequestId id, Network::Callback callback, int status, int uploaded_bytes,
     int downloaded_bytes, const char* error, const char* content_type,
-    jlong count, jlong offset, std::shared_ptr<std::ostream> payload)
+    jlong count, jlong offset, Network::Payload payload)
     : id(id),
       callback(callback),
       payload(payload),

--- a/olp-cpp-sdk-core/src/http/android/NetworkAndroid.h
+++ b/olp-cpp-sdk-core/src/http/android/NetworkAndroid.h
@@ -131,7 +131,7 @@ class NetworkAndroid : public Network {
     RequestData(Network::Callback callback,
                 Network::HeaderCallback header_callback,
                 Network::DataCallback data_callback, const std::string& url,
-                const std::shared_ptr<std::ostream>& payload);
+                Network::Payload payload);
 
     void Reinitialize() {
       obj = nullptr;
@@ -142,7 +142,7 @@ class NetworkAndroid : public Network {
     Network::HeaderCallback header_callback;
     Network::DataCallback data_callback;
     std::string url;
-    std::shared_ptr<std::ostream> payload;
+    Network::Payload payload;
     jobject obj;
     jlong count;
     jlong offset;
@@ -155,12 +155,12 @@ class NetworkAndroid : public Network {
     ResponseData(RequestId id, Network::Callback callback, int status,
                  int uploaded_bytes, int downloaded_bytes, const char* error,
                  const char* content_type, jlong count, jlong offset,
-                 std::shared_ptr<std::ostream> payload);
+                 Network::Payload payload);
     bool IsValid() const { return (callback != nullptr); }
 
     RequestId id = static_cast<RequestId>(RequestIdConstants::RequestIdInvalid);
     Network::Callback callback;
-    std::shared_ptr<std::ostream> payload;
+    Network::Payload payload;
     std::string error;
     std::string content_type;
     int status = 0;


### PR DESCRIPTION
Uninitialized variables count and offset could potentially
cause broken response to user.

* Fix Android proxy enum.
* Fix network initialization in concurrent env.

Resolves: OLPSUP-10333