### PR TITLE
TaskContext should not trigger cancellation.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/TaskContext.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/TaskContext.h
@@ -228,6 +228,9 @@ class CORE_API TaskContext {
              response.GetError().GetErrorCode() == ErrorCode::RequestTimeout)) {
           user_response = std::move(response);
         }
+
+        // Reset the context after the task is finished.
+        context_ = CancellationContext();
       }
 
       if (callback) {


### PR DESCRIPTION
TaskContext should not trigger cancellation after request was
completed. This could happen when the execution function keeps
the last owning reference to the object that cancels task context
in destruction.

Resolves: OLPSUP-10456

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>