### PR TITLE
Fix cpplint warnings in dataservice-write headers

### DIFF
--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/IndexLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/IndexLayerClient.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiNoResult.h>
 #include <olp/core/client/ApiResponse.h>

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClient.h
@@ -19,7 +19,9 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
+#include <vector>
 
 #include <olp/core/cache/CacheSettings.h>
 #include <olp/core/cache/KeyValueCache.h>

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VersionedLayerClient.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiNoResult.h>
 #include <olp/core/client/ApiResponse.h>

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VolatileLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VolatileLayerClient.h
@@ -19,6 +19,9 @@
 
 #pragma once
 
+#include <vector>
+#include <memory>
+
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiNoResult.h>
 #include <olp/core/client/ApiResponse.h>

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/generated/model/Details.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/generated/model/Details.h
@@ -41,8 +41,6 @@ class DATASERVICE_WRITE_API Details {
   int64_t expires_{0};
 
  public:
-  // TODO: This is specified as an enum in Open API spec. Update to enum class,
-  // code generator should support this case.
   const std::string& GetState() const { return state_; }
   std::string& GetMutableState() { return state_; }
   void SetState(const std::string& value) { this->state_ = value; }

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/generated/model/Index.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/generated/model/Index.h
@@ -22,6 +22,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include <boost/optional.hpp>
 
@@ -95,8 +96,7 @@ class DATASERVICE_WRITE_API IndexValue {
  */
 class DATASERVICE_WRITE_API UnsupportedIndexValue final : public IndexValue {
  public:
-  virtual ~UnsupportedIndexValue() = default;
-  UnsupportedIndexValue(IndexType type) : IndexValue(type) {}
+  explicit UnsupportedIndexValue(IndexType type) : IndexValue(type) {}
 };
 
 /**
@@ -125,7 +125,7 @@ class DATASERVICE_WRITE_API IntIndexValue final : public IndexValue {
   virtual ~IntIndexValue() = default;
   IntIndexValue(int64_t intValue, IndexType type) : IndexValue(type) {
     intValue_ = std::move(intValue);
-  };
+  }
 
   const int64_t& GetValue() const { return intValue_; }
   int64_t& GetMutableValue() { return intValue_; }
@@ -188,7 +188,7 @@ class DATASERVICE_WRITE_API HereTileIndexValue final : public IndexValue {
  */
 class DATASERVICE_WRITE_API EmptyIndexValue final : public IndexValue {
  public:
-  EmptyIndexValue(IndexType type) : IndexValue(type) {}
+  explicit EmptyIndexValue(IndexType type) : IndexValue(type) {}
 };
 
 class DATASERVICE_WRITE_API Index final {

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/generated/model/VersionDependency.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/generated/model/VersionDependency.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <string>
+#include <utility>
 
 #include <olp/dataservice/write/DataServiceWriteApi.h>
 

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/CheckDataExistsRequest.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/CheckDataExistsRequest.h
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <olp/dataservice/write/DataServiceWriteApi.h>

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/DeleteIndexDataRequest.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/DeleteIndexDataRequest.h
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <olp/dataservice/write/DataServiceWriteApi.h>

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/PublishDataRequest.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/PublishDataRequest.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <utility>
 
 #include <boost/optional.hpp>
 

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/PublishIndexRequest.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/PublishIndexRequest.h
@@ -21,6 +21,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <boost/optional.hpp>

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/PublishPartitionDataRequest.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/PublishPartitionDataRequest.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <utility>
 
 #include <boost/optional.hpp>
 

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/PublishSdiiRequest.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/PublishSdiiRequest.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <utility>
 
 #include <boost/optional.hpp>
 

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/StartBatchRequest.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/StartBatchRequest.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <boost/optional.hpp>

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/UpdateIndexRequest.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/UpdateIndexRequest.h
@@ -21,6 +21,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <boost/optional.hpp>

--- a/scripts/misc/cpplint_ci.sh
+++ b/scripts/misc/cpplint_ci.sh
@@ -59,9 +59,10 @@ printf "\n\nComplete cpplint\n\n"
 
 cat warnings.txt
 
-# Check for public headers modified.
-# dataservice-read/include must have no new warnings.
-CRITICAL_PATHS=$(echo "$FILES" | grep "dataservice-read/include")
+# Check for public headers modified, must have no new warnings:
+# dataservice-read/include
+# dataservice-write/include
+CRITICAL_PATHS=$(echo "$FILES" | grep "read/include\|write/include")
 
 if [ ! -z "$CRITICAL_PATHS" ]; then
 


### PR DESCRIPTION
Check the warning during PSV and block CI make the warning.

Relates-To: OLPEDGE-1909

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>