### PR TITLE
Add missing include.

### DIFF
--- a/olp-cpp-sdk-core/src/geo/tiling/TileKey.cpp
+++ b/olp-cpp-sdk-core/src/geo/tiling/TileKey.cpp
@@ -19,6 +19,7 @@
 
 #include "olp/core/geo/tiling/TileKey.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <cstdlib>


### PR DESCRIPTION
Add missing include <algorithm> since we use std::max.

Resolves: OLPSUP-10390

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>