### PR TITLE
Optimize quad tree index for GetData(TileRequest)

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -447,6 +447,14 @@ client::CancellationToken VersionedLayerClientImpl::GetData(
                    std::move(callback));
   }
 
+  if (!request.GetTileKey().IsValid()) {
+    auto task = [](client::CancellationContext) -> DataResponse {
+      return {{client::ErrorCode::InvalidArgument, "Tile key is invalid"}};
+    };
+    return AddTask(settings_.task_scheduler, pending_requests_, std::move(task),
+                   std::move(callback));
+  }
+
   auto schedule_get_data = [&](TileRequest request,
                                DataResponseCallback callback) {
     auto catalog = catalog_;

--- a/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
@@ -41,8 +41,8 @@
 #define URL_BLOB_DATA_5904591 \
   R"(https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2/layers/testlayer/data/e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1)"
 
-#define URL_BLOB_DATA_23618364 \
-  R"(https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2/layers/testlayer/data/f9a9fd8e-eb1b-48e5-bfdb-4392b3826443)"
+#define URL_BLOB_DATA_1476147 \
+  R"(https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2/layers/testlayer/data/95c5c703-e00e-4c38-841e-e419367474f1)"
 
 #define HTTP_RESPONSE_LOOKUP_BLOB \
   R"jsonString([{"api":"blob","version":"v1","baseURL":"https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2","parameters":{}}])jsonString"
@@ -52,10 +52,6 @@
 
 #define BLOB_DATA_HANDLE R"(4eed6ed1-0d32-43b9-ae79-043cb4256432)"
 
-#define BLOB_DATA_HANDLE_23618364 R"(f9a9fd8e-eb1b-48e5-bfdb-4392b3826443)"
-
-#define BLOB_DATA_HANDLE_5904591 R"(e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1)"
-
 #define URL_LOOKUP_QUERY \
   R"(https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data::olp-here-test:hereos-internal-test-v2/apis/query/v1)"
 
@@ -63,16 +59,10 @@
   R"jsonString([{"api":"query","version":"v1","baseURL":"https://sab.query.data.api.platform.here.com/query/v1/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2","parameters":{}}])jsonString"
 
 #define QUERY_TREE_INDEX \
-  R"(https://sab.query.data.api.platform.here.com/query/v1/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2/layers/testlayer/versions/4/quadkeys/5904591/depths/4)"
+  R"(https://sab.query.data.api.platform.here.com/query/v1/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2/layers/testlayer/versions/4/quadkeys/23064/depths/4)"
 
 #define SUB_QUADS \
-  R"jsonString({"subQuads": [{"subQuadKey":"4","version":4,"dataHandle":"f9a9fd8e-eb1b-48e5-bfdb-4392b3826443"},{"subQuadKey":"5","version":4,"dataHandle":"e119d20e-c7c6-4563-ae88-8aa5c6ca75c3"},{"subQuadKey":"6","version":4,"dataHandle":"a7a1afdf-db7e-4833-9627-d38bee6e2f81"},{"subQuadKey":"7","version":4,"dataHandle":"9d515348-afce-44e8-bc6f-3693cfbed104"},{"subQuadKey":"1","version":4,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": [{"partition":"1476147","version":4,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"}]})jsonString"
-
-#define QUERY_PARTITION_23618364 \
-  R"(https://sab.query.data.api.platform.here.com/query/v1/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2/layers/testlayer/partitions?partition=23618364&version=4)"
-
-#define RESPONSE_PARTITION_23618364 \
-  R"jsonString({ "partitions": [{"version":4,"partition":"23618364","layer":"testlayer","dataHandle":"f9a9fd8e-eb1b-48e5-bfdb-4392b3826443"}]})jsonString"
+  R"jsonString({"subQuads": [{"subQuadKey":"115","version":4,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"},{"subQuadKey":"463","version":4,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": []})jsonString"
 
 namespace {
 
@@ -328,13 +318,13 @@ TEST_F(DataRepositoryTest, GetVersionedDataTile) {
                                HTTP_RESPONSE_LOOKUP_BLOB));
 
     EXPECT_CALL(*network_mock_,
-                Send(IsGetRequest(URL_BLOB_DATA_23618364), _, _, _, _))
+                Send(IsGetRequest(URL_BLOB_DATA_1476147), _, _, _, _))
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
                                      "someData"));
 
     auto request = olp::dataservice::read::TileRequest().WithTileKey(
-        olp::geo::TileKey::FromHereTile("23618364"));
+        olp::geo::TileKey::FromHereTile("1476147"));
     olp::client::CancellationContext context;
     auto response =
         olp::dataservice::read::repository::DataRepository::GetVersionedTile(

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -107,6 +107,7 @@ const std::string
 
 const std::string kOlpSdkUrlLookupMetadata2 =
     R"(https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data::olp-here-test:hereos-internal-test-v2/apis/metadata/v1)";
+
 const std::string kOlpSdkHttpResponseLookupMetadata2 =
     R"jsonString([{"api":"metadata","version":"v1","baseURL":"https://metadata.data.api.platform.here.com/metadata/v1/catalogs/hereos-internal-test-v2","parameters":{}}])jsonString";
 
@@ -128,13 +129,13 @@ const std::string kHttpResponceLookupQuery =
     R"jsonString([{"api":"query","version":"v1","baseURL":"https://sab.query.data.api.platform.here.com/query/v1/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2","parameters":{}}])jsonString";
 
 const std::string kQueryTreeIndex =
-    R"(https://sab.query.data.api.platform.here.com/query/v1/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2/layers/testlayer/versions/4/quadkeys/5904591/depths/4)";
+    R"(https://sab.query.data.api.platform.here.com/query/v1/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2/layers/testlayer/versions/4/quadkeys/23064/depths/4)";
 
 const std::string kSubQuads =
-    R"jsonString({"subQuads": [{"subQuadKey":"4","version":4,"dataHandle":"f9a9fd8e-eb1b-48e5-bfdb-4392b3826443"},{"subQuadKey":"5","version":4,"dataHandle":"e119d20e-c7c6-4563-ae88-8aa5c6ca75c3"},{"subQuadKey":"6","version":4,"dataHandle":"a7a1afdf-db7e-4833-9627-d38bee6e2f81"},{"subQuadKey":"7","version":4,"dataHandle":"9d515348-afce-44e8-bc6f-3693cfbed104"},{"subQuadKey":"1","version":4,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": [{"partition":"1476147","version":4,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"}]})jsonString";
+    R"jsonString({"subQuads": [{"subQuadKey":"115","version":4,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"},{"subQuadKey":"463","version":4,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": []})jsonString";
 
-const std::string kBlobDataHandle23618364 =
-    R"(f9a9fd8e-eb1b-48e5-bfdb-4392b3826443)";
+const std::string kBlobDataHandle1476147 =
+    R"(95c5c703-e00e-4c38-841e-e419367474f1)";
 
 class PartitionsRepositoryTest : public ::testing::Test,
                                  protected repository::PartitionsRepository {};
@@ -866,13 +867,13 @@ TEST_F(PartitionsRepositoryTest, CheckCashedPartitions) {
     SCOPED_TRACE(
         "Check if all partitions stored in cache, request another tile");
     auto request = olp::dataservice::read::TileRequest().WithTileKey(
-        olp::geo::TileKey::FromHereTile("23618364"));
+        olp::geo::TileKey::FromHereTile("1476147"));
     auto partitions = GetTileFromCache(hrn, layer, request, version, settings);
 
     // check if partition was stored to cache
     ASSERT_FALSE(partitions.GetPartitions().size() == 0);
     ASSERT_EQ(partitions.GetPartitions().front().GetDataHandle(),
-              kBlobDataHandle23618364);
+              kBlobDataHandle1476147);
   }
 }
 
@@ -920,7 +921,7 @@ TEST_F(PartitionsRepositoryTest, GetPartitionForVersionedTile) {
         .Times(0);
 
     auto request = olp::dataservice::read::TileRequest().WithTileKey(
-        olp::geo::TileKey::FromHereTile("23618364"));
+        olp::geo::TileKey::FromHereTile("1476147"));
     olp::client::CancellationContext context;
     auto response = PartitionsRepository::GetPartitionForVersionedTile(
         hrn, layer, request, version, context, settings);
@@ -929,7 +930,7 @@ TEST_F(PartitionsRepositoryTest, GetPartitionForVersionedTile) {
     ASSERT_TRUE(response.IsSuccessful());
     ASSERT_TRUE(response.GetResult().GetPartitions().size() == 1);
     ASSERT_EQ(response.GetResult().GetPartitions().front().GetDataHandle(),
-              kBlobDataHandle23618364);
+              kBlobDataHandle1476147);
   }
 }
 }  // namespace

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
@@ -850,7 +850,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetTileEmptyField) {
       });
 
   EXPECT_FALSE(data_response_compressed.IsSuccessful());
-  ASSERT_EQ(olp::client::ErrorCode::NotFound,
+  ASSERT_EQ(olp::client::ErrorCode::InvalidArgument,
             data_response_compressed.GetError().GetErrorCode());
 }
 

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -98,14 +98,14 @@ constexpr char kHttpLookupQuery[] =
 constexpr char kHttpResponseLookupApiQuery[] =
     R"jsonString([{"api":"query","version":"v1","baseURL":"https://sab.query.data.api.platform.here.com/query/v1/catalogs/hrn:here:data::olp-here-test:here-optimized-map-for-visualization-2","parameters":{}}])jsonString";
 
-constexpr char kHttpQueryTreeIndex[] =
-    R"(https://sab.query.data.api.platform.here.com/query/v1/catalogs/hrn:here:data::olp-here-test:here-optimized-map-for-visualization-2/layers/testlayer/versions/4/quadkeys/5904591/depths/4)";
+constexpr char kHttpQueryTreeIndex_23064[] =
+    R"(https://sab.query.data.api.platform.here.com/query/v1/catalogs/hrn:here:data::olp-here-test:here-optimized-map-for-visualization-2/layers/testlayer/versions/4/quadkeys/23064/depths/4)";
 
-constexpr char kHttpSubQuads[] =
-    R"jsonString({"subQuads": [{"subQuadKey":"4","version":4,"dataHandle":"f9a9fd8e-eb1b-48e5-bfdb-4392b3826443"},{"subQuadKey":"5","version":4,"dataHandle":"e119d20e-c7c6-4563-ae88-8aa5c6ca75c3"},{"subQuadKey":"6","version":4,"dataHandle":"a7a1afdf-db7e-4833-9627-d38bee6e2f81"},{"subQuadKey":"7","version":4,"dataHandle":"9d515348-afce-44e8-bc6f-3693cfbed104"},{"subQuadKey":"1","version":4,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": [{"partition":"1476147","version":4,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"}]})jsonString";
+constexpr char kHttpSubQuads_23064[] =
+    R"jsonString({"subQuads": [{"subQuadKey":"115","version":4,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"},{"subQuadKey":"463","version":4,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": []})jsonString";
 
-constexpr char kUrlBlobData_23618364[] =
-    R"(https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/here-optimized-map-for-visualization-2/layers/testlayer/data/f9a9fd8e-eb1b-48e5-bfdb-4392b3826443)";
+constexpr char kUrlBlobData_1476147[] =
+    R"(https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/here-optimized-map-for-visualization-2/layers/testlayer/data/95c5c703-e00e-4c38-841e-e419367474f1)";
 
 constexpr auto kUrlPartitionsPrefix =
     R"(https://query.data.api.platform.here.com/query/v1/catalogs/here-optimized-map-for-visualization-2/layers/testlayer/partitions)";
@@ -2593,10 +2593,10 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetTile) {
                                    kHttpResponseLookupApiQuery));
 
   EXPECT_CALL(*network_mock_,
-              Send(IsGetRequest(kHttpQueryTreeIndex), _, _, _, _))
+              Send(IsGetRequest(kHttpQueryTreeIndex_23064), _, _, _, _))
       .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                        olp::http::HttpStatusCode::OK),
-                                   kHttpSubQuads));
+                                   kHttpSubQuads_23064));
 
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
       .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
@@ -2633,7 +2633,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetTileCacheOnly) {
       .Times(0);
 
   EXPECT_CALL(*network_mock_,
-              Send(IsGetRequest(kHttpQueryTreeIndex), _, _, _, _))
+              Send(IsGetRequest(kHttpQueryTreeIndex_23064), _, _, _, _))
       .Times(0);
 
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
@@ -2664,10 +2664,10 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetTileOnlineOnly) {
                                      kHttpResponseLookupApiQuery));
 
     EXPECT_CALL(*network_mock_,
-                Send(IsGetRequest(kHttpQueryTreeIndex), _, _, _, _))
+                Send(IsGetRequest(kHttpQueryTreeIndex_23064), _, _, _, _))
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
-                                     kHttpSubQuads));
+                                     kHttpSubQuads_23064));
 
     EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
@@ -2749,10 +2749,10 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetTileTwoSequentialCalls) {
                                    kHttpResponseLookupApiQuery));
 
   EXPECT_CALL(*network_mock_,
-              Send(IsGetRequest(kHttpQueryTreeIndex), _, _, _, _))
+              Send(IsGetRequest(kHttpQueryTreeIndex_23064), _, _, _, _))
       .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                        olp::http::HttpStatusCode::OK),
-                                   kHttpSubQuads));
+                                   kHttpSubQuads_23064));
 
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
       .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
@@ -2784,20 +2784,20 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetTileTwoSequentialCalls) {
         .Times(0);
 
     EXPECT_CALL(*network_mock_,
-                Send(IsGetRequest(kHttpQueryTreeIndex), _, _, _, _))
+                Send(IsGetRequest(kHttpQueryTreeIndex_23064), _, _, _, _))
         .Times(0);
 
     EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
         .Times(0);
 
     EXPECT_CALL(*network_mock_,
-                Send(IsGetRequest(kUrlBlobData_23618364), _, _, _, _))
+                Send(IsGetRequest(kUrlBlobData_1476147), _, _, _, _))
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
                                      "someOtherData"));
 
     auto request = olp::dataservice::read::TileRequest().WithTileKey(
-        olp::geo::TileKey::FromHereTile("23618364"));
+        olp::geo::TileKey::FromHereTile("1476147"));
     auto future = client->GetData(request);
     auto data_response = future.GetFuture().get();
     ASSERT_TRUE(data_response.IsSuccessful())


### PR DESCRIPTION
Change VersionedLayerData::GetData(TileRequest)
to request quad tree for parrent tile.

Relates-To:OLPEDGE-1894

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>