### PR TITLE
Fix cpplint warnings in dataservice-read/include

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogRequest.h
@@ -21,6 +21,7 @@
 
 #include <sstream>
 #include <string>
+#include <utility>
 
 #include <olp/dataservice/read/DataServiceReadApi.h>
 #include <olp/dataservice/read/FetchOptions.h>

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogVersionRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogVersionRequest.h
@@ -19,14 +19,14 @@
 
 #pragma once
 
-#include "FetchOptions.h"
-
 #include <sstream>
 #include <string>
+#include <utility>
 
 #include <boost/optional.hpp>
 
 #include "DataServiceReadApi.h"
+#include "FetchOptions.h"
 
 namespace olp {
 namespace dataservice {

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/ConsumerProperties.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/ConsumerProperties.h
@@ -21,10 +21,11 @@
 
 #include <initializer_list>
 #include <string>
+#include <utility>
 #include <vector>
 
-#include <boost/optional.hpp>
 #include <olp/dataservice/read/DataServiceReadApi.h>
+#include <boost/optional.hpp>
 
 namespace olp {
 namespace dataservice {
@@ -78,13 +79,13 @@ class DATASERVICE_READ_API ConsumerOption final {
    *
    * @return The key of the consumer configuration entry.
    */
-  const std::string& GetKey() const { return key_; };
+  const std::string& GetKey() const { return key_; }
   /**
    * @brief Gets the value of the consumer configuration entry.
    *
    * @return The value of the consumer configuration entry.
    */
-  const std::string& GetValue() const { return value_; };
+  const std::string& GetValue() const { return value_; }
 
  private:
   std::string key_;
@@ -104,7 +105,7 @@ class DATASERVICE_READ_API ConsumerProperties final {
    *
    * @param properties The `ConsumerOptions` instances.
    */
-  ConsumerProperties(ConsumerOptions properties)
+  explicit ConsumerProperties(ConsumerOptions properties)
       : properties_{std::move(properties)} {}
 
   /**
@@ -120,9 +121,7 @@ class DATASERVICE_READ_API ConsumerProperties final {
    *
    * @return The `ConsumerProperties` instance.
    */
-  const ConsumerOptions& GetProperties() const {
-    return properties_;
-  };
+  const ConsumerOptions& GetProperties() const { return properties_; }
 
  private:
   ConsumerOptions properties_;

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/DataRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/DataRequest.h
@@ -21,6 +21,7 @@
 
 #include <sstream>
 #include <string>
+#include <utility>
 
 #include <olp/core/porting/deprecated.h>
 #include <olp/dataservice/read/DataServiceReadApi.h>

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/FetchOptions.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/FetchOptions.h
@@ -22,8 +22,8 @@
 namespace olp {
 namespace dataservice {
 namespace read {
-enum FetchOptions {
 
+enum FetchOptions {
   /**
    * A default option. Queries the network if the requested resource is not
    * found in the cache.

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PartitionsRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PartitionsRequest.h
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <utility>
 
 #include <olp/core/porting/deprecated.h>
 #include <olp/dataservice/read/DataServiceReadApi.h>

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTileResult.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTileResult.h
@@ -93,7 +93,8 @@ class DATASERVICE_READ_API PrefetchTileResult
    * @param error The `ApiError` instance that contains information about
    * the error.
    */
-  PrefetchTileResult(const client::ApiError& error) : base_type(error) {}
+  explicit PrefetchTileResult(const client::ApiError& error)
+      : base_type(error) {}
 
  public:
   /**

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <utility>
 
 #include <olp/core/geo/tiling/TileKey.h>
 #include <olp/core/porting/deprecated.h>

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/StreamLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/StreamLayerClient.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/CancellationToken.h>

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/SubscribeRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/SubscribeRequest.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <string>
+#include <utility>
 
 #include <olp/dataservice/read/ConsumerProperties.h>
 #include <olp/dataservice/read/Types.h>

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/TileRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/TileRequest.h
@@ -21,6 +21,7 @@
 
 #include <sstream>
 #include <string>
+#include <utility>
 
 #include <olp/core/geo/tiling/TileKey.h>
 #include <olp/dataservice/read/FetchOptions.h>

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
@@ -20,6 +20,8 @@
 #pragma once
 
 #include <memory>
+#include <string>
+#include <vector>
 
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -21,6 +21,7 @@
 
 #include <memory>
 #include <vector>
+#include <string>
 
 #include <boost/optional.hpp>
 #include <olp/core/client/ApiError.h>

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/model/Messages.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/model/Messages.h
@@ -21,11 +21,13 @@
 
 #include <string>
 #include <vector>
+#include <utility>
+
+#include <boost/optional.hpp>
 
 #include <olp/dataservice/read/DataServiceReadApi.h>
 #include <olp/dataservice/read/model/Data.h>
 #include <olp/dataservice/read/model/StreamOffsets.h>
-#include <boost/optional.hpp>
 
 namespace olp {
 namespace dataservice {
@@ -204,26 +206,26 @@ class DATASERVICE_READ_API Message final {
    *
    * @return The \ref `Metadata` instance.
    */
-  const Metadata& GetMetaData() const { return meta_data_; };
+  const Metadata& GetMetaData() const { return meta_data_; }
   /**
    * @brief Sets the \ref `Metadata` instance of this message.
    *
    * @param value The \ref `Metadata` instance.
    */
-  void SetMetaData(Metadata value) { meta_data_ = std::move(value); };
+  void SetMetaData(Metadata value) { meta_data_ = std::move(value); }
 
   /**
    * @brief Gets the offset in a specific partition of the stream layer.
    *
    * @return The \ref `StreamOffset` instance.
    */
-  const StreamOffset& GetOffset() const { return offset_; };
+  const StreamOffset& GetOffset() const { return offset_; }
   /**
    * @brief Sets the \ref `StreamOffset` instance of this message.
    *
    * @param value The \ref `StreamOffset` instance.
    */
-  void SetOffset(StreamOffset value) { offset_ = std::move(value); };
+  void SetOffset(StreamOffset value) { offset_ = std::move(value); }
 
   /**
    * @brief Gets the actual content of this message.
@@ -247,15 +249,13 @@ class DATASERVICE_READ_API Messages final {
    *
    * @return The vector of messages consumed from \ref `StreamLayerClient`.
    */
-  const std::vector<Message>& GetMessages() const { return messages_; };
+  const std::vector<Message>& GetMessages() const { return messages_; }
   /**
    * @brief Sets the vector of messages.
    *
    * @param value The vector of messages consumed from \ref `StreamLayerClient`.
    */
-  void SetMessages(std::vector<Message> value) {
-    messages_ = std::move(value);
-  };
+  void SetMessages(std::vector<Message> value) { messages_ = std::move(value); }
 
  private:
   std::vector<Message> messages_;

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/model/Partitions.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/model/Partitions.h
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <vector>
+#include <utility>
 
 #include <boost/optional.hpp>
 

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/model/StreamOffsets.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/model/StreamOffsets.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <utility>
 #include <vector>
 
 #include <olp/dataservice/read/DataServiceReadApi.h>
@@ -55,7 +56,7 @@ class DATASERVICE_READ_API StreamOffset final {
    *
    * @return The offset in the stream layer partition.
    */
-  int64_t GetOffset() const { return offset_; };
+  int64_t GetOffset() const { return offset_; }
   /**
    * @brief Sets the offset for the request.
    *
@@ -85,7 +86,7 @@ class DATASERVICE_READ_API StreamOffsets final {
    *
    * @return The list of offsets.
    */
-  const std::vector<StreamOffset>& GetOffsets() const { return offsets_; };
+  const std::vector<StreamOffset>& GetOffsets() const { return offsets_; }
   /**
    * @brief Sets the list of offsets.
    *
@@ -93,7 +94,7 @@ class DATASERVICE_READ_API StreamOffsets final {
    */
   void SetOffsets(std::vector<StreamOffset> value) {
     offsets_ = std::move(value);
-  };
+  }
 
  private:
   std::vector<StreamOffset> offsets_;

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClient.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <string>
+
 #include <olp/core/cache/CacheSettings.h>
 #include <olp/core/cache/KeyValueCache.h>
 #include <olp/core/client/ApiError.h>


### PR DESCRIPTION
Fix all warnings reported in dataservice-read public headers.
Validate any change in them with a cpplint tool and block psv
in case any issue is found. (except: include order warnings)

Relates-To: OLPEDGE-1909

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>